### PR TITLE
Fix workflow errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "20"
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Restore cache

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -3,8 +3,6 @@ name: 'tauri build and release'
 # This will trigger the action on each push to main branch if a tag is present
 on:
   push:
-    branches:
-      - main
     tags:
       - '*'
 


### PR DESCRIPTION
- deploy crashed because of outdated nodejs version
- tauri release cannot take a branch and a tag at the same time because a tag is completely independent from any branch. 