### PR TITLE
Fix dev build being deployed before being tagged

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,9 @@
 name: Build & Deploy site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["main", "master"]
+    tags:
+      - '*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Now the project will be deployed only upon a new tag, i.e a new version.