### PR TITLE
Added Kerr black holes

### DIFF
--- a/src/shaders/blackhole.glsl
+++ b/src/shaders/blackhole.glsl
@@ -94,7 +94,7 @@ vec4 raymarchDisk(vec3 rayDir, vec3 initialPosition) {
 
     float redShift = (1.0 + parallel) / 2.0;
 
-    float diskMix = smoothstep(0.6, 0.9, relativeDistance / relativeDiskRadius);// transition between inner and outer color
+    float diskMix = smoothstep(0.3, 0.9, relativeDistance / relativeDiskRadius); // transition between inner and outer color
     vec3 innerDiskColor = vec3(1.0, 0.8, 0.1);
     vec3 outerDiskColor = vec3(0.5, 0.13, 0.02) * 0.2;
     vec3 insideCol =  mix(innerDiskColor, outerDiskColor, diskMix) * 1.25;
@@ -113,8 +113,8 @@ vec4 raymarchDisk(vec3 rayDir, vec3 initialPosition) {
         relativeDistance = distanceToCenter / object_radius;
 
         float diskMask = 1.0;
-        diskMask *= clamp(relativeDistance - 1.2, 0.0, 1.0);// The 1.2 is only for aesthetics
-        diskMask *= smoothstep(0.0, 2.0, relativeDiskRadius - relativeDistance);// The 2.0 is only for aesthetics
+        diskMask *= smoothstep(1.5, 2.5, relativeDistance); // Fade the disk when too close to the event horizon. 1.5 is the IBCO (innermost bound circular orbit) for a Schwarzschild black hole. It is also called the photon sphere.
+        diskMask *= clamp(1.0 - relativeDistance / relativeDiskRadius, 0.0, 1.0); //smoothstep(0.0, 1.0, relativeDiskRadius - relativeDistance);// The 2.0 is only for aesthetics
 
         // rotation of the disk
         float theta = -2.0 * 3.1415 * time / rotationPeriod;

--- a/src/ts/blackHoleDemo.ts
+++ b/src/ts/blackHoleDemo.ts
@@ -35,6 +35,7 @@ const starSystem = new StarSystemController(starSystemSeed, scene);
 
 const BH = StarSystemHelper.MakeBlackHole(starSystem, 0);
 BH.model.orbit.radius = 0;
+BH.model.physicalProperties.accretionDiskRadius = BH.model.radius * 12;
 
 const planet = StarSystemHelper.MakeTelluricPlanet(starSystem);
 planet.model.orbit.radius = 45 * planet.getRadius();
@@ -44,8 +45,6 @@ await starSystemView.loadStarSystem(starSystem, false);
 
 engine.init(true);
 
-positionNearObjectBrightSide(scene.getActiveControls(), BH, starSystem, 20);
+starSystemView.switchToDefaultControls();
 
-starSystemView.ui.setEnabled(true);
-starSystemView.showHtmlUI();
-starSystemView.getSpaceshipControls().spaceship.enableWarpDrive();
+positionNearObjectBrightSide(scene.getActiveControls(), BH, starSystem, 20);

--- a/src/ts/blackHoleDemo.ts
+++ b/src/ts/blackHoleDemo.ts
@@ -38,6 +38,7 @@ BH.model.orbit.radius = 0;
 
 const planet = StarSystemHelper.MakeTelluricPlanet(starSystem);
 planet.model.orbit.radius = 45 * planet.getRadius();
+planet.model.orbit.period = 24 * 60 * 60;
 
 await starSystemView.loadStarSystem(starSystem, false);
 

--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -191,7 +191,9 @@ export class CosmosJourneyer {
               })
             : new Engine(canvas, true, {
                   // the preserveDrawingBuffer option is required for the screenshot feature to work
-                  preserveDrawingBuffer: true
+                  preserveDrawingBuffer: true,
+                  useHighPrecisionMatrix: true,
+                  useHighPrecisionFloats: true
               });
 
         engine.useReverseDepthBuffer = true;

--- a/src/ts/postProcesses/blackHolePostProcess.ts
+++ b/src/ts/postProcesses/blackHolePostProcess.ts
@@ -23,7 +23,7 @@ import { ObjectPostProcess } from "./objectPostProcess";
 import { Assets } from "../assets";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { getForwardDirection } from "../uberCore/transforms/basicTransform";
-import { UniformEnumType, ShaderSamplers, ShaderUniforms, SamplerEnumType } from "../uberCore/postProcesses/types";
+import { SamplerEnumType, ShaderSamplers, ShaderUniforms, UniformEnumType } from "../uberCore/postProcesses/types";
 import { Matrix, Quaternion } from "@babylonjs/core/Maths/math";
 import { BlackHole } from "../stellarObjects/blackHole/blackHole";
 
@@ -68,6 +68,20 @@ export class BlackHolePostProcess extends UberPostProcess implements ObjectPostP
                 type: UniformEnumType.FLOAT,
                 get: () => {
                     return blackHoleUniforms.time % (blackHoleUniforms.rotationPeriod * 10000);
+                }
+            },
+            {
+                name: "schwarzschildRadius",
+                type: UniformEnumType.FLOAT,
+                get: () => {
+                    return blackHole.model.getSchwarzschildRadius();
+                }
+            },
+            {
+                name: "frameDraggingFactor",
+                type: UniformEnumType.FLOAT,
+                get: () => {
+                    return blackHole.model.getKerrMetricA() / blackHole.model.physicalProperties.mass;
                 }
             },
             {

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -21,7 +21,6 @@ import { makeNoise3D } from "fast-simplex-noise";
 export const Settings = {
     UNIVERSE_SEED: Math.PI,
     EARTH_RADIUS: 1000e3, // target is 6000e3
-    AU: 150e9, // target is 150e9
 
     /**
      * The distance light travels in one year.
@@ -39,7 +38,32 @@ export const Settings = {
     CHUNK_RENDERING_DISTANCE_MULTIPLIER: 2,
     ENABLE_VOLUMETRIC_CLOUDS: false,
     SEED_HALF_RANGE: 1e4,
+
+    /**
+     * The speed of light in meters per second.
+     */
     C: 299792458,
+
+    /**
+     * The gravitational constant in m^3 kg^-1 s^-2.
+     */
+    G: 6.67430e-11,
+
+    /**
+     * The astronomical unit in meters.
+     */
+    AU: 150e9,
+
+    /**
+     * The mass of the sun in kilograms.
+     */
+    SOLAR_MASS: 1.989e30,
+
+    /**
+     * The radius of the sun in meters.
+     */
+    SOLAR_RADIUS: 696340e3,
+
     FOV: (92 * Math.PI) / 180,
 
     MAIN_FONT: "Nasalization"

--- a/src/ts/stellarObjects/blackHole/blackHoleModel.ts
+++ b/src/ts/stellarObjects/blackHole/blackHoleModel.ts
@@ -25,12 +25,17 @@ import { BlackHolePhysicalProperties } from "../../architecture/physicalProperti
 import { CelestialBodyModel } from "../../architecture/celestialBody";
 import { StellarObjectModel } from "../../architecture/stellarObject";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
+import { Settings } from "../../settings";
+import { estimateStarRadiusFromMass } from "../../utils/estimateStarRadiusFromMass";
 
 export class BlackHoleModel implements StellarObjectModel {
     readonly bodyType = BodyType.BLACK_HOLE;
     readonly seed: number;
     readonly rng: (step: number) => number;
 
+    /**
+     * The Schwarzschild radius of the black hole in meters
+     */
     readonly radius: number;
 
     readonly orbit: OrbitProperties;
@@ -65,15 +70,75 @@ export class BlackHoleModel implements StellarObjectModel {
         };
 
         this.physicalProperties = {
-            mass: 10,
-            rotationPeriod: 24 * 60 * 60,
+            mass: BlackHoleModel.GetMassFromSchwarzschildRadius(this.radius),
+            rotationPeriod: 1.5e-19,
             axialTilt: normalRandom(0, 0.4, this.rng, GenerationSteps.AXIAL_TILT),
-            accretionDiskRadius: 8000e3
+            accretionDiskRadius: this.radius * 8
         };
     }
 
     public getNbSpaceStations(): number {
         if (uniformRandBool(0.1, this.rng, GenerationSteps.SPACE_STATIONS)) return 1;
         return 0;
+    }
+
+    /**
+     * Returns the Schwarzschild radius of the black hole
+     * @returns the Schwarzschild radius of the black hole
+     */
+    public getSchwarzschildRadius(): number {
+        return 2 * Settings.G  * this.physicalProperties.mass / (Settings.C * Settings.C);
+    }
+
+    /**
+     * Returns the mass a black hole needs to posess a given Schwarzschild radius
+     * @param radius The target radius (in meters)
+     * @returns The mass needed to achieve the given radius
+     */
+    public static GetMassFromSchwarzschildRadius(radius: number): number {
+        return radius * Settings.C * Settings.C / (2 * Settings.G);
+    }
+
+    /**
+     * As the angular momentum is conserved, the black hole retains the original star's angular momentum.
+     * As the original star's radius is only known approximately, the black hole's angular momentum can only be estimated.
+     * The angular momentum is important in the Kerr metric to compute frame dragging.
+     */
+    public estimateAngularMomentum(): number {
+        if(this.physicalProperties.rotationPeriod === 0) 0;
+
+        const estimatedOriginalStarRadius = estimateStarRadiusFromMass(this.physicalProperties.mass);
+
+        // The inertia tensor for a sphere is a diagonal scaling matrix, we can express it as a simple number
+        const inertiaTensor = (2 / 5) * this.physicalProperties.mass * estimatedOriginalStarRadius * estimatedOriginalStarRadius;
+
+        const omega = 2 * Math.PI / this.physicalProperties.rotationPeriod;
+
+        return inertiaTensor * omega;
+    }
+
+    /**
+     * This corresponds to a=J/Mc in the Kerr metric. Physical values are between 0 and the mass of the black hole. Exceeding that range will create naked singularities. (J > M²)
+     * @returns J/Mc for this black hole
+     * @see https://en.wikipedia.org/wiki/Kerr_metric#Overextreme_Kerr_solutions
+     */
+    public getKerrMetricA(): number {
+        return this.estimateAngularMomentum() / (this.physicalProperties.mass * Settings.C);
+    }
+
+    /**
+     * Returns the radius of the ergosphere at a given angle theta.
+     * @param theta The angle in radians to the black hole's rotation axis. (equator => theta = pi / 2)
+     * @throws This function throws an error when the black hole is a naked singularity
+     */
+    public getErgosphereRadius(theta: number): number {
+        const m = Settings.G * this.physicalProperties.mass / (Settings.C * Settings.C);
+
+        const a = this.getKerrMetricA();
+        const cosTheta = Math.cos(theta);
+        
+        if(a > m) throw new Error("Black hole angular momentum exceeds maximum value for a Kerr black hole. a > m: " + a);
+
+        return m + Math.sqrt(m * m - a * a * cosTheta * cosTheta);
     }
 }

--- a/src/ts/stellarObjects/blackHole/blackHoleModel.ts
+++ b/src/ts/stellarObjects/blackHole/blackHoleModel.ts
@@ -73,7 +73,7 @@ export class BlackHoleModel implements StellarObjectModel {
             mass: BlackHoleModel.GetMassFromSchwarzschildRadius(this.radius),
             rotationPeriod: 1.5e-19,
             axialTilt: normalRandom(0, 0.4, this.rng, GenerationSteps.AXIAL_TILT),
-            accretionDiskRadius: this.radius * 8
+            accretionDiskRadius: this.radius * normalRandom(12, 3, this.rng, 7777)
         };
     }
 

--- a/src/ts/utils/estimateStarRadiusFromMass.ts
+++ b/src/ts/utils/estimateStarRadiusFromMass.ts
@@ -1,0 +1,33 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Settings } from "../settings";
+
+/**
+ * Returns an estimate of the radius of a star given its mass. This is only an approximation!
+ * This can be used to estimate the angular momentum of a black hole.
+ * @param mass The mass of the object
+ * @constructor
+ * @see https://en.wikipedia.org/wiki/Main_sequence#Sample_parameters
+ */
+export function estimateStarRadiusFromMass(mass: number) {
+    const massInSolarUnits = mass / Settings.SOLAR_MASS;
+
+    const estimatedRadiusInSolarUnits = Math.pow(massInSolarUnits, 0.78);
+
+    return estimatedRadiusInSolarUnits * Settings.SOLAR_RADIUS;
+}


### PR DESCRIPTION
![screenshot_24-5-2_16-37(1)](https://github.com/BarthPaleologue/CosmosJourneyer/assets/31370477/94e6cbbc-a289-43fc-9dd8-7cb224516c0f)

Kerr black holes differ from regular Schwarzschild black holes by their rotation. 
Schwarzschild black holes are simpler as they assume no rotation. However, it is very unlikely that a black hole would not rotate as every object in the universe are more or less rotating. 

Kerr black holes use the Kerr metric, which brings a few modification, most notably frame dragging: the black hole bends space in the direction of the rotation. This visually breaks the symmetry of the shadow of the black hole.

Moreover, the inside of the black hole shadow is composed of different regions, with different properties like the Ergosphere.

This pull request brings angular momentum estimations for black holes, enabling visible frame dragging at extreme rotation speed. I also enhanced the look of the accretion disk and tweaked some defaults. The accretion disk radius are now randomized as well.