### PR TITLE
Add back Mandelbulbs to star systems

### DIFF
--- a/src/shaders/mandelbulb.glsl
+++ b/src/shaders/mandelbulb.glsl
@@ -23,6 +23,7 @@ varying vec2 vUV;
 
 uniform float power;
 uniform vec3 accentColor;
+uniform float elapsedSeconds;
 
 #include "./utils/stars.glsl";
 
@@ -61,7 +62,7 @@ vec3 palette (float t) {
 // returns the distance to the set on the x coordinate 
 // and the color on the y coordinate
 vec2 sdf(vec3 pos) {
-    float Power = power;
+    float Power = power + 4.0 * sin(elapsedSeconds * 0.1);
     vec3 z = pos;
     float dr = 1.0;
     float r = 0.0;

--- a/src/shaders/mandelbulb.glsl
+++ b/src/shaders/mandelbulb.glsl
@@ -55,7 +55,7 @@ vec3 cosineColor(in float t, in vec3 a, in vec3 b, in vec3 c, in vec3 d) {
     return a + b * cos(6.28318*(c*t+d));
 }
 vec3 palette (float t) {
-    return cosineColor(t, vec3(0.5, 0.5, 0.5), vec3(0.5, 0.5, 0.5), vec3(0.01, 0.01, 0.01), accentColor);
+    return cosineColor(t, vec3(0.5, 0.5, 0.5), vec3(0.5, 0.5, 0.5), vec3(0.07, 0.07, 0.07), accentColor);
 }
 
 // distance estimator to a mandelbulb set
@@ -149,16 +149,6 @@ float contrast(float val, float contrast_offset, float contrast_mid_level)
     return clamp((val - contrast_mid_level) * (1. + contrast_offset) + contrast_mid_level, 0., 1.);
 }
 
-vec3 estimate_normal(const vec3 p, const float delta)
-{
-    vec3 normal = vec3(
-    sdf(vec3(p.x + delta, p.y, p.z)).x - sdf(vec3(p.x - delta, p.y, p.z)).x,
-    sdf(vec3(p.x, p.y + delta, p.z)).x - sdf(vec3(p.x, p.y - delta, p.z)).x,
-    sdf(vec3(p.x, p.y, p.z  + delta)).x - sdf(vec3(p.x, p.y, p.z - delta)).x
-    );
-    return normalize(normal);
-}
-
 void main() {
     vec4 screenColor = texture2D(textureSampler, vUV);// the current screen color
 
@@ -192,6 +182,22 @@ void main() {
     }
 
     vec3 intersectionPoint = origin + mandelDepth.x * rayDir;
+
+    // compute normal and anti-aliasing at the same time
+    vec3 p = intersectionPoint;
+    float delta = EPSILON * 2.0;
+    vec2 x1 = sdf(vec3(p.x + delta, p.y, p.z));
+    vec2 x2 = sdf(vec3(p.x - delta, p.y, p.z));
+    vec2 y1 = sdf(vec3(p.x, p.y + delta, p.z));
+    vec2 y2 = sdf(vec3(p.x, p.y - delta, p.z));
+    vec2 z1 = sdf(vec3(p.x, p.y, p.z + delta));
+    vec2 z2 = sdf(vec3(p.x, p.y, p.z - delta));
+
+    mandelDepth += x1 + x2 + y1 + y2 + z1 + z2;
+    mandelDepth /= 7.0;
+
+    intersectionPoint = origin + mandelDepth.x * rayDir;
+
     float intersectionDistance = length(intersectionPoint);
 
     vec4 mandelbulbColor = vec4(palette(mandelDepth.y), 1.0);
@@ -204,7 +210,11 @@ void main() {
 
     mandelbulbColor.xyz *= ao * 2.0;
 
-    vec3 normal = estimate_normal(intersectionPoint, EPSILON * 2.0);
+    vec3 normal = normalize(vec3(
+        x1.x - x2.x,
+        y1.x - y2.x,
+        z1.x - z2.x
+    ));
     float ndl = 0.0;
     for (int i = 0; i < nbStars; i++) {
         vec3 starDir = normalize(star_positions[i] - object_position);

--- a/src/shaders/mandelbulb.glsl
+++ b/src/shaders/mandelbulb.glsl
@@ -221,6 +221,10 @@ void main() {
         ndl += max(0.0, dot(normal, starDir));
     }
 
+    if(nbStars == 0) {
+        ndl = 1.0;
+    }
+
     mandelbulbColor.xyz *= clamp(ndl, 0.3, 1.0);
 
     gl_FragColor = mix(mandelbulbColor, screenColor, smoothstep(2.0, 15.0, intersectionDistance));

--- a/src/ts/mandelbulb/mandelbulbPostProcess.ts
+++ b/src/ts/mandelbulb/mandelbulbPostProcess.ts
@@ -54,7 +54,8 @@ export class MandelbulbPostProcess extends PostProcess implements ObjectPostProc
 
         const MandelbulbUniformNames = {
             POWER: "power",
-            ACCENT_COLOR: "accentColor"
+            ACCENT_COLOR: "accentColor",
+            ELAPSED_SECONDS: "elapsedSeconds"
         };
 
         const uniforms: string[] = [
@@ -84,8 +85,9 @@ export class MandelbulbPostProcess extends PostProcess implements ObjectPostProc
             setStellarObjectUniforms(effect, stellarObjects);
             setObjectUniforms(effect, mandelbulb);
 
-            effect.setFloat(MandelbulbUniformNames.POWER, mandelbulb.model.power + 4 * Math.sin(this.elapsedSeconds * 0.1));
+            effect.setFloat(MandelbulbUniformNames.POWER, mandelbulb.model.power);
             effect.setColor3(MandelbulbUniformNames.ACCENT_COLOR, mandelbulb.model.accentColor);
+            effect.setFloat(MandelbulbUniformNames.ELAPSED_SECONDS, this.elapsedSeconds);
 
             setSamplerUniforms(effect, this.activeCamera, scene);
         });

--- a/src/ts/postProcesses/postProcessManager.ts
+++ b/src/ts/postProcesses/postProcessManager.ts
@@ -136,7 +136,7 @@ export class PostProcessManager {
     /**
      * All post processes that are updated every frame.
      */
-    private readonly updatablePostProcesses: UpdatablePostProcess[][] = [this.oceans, this.clouds, this.blackHoles, this.matterJets];
+    private readonly updatablePostProcesses: UpdatablePostProcess[][] = [this.oceans, this.clouds, this.blackHoles, this.matterJets, this.mandelbulbs];
 
     /**
      * The color correction post process responsible for tone mapping, saturation, contrast, brightness and gamma.

--- a/src/ts/postProcesses/uniforms/stellarObjectUniforms.ts
+++ b/src/ts/postProcesses/uniforms/stellarObjectUniforms.ts
@@ -28,10 +28,17 @@ export const StellarObjectUniformNames = {
 };
 
 export function setStellarObjectUniforms(effect: Effect, stellarObjects: Transformable[]): void {
+    effect.setInt(StellarObjectUniformNames.NB_STARS, stellarObjects.length);
+
+    if (stellarObjects.length === 0) {
+        effect.setArray3(StellarObjectUniformNames.STAR_POSITIONS, [0,0,0]);
+        effect.setArray3(StellarObjectUniformNames.STAR_COLORS, [1,1,1]);
+        return;
+    }
+
     effect.setArray3(StellarObjectUniformNames.STAR_POSITIONS, flattenVector3Array(stellarObjects.map((stellarObject) => stellarObject.getTransform().getAbsolutePosition())));
     effect.setArray3(
         StellarObjectUniformNames.STAR_COLORS,
         flattenColor3Array(stellarObjects.map((stellarObject) => (stellarObject instanceof Star ? stellarObject.model.color : Color3.White())))
     );
-    effect.setInt(StellarObjectUniformNames.NB_STARS, stellarObjects.length);
 }

--- a/src/ts/starSystem/starSystemHelper.ts
+++ b/src/ts/starSystem/starSystemHelper.ts
@@ -18,7 +18,7 @@
 import { StarSystemController } from "./starSystemController";
 import { StarModel } from "../stellarObjects/star/starModel";
 import { Star } from "../stellarObjects/star/star";
-import { starName } from "../utils/parseToStrings";
+import { GreekAlphabet, starName } from "../utils/parseToStrings";
 import { MandelbulbModel } from "../mandelbulb/mandelbulbModel";
 import { Mandelbulb } from "../mandelbulb/mandelbulb";
 import { BlackHoleModel } from "../stellarObjects/blackHole/blackHoleModel";
@@ -49,14 +49,21 @@ export class StarSystemHelper {
         return star;
     }
 
-    public static MakeMandelbulb(starsystem: StarSystemController, model: number | MandelbulbModel = starsystem.model.getPlanetSeed(starsystem.mandelbulbs.length)): Mandelbulb {
-        if (starsystem.planets.length >= starsystem.model.getNbPlanets())
+    public static MakeMandelbulb(starsystem: StarSystemController, model: number | MandelbulbModel = starsystem.model.getAnomalySeed(starsystem.mandelbulbs.length)): Mandelbulb {
+        if (starsystem.mandelbulbs.length >= starsystem.model.getNbAnomalies())
             console.warn(`You are adding a mandelbulb to the system.
-            The system generator had planned for ${starsystem.model.getNbPlanets()} planets, but you are adding the ${starsystem.planets.length + 1}th planet.
-            starsystem might cause issues, or not who knows.`);
-        const mandelbulb = new Mandelbulb(`${starsystem.model.getName()} ${romanNumeral(starsystem.planets.length + 1)}`, starsystem.scene, model, starsystem.stellarObjects[0]);
+            The system generator had planned for ${starsystem.model.getNbAnomalies()} anomalies, but you are adding the ${starsystem.mandelbulbs.length + 1}th anomaly.
+            This might cause issues, or not who knows.`);
+        const mandelbulb = new Mandelbulb(`${starsystem.model.getName()} ${GreekAlphabet[starsystem.mandelbulbs.length]}`, starsystem.scene, model, starsystem.stellarObjects[0]);
         starsystem.addMandelbulb(mandelbulb);
         return mandelbulb;
+    }
+
+    public static MakeAnomalies(starsystem: StarSystemController, n = starsystem.model.getNbAnomalies()): void {
+        if (n < 0) throw new Error(`Cannot make a negative amount of anomalies : ${n}`);
+        for (let i = 0; i < n; i++) {
+            StarSystemHelper.MakeMandelbulb(starsystem);
+        }
     }
 
     /**
@@ -232,8 +239,9 @@ export class StarSystemHelper {
     /**
      * Generates the system using the seed provided in the constructor
      */
-    public static Generate(starsystem: StarSystemController) {
-        StarSystemHelper.MakeStellarObjects(starsystem, starsystem.model.getNbStellarObjects());
-        StarSystemHelper.MakePlanets(starsystem, starsystem.model.getNbPlanets());
+    public static Generate(starSystem: StarSystemController) {
+        StarSystemHelper.MakeStellarObjects(starSystem, starSystem.model.getNbStellarObjects());
+        StarSystemHelper.MakePlanets(starSystem, starSystem.model.getNbPlanets());
+        StarSystemHelper.MakeAnomalies(starSystem, starSystem.model.getNbAnomalies());
     }
 }

--- a/src/ts/starSystem/starSystemModel.ts
+++ b/src/ts/starSystem/starSystemModel.ts
@@ -21,6 +21,7 @@ import { Settings } from "../settings";
 import { generateStarName } from "../utils/starNameGenerator";
 import { SystemSeed } from "../utils/systemSeed";
 import { BodyType } from "../architecture/bodyType";
+import { wheelOfFortune } from "../utils/wheelOfFortune";
 
 const enum GenerationSteps {
     NAME,
@@ -28,7 +29,8 @@ const enum GenerationSteps {
     GENERATE_STARS = 21,
     NB_PLANETS = 30,
     GENERATE_PLANETS = 200,
-    CHOOSE_PLANET_TYPE = 400
+    CHOOSE_PLANET_TYPE = 400,
+    GENERATE_ANOMALIES = 666
 }
 
 export class StarSystemModel {
@@ -89,5 +91,16 @@ export class StarSystemModel {
 
     public getPlanetSeed(index: number) {
         return centeredRand(this.rng, GenerationSteps.GENERATE_PLANETS + index) * Settings.SEED_HALF_RANGE;
+    }
+
+    public getAnomalySeed(index: number) {
+        return centeredRand(this.rng, GenerationSteps.GENERATE_ANOMALIES + index * 100) * Settings.SEED_HALF_RANGE;
+    }
+
+    public getNbAnomalies(): number {
+        return wheelOfFortune(
+            [[0, 0.95], [1, 0.04], [2, 0.01]],
+            this.rng(GenerationSteps.GENERATE_ANOMALIES * 16)
+        );
     }
 }

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -429,6 +429,15 @@ export class StarSystemView implements View {
                 await wait(timeOut);
             }
         }
+
+        // Anomalies
+        for (let i = 0; i < systemModel.getNbAnomalies(); i++) {
+            console.log("Anomaly:", i + 1, "of", systemModel.getNbAnomalies());
+            const anomaly = StarSystemHelper.MakeMandelbulb(starSystem);
+            anomaly.getTransform().setAbsolutePosition(new Vector3(offset * ++objectIndex, 0, 0));
+
+            await wait(timeOut);
+        }
     }
 
     /**

--- a/src/ts/stereo.ts
+++ b/src/ts/stereo.ts
@@ -81,7 +81,7 @@ function createBlackHole(): TransformNode {
 
 function createMandelbulb(): TransformNode {
     const mandelbulb = new Mandelbulb("bulb", scene, Math.random() * 10000, null);
-    mandelbulb.getTransform().setAbsolutePosition(new Vector3(0, 0, 15));
+    mandelbulb.getTransform().setAbsolutePosition(new Vector3(0, 0, 20));
     mandelbulb.getTransform().scalingDeterminant = 1 / 100e3;
 
     const mandelbulbPP = new MandelbulbPostProcess(mandelbulb, scene, []);

--- a/src/ts/utils/parseToStrings.ts
+++ b/src/ts/utils/parseToStrings.ts
@@ -70,6 +70,8 @@ export function parsePercentageFrom01(percentage01: number): string {
 
 export const Alphabet = "abcdefghijklmnopqrstuvwxyz";
 
+export const GreekAlphabet = "αβγδεζηθικλμνξοπρστυφχψω";
+
 export function starName(baseName: string, index: number): string {
     return `${baseName} ${Alphabet[index].toUpperCase()}`;
 }


### PR DESCRIPTION
![screenshot_24-5-12_10-42(1)](https://github.com/BarthPaleologue/CosmosJourneyer/assets/31370477/04ab7a88-6ead-4a88-bd49-0cd6c02ed78e)

- Mandelbulbs now have a slim chance of spawning in star systems under the category "anomaly"
- Bulbs will use emissive lighting when no stellar object is around
- fix a warning that would pop up during load times because of the absence of stellar objects