### PR TITLE
Fix overlay disappearing

### DIFF
--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -191,9 +191,7 @@ export class CosmosJourneyer {
               })
             : new Engine(canvas, true, {
                   // the preserveDrawingBuffer option is required for the screenshot feature to work
-                  preserveDrawingBuffer: true,
-                  useHighPrecisionMatrix: true,
-                  useHighPrecisionFloats: true
+                  preserveDrawingBuffer: true
               });
 
         engine.useReverseDepthBuffer = true;

--- a/src/ts/ui/objectOverlay.ts
+++ b/src/ts/ui/objectOverlay.ts
@@ -107,11 +107,18 @@ export class ObjectOverlay {
     }
 
     update(camera: Camera, target: (Transformable & BoundingSphere & TypedObject) | null) {
+        const viewRay = camera.getDirection(LocalDirection.BACKWARD);
         const objectRay = this.object.getTransform().getAbsolutePosition().subtract(camera.globalPosition);
         const distance = objectRay.length();
         const deltaDistance = this.lastDistance - distance;
         const speed = deltaDistance !== 0 ? deltaDistance / (camera.getScene().getEngine().getDeltaTime() / 1000) : 0;
         objectRay.scaleInPlace(1 / distance);
+
+        if (Vector3.Dot(viewRay, objectRay) < 0) {
+            this.cursor.isVisible = false;
+            this.textRoot.isVisible = false;
+            return;
+        }
 
         this.cursor.isVisible = true;
         this.textRoot.isVisible = this.object === target;


### PR DESCRIPTION
- high precision matrices makes the overlay of distant targeted star systems disappear, they have been removed for now
- sometimes the overlay would render on the opposite side of the camera, allowing to see overlays that should not be visible. This is fixed by enabling back the direction detection code that had been removed previously