### PR TITLE
Improved stereo

### DIFF
--- a/src/ts/julia/juliaSet.ts
+++ b/src/ts/julia/juliaSet.ts
@@ -1,0 +1,103 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Camera } from "@babylonjs/core/Cameras/camera";
+import { JuliaSetModel } from "./juliaSetModel";
+import { PostProcessType } from "../postProcesses/postProcessTypes";
+import { Axis } from "@babylonjs/core/Maths/math.axis";
+import { CelestialBody } from "../architecture/celestialBody";
+import { TransformNode } from "@babylonjs/core/Meshes";
+import { Scene } from "@babylonjs/core/scene";
+import { OrbitProperties } from "../orbit/orbitProperties";
+import { RingsUniforms } from "../rings/ringsUniform";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Cullable } from "../utils/cullable";
+import { OrbitalObjectPhysicalProperties } from "../architecture/physicalProperties";
+import i18n from "../i18n";
+
+export class JuliaSet implements CelestialBody, Cullable {
+    readonly name: string;
+
+    readonly model: JuliaSetModel;
+
+    private readonly transform: TransformNode;
+
+    readonly postProcesses: PostProcessType[] = [];
+
+    readonly parent: CelestialBody | null = null;
+
+    /**
+     * New Gas Planet
+     * @param name The name of the planet
+     * @param scene
+     * @param parentBody The bodies the planet is orbiting
+     * @param model The model to create the planet from or a seed for the planet in [-1, 1]
+     */
+    constructor(name: string, scene: Scene, model: JuliaSetModel | number, parentBody: CelestialBody | null = null) {
+        this.name = name;
+
+        this.model = model instanceof JuliaSetModel ? model : new JuliaSetModel(model, parentBody?.model);
+
+        this.parent = parentBody;
+
+        this.transform = new TransformNode(name, scene);
+
+        this.postProcesses.push(PostProcessType.MANDELBULB);
+
+        this.getTransform().rotate(Axis.X, this.model.physicalProperties.axialTilt);
+    }
+
+    getTransform(): TransformNode {
+        return this.transform;
+    }
+
+    getRotationAxis(): Vector3 {
+        return this.getTransform().up;
+    }
+
+    getOrbitProperties(): OrbitProperties {
+        return this.model.orbit;
+    }
+
+    getPhysicalProperties(): OrbitalObjectPhysicalProperties {
+        return this.model.physicalProperties;
+    }
+
+    getRingsUniforms(): RingsUniforms | null {
+        return this.model.ringsUniforms;
+    }
+
+    getRadius(): number {
+        return this.model.radius;
+    }
+
+    getBoundingRadius(): number {
+        return this.model.radius;
+    }
+
+    getTypeName(): string {
+        return i18n.t("objectTypes:anomaly");
+    }
+
+    computeCulling(cameras: Camera[]): void {
+        // do nothing
+    }
+
+    dispose() {
+        this.transform.dispose();
+    }
+}

--- a/src/ts/julia/juliaSetModel.ts
+++ b/src/ts/julia/juliaSetModel.ts
@@ -1,0 +1,97 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { seededSquirrelNoise } from "squirrel-noise";
+
+import { OrbitProperties } from "../orbit/orbitProperties";
+import { normalRandom, randRangeInt } from "extended-random";
+import { clamp } from "../utils/math";
+import { getOrbitalPeriod, getPeriapsis } from "../orbit/orbit";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { PlanetModel } from "../architecture/planet";
+import { PlanetPhysicalProperties } from "../architecture/physicalProperties";
+import { CelestialBodyModel } from "../architecture/celestialBody";
+import { BodyType } from "../architecture/bodyType";
+import { GenerationSteps } from "../utils/generationSteps";
+import { wheelOfFortune } from "../utils/wheelOfFortune";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+
+export class JuliaSetModel implements PlanetModel {
+    readonly bodyType = BodyType.MANDELBULB;
+    readonly seed: number;
+    readonly rng: (step: number) => number;
+
+    readonly radius: number;
+
+    readonly orbit: OrbitProperties;
+
+    readonly physicalProperties: PlanetPhysicalProperties;
+
+    readonly parentBody: CelestialBodyModel | null;
+
+    readonly childrenBodies: CelestialBodyModel[] = [];
+
+    readonly nbMoons: number;
+
+    readonly ringsUniforms = null;
+
+    readonly accentColor: Color3;
+
+    constructor(seed: number, parentBody?: CelestialBodyModel) {
+        this.seed = seed;
+        this.rng = seededSquirrelNoise(this.seed);
+
+        this.radius = 1000e3;
+
+        this.parentBody = parentBody ?? null;
+        
+        this.accentColor = Color3.FromHSV(360 * this.rng(GenerationSteps.ACCENT_COLOR), this.rng(GenerationSteps.ACCENT_COLOR + 123) * 0.5, 0.8);
+
+        // Todo: do not hardcode
+        let orbitRadius = this.rng(GenerationSteps.ORBIT) * 15e9;
+
+        const orbitalP = clamp(0.5, 3.0, normalRandom(1.0, 0.3, this.rng, GenerationSteps.ORBIT + 80));
+        orbitRadius += orbitRadius - getPeriapsis(orbitRadius, orbitalP);
+
+        this.orbit = {
+            radius: orbitRadius,
+            p: orbitalP,
+            period: getOrbitalPeriod(orbitRadius, this.parentBody?.physicalProperties.mass ?? 0),
+            normalToPlane: Vector3.Up(),
+            isPlaneAlignedWithParent: true
+        };
+
+        this.physicalProperties = {
+            mass: 10,
+            rotationPeriod: 0,
+            axialTilt: normalRandom(0, 0.4, this.rng, GenerationSteps.AXIAL_TILT),
+            minTemperature: -180,
+            maxTemperature: 100,
+            pressure: 0
+        };
+
+        this.nbMoons = wheelOfFortune([[0, 0.95], [1, 0.5]], this.rng(GenerationSteps.NB_MOONS));
+    }
+
+    getApparentRadius(): number {
+        return this.radius;
+    }
+
+    getNbSpaceStations(): number {
+        return 0;
+    }
+}

--- a/src/ts/julia/juliaSetPostProcess.ts
+++ b/src/ts/julia/juliaSetPostProcess.ts
@@ -1,0 +1,87 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import juliaFragment from "../../shaders/juliaSet.glsl";
+import { ObjectPostProcess, UpdatablePostProcess } from "../postProcesses/objectPostProcess";
+import { Effect } from "@babylonjs/core/Materials/effect";
+import { JuliaSet } from "./juliaSet";
+import { StellarObject } from "../architecture/stellarObject";
+import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
+import { Camera } from "@babylonjs/core/Cameras/camera";
+import { ObjectUniformNames, setObjectUniforms } from "../postProcesses/uniforms/objectUniforms";
+import { CameraUniformNames, setCameraUniforms } from "../postProcesses/uniforms/cameraUniforms";
+import { setStellarObjectUniforms, StellarObjectUniformNames } from "../postProcesses/uniforms/stellarObjectUniforms";
+import { SamplerUniformNames, setSamplerUniforms } from "../postProcesses/uniforms/samplerUniforms";
+import { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import { Constants } from "@babylonjs/core/Engines/constants";
+import { Scene } from "@babylonjs/core/scene";
+
+export class JuliaSetPostProcess extends PostProcess implements ObjectPostProcess, UpdatablePostProcess {
+    readonly object: JuliaSet;
+
+    private elapsedSeconds = 0;
+
+    private activeCamera: Camera | null = null;
+
+    constructor(julia: JuliaSet, scene: Scene, stellarObjects: StellarObject[]) {
+        const shaderName = "julia";
+        if (Effect.ShadersStore[`${shaderName}FragmentShader`] === undefined) {
+            Effect.ShadersStore[`${shaderName}FragmentShader`] = juliaFragment;
+        }
+
+        const JuliaUniformNames = {
+            ELAPSED_SECONDS: "elapsedSeconds",
+            ACCENT_COLOR: "accentColor"
+        };
+
+        const uniforms: string[] = [
+            ...Object.values(ObjectUniformNames),
+            ...Object.values(CameraUniformNames),
+            ...Object.values(StellarObjectUniformNames),
+            ...Object.values(JuliaUniformNames)
+        ];
+
+        const samplers: string[] = Object.values(SamplerUniformNames);
+
+        super(julia.name, shaderName, uniforms, samplers, 1, null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), false, null, Constants.TEXTURETYPE_HALF_FLOAT);
+
+        this.object = julia;
+
+        this.onActivateObservable.add((camera) => {
+            this.activeCamera = camera;
+        });
+
+        this.onApplyObservable.add((effect) => {
+            if (this.activeCamera === null) {
+                throw new Error("Camera is null");
+            }
+
+            setCameraUniforms(effect, this.activeCamera);
+            setStellarObjectUniforms(effect, stellarObjects);
+            setObjectUniforms(effect, julia);
+
+            effect.setFloat(JuliaUniformNames.ELAPSED_SECONDS, this.elapsedSeconds);
+            effect.setColor3(JuliaUniformNames.ACCENT_COLOR, julia.model.accentColor);
+
+            setSamplerUniforms(effect, this.activeCamera, scene);
+        });
+    }
+
+    public update(deltaSeconds: number): void {
+        this.elapsedSeconds += deltaSeconds;
+    }
+}

--- a/src/ts/mandelbulb/mandelbulbModel.ts
+++ b/src/ts/mandelbulb/mandelbulbModel.ts
@@ -28,6 +28,7 @@ import { PlanetPhysicalProperties } from "../architecture/physicalProperties";
 import { CelestialBodyModel } from "../architecture/celestialBody";
 import { BodyType } from "../architecture/bodyType";
 import { GenerationSteps } from "../utils/generationSteps";
+import { wheelOfFortune } from "../utils/wheelOfFortune";
 
 export class MandelbulbModel implements PlanetModel {
     readonly bodyType = BodyType.MANDELBULB;
@@ -85,7 +86,7 @@ export class MandelbulbModel implements PlanetModel {
             pressure: 0
         };
 
-        this.nbMoons = randRangeInt(0, 2, this.rng, GenerationSteps.NB_MOONS);
+        this.nbMoons = wheelOfFortune([[0, 0.95], [1, 0.5]], this.rng(GenerationSteps.NB_MOONS));
     }
 
     getApparentRadius(): number {

--- a/src/ts/stereo.ts
+++ b/src/ts/stereo.ts
@@ -48,7 +48,7 @@ scene.useRightHandedSystem = true;
 
 await Assets.Init(scene);
 
-const stereoCameras = new StereoCameras(canvas, engine, scene);
+const stereoCameras = new StereoCameras(scene);
 
 const leftEye = stereoCameras.leftEye;
 const rightEye = stereoCameras.rightEye;
@@ -137,6 +137,9 @@ scene.onBeforeRenderObservable.add(() => {
     stereoCameras.getTransform().computeWorldMatrix(true);
     stereoCameras.getTransform().rotateAround(targetObject.getAbsolutePosition(), Axis.Y, 0.1 * deltaSeconds);
     stereoCameras.getTransform().computeWorldMatrix(true);
+
+    stereoCameras.setDistanceToFocalPlane(Vector3.Distance(stereoCameras.getTransform().getAbsolutePosition(), targetObject.getAbsolutePosition()));
+    stereoCameras.updateCameraProjections();
 
     applyFloatingOrigin();
 });

--- a/src/ts/utils/stereoCameras.ts
+++ b/src/ts/utils/stereoCameras.ts
@@ -2,9 +2,10 @@ import { Transformable } from "../architecture/transformable";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { FreeCamera } from "@babylonjs/core/Cameras/freeCamera";
 import { Engine } from "@babylonjs/core/Engines/engine";
-import { Scene } from "@babylonjs/core";
+import { Scene, Tools } from "@babylonjs/core";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Viewport } from "@babylonjs/core/Maths/math.viewport";
+import { Camera } from "@babylonjs/core/Cameras/camera";
 
 export class StereoCameras implements Transformable {
     private readonly transform: TransformNode;
@@ -17,48 +18,51 @@ export class StereoCameras implements Transformable {
      * @private
      */
     private interPupillaryDistance = 0.065;
+    
+    private distanceToFocalPlane = 0;
 
-    constructor(canvas: HTMLCanvasElement, engine: Engine, scene: Scene) {
+    private focalPlaneHalfHeight = 17;
+
+    constructor(scene: Scene) {
         // This transform will be used as the parent of both eyes
         this.transform = new TransformNode("HeadTransform", scene);
 
         // left eye is on the left
         this.leftEye = new FreeCamera("LeftEye", new Vector3(-this.interPupillaryDistance / 2, 0, 0), scene);
         this.leftEye.viewport = new Viewport(0, 0.0, 0.5, 1);
+        this.leftEye.fov = Tools.ToRadians(90);
         this.leftEye.parent = this.transform;
         this.leftEye.onProjectionMatrixChangedObservable.add(() => {
-            const aspectRatio = canvas.width / canvas.height;
-            this.leftEye._projectionMatrix.copyFrom(
-                Matrix.PerspectiveFovLH(
-                    this.leftEye.fov,
-                    aspectRatio,
-                    this.leftEye.minZ,
-                    this.leftEye.maxZ,
-                    engine.isNDCHalfZRange,
-                    this.leftEye.projectionPlaneTilt,
-                    engine.useReverseDepthBuffer
-                )
-            );
+            this.updateCameraProjection(this.leftEye, -this.interPupillaryDistance / 2);
         });
 
         // right eye is on the right
         this.rightEye = new FreeCamera("RightEye", new Vector3(this.interPupillaryDistance / 2, 0, 0), scene);
         this.rightEye.viewport = new Viewport(0.5, 0, 0.5, 1);
+        this.rightEye.fov = Tools.ToRadians(90);
         this.rightEye.parent = this.transform;
         this.rightEye.onProjectionMatrixChangedObservable.add(() => {
-            const aspectRatio = canvas.width / canvas.height;
-            this.rightEye._projectionMatrix.copyFrom(
-                Matrix.PerspectiveFovLH(
-                    this.rightEye.fov,
-                    aspectRatio,
-                    this.rightEye.minZ,
-                    this.rightEye.maxZ,
-                    engine.isNDCHalfZRange,
-                    this.rightEye.projectionPlaneTilt,
-                    engine.useReverseDepthBuffer
-                )
-            );
+            this.updateCameraProjection(this.rightEye, this.interPupillaryDistance / 2);
         });
+    }
+
+    private updateCameraProjection(camera: Camera, cameraOffset: number) {
+        const engine = camera.getEngine();
+        const canvas = engine.getRenderingCanvas();
+        if (canvas === null) {
+            throw new Error("Canvas is null!");
+        }
+
+        const aspectRatio = canvas.width / canvas.height;
+        
+        camera.fov = Math.atan(this.focalPlaneHalfHeight / this.distanceToFocalPlane);
+
+        const offset = cameraOffset;
+        camera.position.x = offset;
+
+        const projectionMatrix = Matrix.PerspectiveFovLH(camera.fov, aspectRatio, camera.minZ, camera.maxZ, engine.isNDCHalfZRange, camera.projectionPlaneTilt, engine.useReverseDepthBuffer);
+        projectionMatrix.addAtIndex(8, offset / (this.focalPlaneHalfHeight * aspectRatio));
+        camera._projectionMatrix.copyFrom(projectionMatrix);
     }
 
     /**
@@ -67,8 +71,6 @@ export class StereoCameras implements Transformable {
      */
     setInterPupillaryDistance(distance: number) {
         this.interPupillaryDistance = distance;
-        this.leftEye.position.x = -this.interPupillaryDistance / 2;
-        this.rightEye.position.x = this.interPupillaryDistance / 2;
     }
 
     /**
@@ -78,8 +80,17 @@ export class StereoCameras implements Transformable {
         return this.interPupillaryDistance;
     }
 
+    setDistanceToFocalPlane(distance: number) {
+        this.distanceToFocalPlane = distance;
+    }
+
     getTransform(): TransformNode {
         return this.transform;
+    }
+
+    updateCameraProjections() {
+        this.leftEye.getProjectionMatrix(true);
+        this.rightEye.getProjectionMatrix(true);
     }
 
     dispose() {

--- a/src/ts/utils/stereoCameras.ts
+++ b/src/ts/utils/stereoCameras.ts
@@ -17,36 +17,59 @@ export class StereoCameras implements Transformable {
      * The distance between the two cameras in meters (IPD)
      * @private
      */
-    private interPupillaryDistance = 0.065;
+    private defaultIPD = 0.065;
     
-    private distanceToFocalPlane = 0;
+    private defaultDistanceToScreen = 0.8;
 
-    private focalPlaneHalfHeight = 17;
+    private screenHalfHeight = 0.17;
+
+    private useOffAxisProjection = true;
+
+    private useEyeTracking = false;
+
+    /**
+     * The position of the left eye given by the eye tracking
+     */
+    private eyeTrackingLeftPosition = Vector3.Zero();
+
+    /**
+     * The position of the right eye given by the eye tracking
+     */
+    private eyeTrackingRightPosition = Vector3.Zero();
 
     constructor(scene: Scene) {
         // This transform will be used as the parent of both eyes
         this.transform = new TransformNode("HeadTransform", scene);
 
         // left eye is on the left
-        this.leftEye = new FreeCamera("LeftEye", new Vector3(-this.interPupillaryDistance / 2, 0, 0), scene);
+        this.leftEye = new FreeCamera("LeftEye", new Vector3(this.defaultIPD / 2, 0, 0), scene);
         this.leftEye.viewport = new Viewport(0, 0.0, 0.5, 1);
         this.leftEye.fov = Tools.ToRadians(90);
+        this.leftEye.minZ = 0.01;
         this.leftEye.parent = this.transform;
         this.leftEye.onProjectionMatrixChangedObservable.add(() => {
-            this.updateCameraProjection(this.leftEye, -this.interPupillaryDistance / 2);
+            const cameraOffset = !this.useEyeTracking ? new Vector3(this.defaultIPD / 2, 0, this.defaultDistanceToScreen) : this.eyeTrackingLeftPosition;
+            this.updateCameraProjection(this.leftEye, cameraOffset);
         });
 
         // right eye is on the right
-        this.rightEye = new FreeCamera("RightEye", new Vector3(this.interPupillaryDistance / 2, 0, 0), scene);
+        this.rightEye = new FreeCamera("RightEye", new Vector3(-this.defaultIPD / 2, 0, 0), scene);
         this.rightEye.viewport = new Viewport(0.5, 0, 0.5, 1);
         this.rightEye.fov = Tools.ToRadians(90);
+        this.rightEye.minZ = 0.01;
         this.rightEye.parent = this.transform;
         this.rightEye.onProjectionMatrixChangedObservable.add(() => {
-            this.updateCameraProjection(this.rightEye, this.interPupillaryDistance / 2);
+            const cameraOffset = !this.useEyeTracking ? new Vector3(-this.defaultIPD / 2, 0, this.defaultDistanceToScreen) : this.eyeTrackingRightPosition;
+            this.updateCameraProjection(this.rightEye, cameraOffset);
         });
     }
 
-    private updateCameraProjection(camera: Camera, cameraOffset: number) {
+    /**
+     * Updates the projection matrices of the cameras with off-axis projection
+     * @param camera 
+     * @param cameraOffset The camera position in local space
+     */
+    private updateCameraProjection(camera: Camera, cameraOffset: Vector3) {
         const engine = camera.getEngine();
         const canvas = engine.getRenderingCanvas();
         if (canvas === null) {
@@ -54,34 +77,67 @@ export class StereoCameras implements Transformable {
         }
 
         const aspectRatio = canvas.width / canvas.height;
-        
-        camera.fov = Math.atan(this.focalPlaneHalfHeight / this.distanceToFocalPlane);
 
-        const offset = cameraOffset;
-        camera.position.x = offset;
+        camera.position.x = cameraOffset.x;
+        camera.position.y = cameraOffset.y;
+        camera.position.z = Math.abs(cameraOffset.z);
+
+        // the distance to the focal plane is the distance of the eye to the screen plane
+        const distanceToFocalPlane = Math.abs(camera.position.z);
+
+        camera.fov = 2 * Math.atan(this.screenHalfHeight / distanceToFocalPlane);
 
         const projectionMatrix = Matrix.PerspectiveFovLH(camera.fov, aspectRatio, camera.minZ, camera.maxZ, engine.isNDCHalfZRange, camera.projectionPlaneTilt, engine.useReverseDepthBuffer);
-        projectionMatrix.addAtIndex(8, offset / (this.focalPlaneHalfHeight * aspectRatio));
+        if (this.useOffAxisProjection) {
+            projectionMatrix.addAtIndex(8, -cameraOffset.x / (this.screenHalfHeight * aspectRatio));
+            projectionMatrix.addAtIndex(9, cameraOffset.y / this.screenHalfHeight);
+        }
         camera._projectionMatrix.copyFrom(projectionMatrix);
     }
+    
+    setEyeTrackingEnabled(useEyeTracking: boolean) {
+        this.useEyeTracking = useEyeTracking;
+    }
+
+    isEyeTrackingEnabled(): boolean {
+        return this.useEyeTracking;
+    }
+
+    setOffAxisProjectionEnabled(enabled: boolean) {
+        this.useOffAxisProjection = enabled;
+    }
+
+    isOffAxisProjectionEnabled(): boolean {
+        return this.useOffAxisProjection;
+    }
+
+    setEyeTrackingPositions(leftEyePosition: Vector3, rightEyePosition: Vector3) {
+        this.eyeTrackingLeftPosition = leftEyePosition;
+        this.eyeTrackingRightPosition = rightEyePosition;
+    }
+
 
     /**
      * Set the distance between the two cameras in meters (IPD)
      * @param distance The distance between the two cameras in meters
      */
-    setInterPupillaryDistance(distance: number) {
-        this.interPupillaryDistance = distance;
+    setDefaultIPD(distance: number) {
+        this.defaultIPD = distance;
     }
 
     /**
      * Returns the distance between the two cameras in meters (IPD)
      */
-    getInterPupillaryDistance(): number {
-        return this.interPupillaryDistance;
+    getDefaultIPD(): number {
+        return this.defaultIPD;
     }
 
-    setDistanceToFocalPlane(distance: number) {
-        this.distanceToFocalPlane = distance;
+    setScreenHalfHeight(screenHalfHeight: number) {
+        this.screenHalfHeight = screenHalfHeight;
+    }
+
+    getScreenHalfHeight(): number {
+        return this.screenHalfHeight;
     }
 
     getTransform(): TransformNode {


### PR DESCRIPTION
![image](https://github.com/BarthPaleologue/CosmosJourneyer/assets/31370477/b64fd069-c21b-440b-8092-d8bf8b8f9efe)

- Added Websocket-based eye position retrieval
- Added 3D Julia set in stereo demo, can be chosen instead of mandelbulb using the `scene` url parameter
- Stereo handles RHS and LHS by itself
- Added WebGPU support to stereo demo
- Added IPD (inter pupillary distance) tweaking using a keyboard shortcut (numpad + and -)
- Reduced moon frequency for mandelbulbs
- Removed star field background from stereo as it broke the effect