### PR TITLE
High precision matrix fix

### DIFF
--- a/src/ts/assets/textures.ts
+++ b/src/ts/assets/textures.ts
@@ -39,6 +39,8 @@ import seamlessPerlin from "../../asset/perlin.png";
 import atmosphereLUT from "../../shaders/textures/atmosphereLUT.glsl";
 import empty from "../../asset/oneBlackPixel.png";
 
+import cursorImage from "../../asset/textures/hoveredCircle.png";
+
 export class Textures {
     static ROCK_NORMAL_METALLIC_MAP: Texture;
     static ROCK_ALBEDO_ROUGHNESS_MAP: Texture;
@@ -64,6 +66,8 @@ export class Textures {
     static FLARE_TEXTURE: Texture;
 
     static EMPTY_TEXTURE: Texture;
+
+    static CURSOR_IMAGE_URL: string;
 
     static ATMOSPHERE_LUT: ProceduralTexture;
 
@@ -97,6 +101,8 @@ export class Textures {
 
         Textures.ATMOSPHERE_LUT = new ProceduralTexture("atmosphereLUT", 100, { fragmentSource: atmosphereLUT }, scene, undefined, false, false);
         Textures.ATMOSPHERE_LUT.refreshRate = 0;
+
+        this.CURSOR_IMAGE_URL = cursorImage;
 
         manager.addTextureTask("EmptyTexture", empty).onSuccess = (task) => (Textures.EMPTY_TEXTURE = task.texture);
     }

--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -192,7 +192,8 @@ export class CosmosJourneyer {
               })
             : new Engine(canvas, true, {
                   // the preserveDrawingBuffer option is required for the screenshot feature to work
-                  preserveDrawingBuffer: true
+                  preserveDrawingBuffer: true,
+                  useHighPrecisionMatrix: true
               });
 
         engine.useReverseDepthBuffer = true;

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -345,7 +345,12 @@ export class StarSystemView implements View {
         // main update loop for the star system
         this.scene.onBeforePhysicsObservable.add(() => {
             const deltaSeconds = engine.getDeltaTime() / 1000;
-            this.update(deltaSeconds * Settings.TIME_MULTIPLIER);
+            this.updateBeforePhysics(deltaSeconds * Settings.TIME_MULTIPLIER);
+        });
+
+        this.scene.onBeforeRenderObservable.add(() => {
+            const deltaSeconds = engine.getDeltaTime() * Settings.TIME_MULTIPLIER / 1000;
+            this.updateBeforeRender(deltaSeconds);
         });
 
         window.addEventListener("resize", () => {
@@ -514,7 +519,7 @@ export class StarSystemView implements View {
      * Updates the system view. It updates the underlying star system, the UI, the chunk forge and the controls
      * @param deltaSeconds the time elapsed since the last update in seconds
      */
-    public update(deltaSeconds: number) {
+    public updateBeforePhysics(deltaSeconds: number) {
         if (this.isLoadingSystem) return;
 
         const starSystem = this.getStarSystem();
@@ -522,7 +527,12 @@ export class StarSystemView implements View {
         this.chunkForge.update();
 
         starSystem.update(deltaSeconds, this.chunkForge, this.postProcessManager);
+    }
 
+    public updateBeforeRender(deltaSeconds: number) {
+        if (this.isLoadingSystem) return;
+
+        const starSystem = this.getStarSystem();
         if (this.spaceshipControls === null) throw new Error("Spaceship controls is null");
         if (this.characterControls === null) throw new Error("Character controls is null");
 


### PR DESCRIPTION
Cosmos Journeyer now uses 64bit matrices. This will improve the rendering of terrain quite a bit like in #59

This required changing the way the UI is rendered: the object overlays can't be further than the far plane so I create placeholder transforms to put them in front of the camera as suggested here: https://forum.babylonjs.com/t/how-to-render-gui-attached-to-objects-far-away/51271/2