### PR TITLE
fix overlay jittering

### DIFF
--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -551,9 +551,7 @@ export class StarSystemView implements View {
 
         this.characterControls.setClosestWalkableObject(nearestBody);
         this.spaceshipControls.spaceship.setClosestWalkableObject(nearestBody);
-
-        this.ui.update(this.scene.getActiveCameras()[0]);
-
+        
         const nearestOrbitalObject = starSystem.getNearestOrbitalObject();
         const nearestCelestialBody = starSystem.getNearestCelestialBody(this.scene.getActiveControls().getTransform().getAbsolutePosition());
 

--- a/src/ts/ui/systemUI.ts
+++ b/src/ts/ui/systemUI.ts
@@ -18,7 +18,6 @@
 import { Scene } from "@babylonjs/core/scene";
 import { AdvancedDynamicTexture } from "@babylonjs/gui/2D/advancedDynamicTexture";
 import { ObjectOverlay } from "./objectOverlay";
-import { Camera } from "@babylonjs/core/Cameras/camera";
 import { FreeCamera } from "@babylonjs/core/Cameras/freeCamera";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Transformable } from "../architecture/transformable";
@@ -42,6 +41,12 @@ export class SystemUI {
         this.camera = new FreeCamera("UiCamera", Vector3.Zero(), this.scene);
 
         this.gui = AdvancedDynamicTexture.CreateFullscreenUI("SystemUI", true, this.scene);
+
+        this.scene.onBeforeRenderObservable.add(() => {
+            for (const overlay of this.objectOverlays) {
+                overlay.update(this.camera, this.target);
+            }
+        });
     }
 
     public setEnabled(enabled: boolean) {
@@ -73,12 +78,6 @@ export class SystemUI {
             overlay.dispose();
         }
         this.objectOverlays = [];
-    }
-
-    public update(camera: Camera) {
-        for (const overlay of this.objectOverlays) {
-            overlay.update(camera, this.target);
-        }
     }
 
     public setTarget(object: (Transformable & BoundingSphere & TypedObject) | null) {


### PR DESCRIPTION
The overlay positions were updated too early, resulting in some noticable lag when rotating the camera