### PR TITLE
Fix nearest orbital object computation

### DIFF
--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -327,7 +327,7 @@ export class CosmosJourneyer {
         const seed = currentStarSystem.model.seed;
 
         // Finding the index of the nearest orbital object
-        const nearestOrbitalObject = currentStarSystem.getNearestOrbitalObject();
+        const nearestOrbitalObject = currentStarSystem.getNearestOrbitalObject(this.starSystemView.scene.getActiveControls().getTransform().getAbsolutePosition());
         const nearestOrbitalObjectIndex = currentStarSystem.getOrbitalObjects().indexOf(nearestOrbitalObject);
         if (nearestOrbitalObjectIndex === -1) throw new Error("Nearest orbital object not found");
 

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -537,9 +537,9 @@ export class StarSystemView implements View {
         if (this.characterControls === null) throw new Error("Character controls is null");
 
         const shipPosition = this.spaceshipControls.getTransform().getAbsolutePosition();
-        const nearestBody = starSystem.getNearestOrbitalObject();
-        const distance = nearestBody.getTransform().getAbsolutePosition().subtract(shipPosition).length();
-        const radius = nearestBody.getBoundingRadius();
+        const nearestOrbitalObject = starSystem.getNearestOrbitalObject(this.scene.getActiveControls().getTransform().getAbsolutePosition());
+        const distance = nearestOrbitalObject.getTransform().getAbsolutePosition().subtract(shipPosition).length();
+        const radius = nearestOrbitalObject.getBoundingRadius();
         this.spaceshipControls.spaceship.registerClosestObject(distance, radius);
 
         const warpDrive = this.spaceshipControls.spaceship.getWarpDrive();
@@ -549,10 +549,9 @@ export class StarSystemView implements View {
             this.helmetOverlay.displaySpeed(this.spaceshipControls.spaceship.getThrottle(), this.spaceshipControls.spaceship.getSpeed());
         }
 
-        this.characterControls.setClosestWalkableObject(nearestBody);
-        this.spaceshipControls.spaceship.setClosestWalkableObject(nearestBody);
-        
-        const nearestOrbitalObject = starSystem.getNearestOrbitalObject();
+        this.characterControls.setClosestWalkableObject(nearestOrbitalObject);
+        this.spaceshipControls.spaceship.setClosestWalkableObject(nearestOrbitalObject);
+
         const nearestCelestialBody = starSystem.getNearestCelestialBody(this.scene.getActiveControls().getTransform().getAbsolutePosition());
 
         this.bodyEditor.update(nearestCelestialBody, this.postProcessManager, this.scene);


### PR DESCRIPTION
As the nearest object depends on the position queried, it makes no sense to cache the result.

The error was caused by the cache not being populated, now it will be recomputed everytime it is queried, solving the issue.