### PR TITLE
Fix spaceship crashing in planet at the start of a new journey

### DIFF
--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -69,7 +69,7 @@ export class Spaceship implements Transformable {
     private state = ShipState.FLYING;
 
     private closestObject = {
-        distance: Infinity,
+        distance: 0,
         radius: 1
     };
 

--- a/src/ts/starSystem/starSystemController.ts
+++ b/src/ts/starSystem/starSystemController.ts
@@ -223,19 +223,18 @@ export class StarSystemController {
     public getNearestOrbitalObject(position: Vector3): OrbitalObject {
         if (this.orbitalObjects.length === 0) throw new Error("There are no orbital objects in the solar system");
         let nearest: OrbitalObject = this.orbitalObjects[0];
-        let smallerDistance = -1;
+        let smallerDistance = Number.POSITIVE_INFINITY;
         for (const body of this.celestialBodies) {
             const distance = body.getTransform().getAbsolutePosition().subtract(position).length() - body.getRadius();
-            if (nearest === null || distance < smallerDistance) {
+            if (distance < smallerDistance) {
                 nearest = body;
                 smallerDistance = distance;
             }
         }
 
-        smallerDistance = -1;
         for (const spacestation of this.spaceStations) {
             const distance = spacestation.getTransform().getAbsolutePosition().subtract(position).length() - spacestation.getBoundingRadius() * 100;
-            if (distance < smallerDistance && distance < 0) {
+            if (distance < smallerDistance && distance < spacestation.getBoundingRadius() * 500) {
                 nearest = spacestation;
                 smallerDistance = distance;
             }


### PR DESCRIPTION
- The nearest orbital object was wrongfully computed
- Space stations will be considered closest objects only when close enough