### PR TITLE
Fix asteroid layout

### DIFF
--- a/src/ts/asteroidFields/asteroidField.ts
+++ b/src/ts/asteroidFields/asteroidField.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { Scene } from "@babylonjs/core/scene";
+import { IDisposable, Scene } from "@babylonjs/core/scene";
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Objects } from "../assets/objects";
 import { AsteroidPatch } from "./asteroidPatch";
@@ -26,7 +26,7 @@ import { seededSquirrelNoise } from "squirrel-noise";
  * An asteroid field is basically a collection of instance chunks that can be created and destroyed depending on where the player is.
  * This allows to only render the asteroids close to the player, saving immense resources.
  */
-export class AsteroidField {
+export class AsteroidField implements IDisposable {
     readonly seed: number;
     readonly rng: (step: number) => number;
 
@@ -44,8 +44,6 @@ export class AsteroidField {
     readonly patchThickness = 1000;
 
     readonly neighborCellsRenderRadius = 2;
-
-    readonly fadeSpeed = 1;
 
     private readonly patches = new Map<string, { patch: AsteroidPatch, cellX: number, cellZ: number }>();
 
@@ -127,6 +125,12 @@ export class AsteroidField {
 
                 this.patches.set(`${cellX};${cellZ}`, { patch: patch, cellX: cellX, cellZ: cellZ });
             }
+        }
+    }
+
+    dispose() {
+        for (const value of this.patches.values()) {
+            value.patch.dispose();
         }
     }
 

--- a/src/ts/asteroidFields/asteroidField.ts
+++ b/src/ts/asteroidFields/asteroidField.ts
@@ -154,7 +154,7 @@ export class AsteroidField {
         const cellSize = patchSize / resolution;
         for (let x = 0; x < resolution; x++) {
             for (let z = 0; z < resolution; z++) {
-                const asteroidIndex = cellIndex + (x * resolution + z) / 1000;
+                const asteroidIndex = (cellIndex / 1000e3) + (x * resolution + z) / 1000;
                 const randomCellPositionX = rng(asteroidIndex) * cellSize;
                 const randomCellPositionZ = rng(asteroidIndex + 4621) * cellSize;
                 const positionX = position.x + x * cellSize - patchSize / 2 + randomCellPositionX;

--- a/src/ts/asteroidFields/asteroidPatch.ts
+++ b/src/ts/asteroidFields/asteroidPatch.ts
@@ -30,12 +30,12 @@ export class AsteroidPatch implements IPatch {
     readonly instances: InstancedMesh[] = [];
     readonly instanceAggregates: PhysicsAggregate[] = [];
 
-    private positions: Vector3[];
-    private rotations: Quaternion[];
-    private scalings: Vector3[];
+    private readonly positions: Vector3[];
+    private readonly rotations: Quaternion[];
+    private readonly scalings: Vector3[];
 
-    private rotationAxes: Vector3[] = [];
-    private rotationSpeeds: number[] = [];
+    private readonly rotationAxes: Vector3[] = [];
+    private readonly rotationSpeeds: number[] = [];
 
     private nbInstances = 0;
 
@@ -136,6 +136,10 @@ export class AsteroidPatch implements IPatch {
 
     public dispose() {
         this.clearInstances();
-        if (this.baseMesh !== null) this.baseMesh.dispose();
+        this.positions.length = 0;
+        this.rotations.length = 0;
+        this.scalings.length = 0;
+        this.rotationAxes.length = 0;
+        this.rotationSpeeds.length = 0;
     }
 }

--- a/src/ts/planets/gasPlanet/gasPlanet.ts
+++ b/src/ts/planets/gasPlanet/gasPlanet.ts
@@ -152,6 +152,7 @@ export class GasPlanet implements Planet, Cullable {
         this.mesh.dispose();
         this.aggregate.dispose();
         this.material.dispose();
+        this.asteroidField?.dispose();
     }
 
     getOrbitProperties(): OrbitProperties {

--- a/src/ts/planets/telluricPlanet/telluricPlanet.ts
+++ b/src/ts/planets/telluricPlanet/telluricPlanet.ts
@@ -211,5 +211,6 @@ export class TelluricPlanet implements Planet, Cullable {
         this.material.dispose();
         this.aggregate.dispose();
         this.transform.dispose();
+        this.asteroidField?.dispose();
     }
 }

--- a/src/ts/stellarObjects/neutronStar/neutronStar.ts
+++ b/src/ts/stellarObjects/neutronStar/neutronStar.ts
@@ -180,5 +180,6 @@ export class NeutronStar implements StellarObject, Cullable {
         this.mesh.dispose();
         this.light.dispose();
         this.material.dispose();
+        this.asteroidField?.dispose();
     }
 }

--- a/src/ts/stellarObjects/star/star.ts
+++ b/src/ts/stellarObjects/star/star.ts
@@ -188,5 +188,6 @@ export class Star implements StellarObject, Cullable {
         this.mesh.dispose();
         this.material.dispose();
         this.light.dispose();
+        this.asteroidField?.dispose();
     }
 }


### PR DESCRIPTION
Asteroids seeds can get big around gas giants. Scaling them down helps avoiding imprecision while retaining variety.

Also asteroid fields are now disposed with their parent bodies