### PR TITLE
Asteroid field physics shape optimization

### DIFF
--- a/src/ts/assets/objects.ts
+++ b/src/ts/assets/objects.ts
@@ -39,6 +39,8 @@ import { InstancedMesh } from "@babylonjs/core/Meshes/instancedMesh";
 import "@babylonjs/loaders";
 import "@babylonjs/core/Loading/Plugins/babylonFileLoader";
 import "@babylonjs/core/Animations/animatable";
+import { PhysicsShape, PhysicsShapeMesh } from "@babylonjs/core";
+import { CollisionMask } from "../settings";
 
 export class Objects {
     private static SPACESHIP: Mesh;
@@ -52,7 +54,8 @@ export class Objects {
 
     public static ROCK: Mesh;
 
-    public static ASTEROID: Mesh;
+    public static ASTEROIDS: Mesh[] = [];
+    public static ASTEROID_PHYSICS_SHAPES: PhysicsShape[] = [];
 
     public static TREE: Mesh;
 
@@ -145,11 +148,37 @@ export class Objects {
 
         const asteroidTask = manager.addMeshTask("asteroidTask", "", "", asteroid);
         asteroidTask.onSuccess = function (task: MeshAssetTask) {
-            Objects.ASTEROID = task.loadedMeshes[0].getChildMeshes()[0] as Mesh;
-            Objects.ASTEROID.setParent(null);
-            Objects.ASTEROID.scaling.scaleInPlace(100);
-            Objects.ASTEROID.bakeCurrentTransformIntoVertices();
-            Objects.ASTEROID.setEnabled(false);
+            const asteroid = task.loadedMeshes[0].getChildMeshes()[0] as Mesh;
+            asteroid.setParent(null);
+            asteroid.scaling.scaleInPlace(100);
+            asteroid.bakeCurrentTransformIntoVertices();
+            asteroid.setEnabled(false);
+
+            Objects.ASTEROIDS.push(asteroid);
+
+            const physicsShape = new PhysicsShapeMesh(asteroid, scene);
+            physicsShape.filterMembershipMask = CollisionMask.ENVIRONMENT;
+            physicsShape.filterCollideMask = CollisionMask.DYNAMIC_OBJECTS;
+
+            Objects.ASTEROID_PHYSICS_SHAPES.push(physicsShape);
+
+            const scalings = [0.5, 0.7, 0.9, 1.1, 1.3, 1.5, 1.7, 1.9, 2.1, 2.3]
+            for(let i = 0; i < scalings.length; i++) {
+                const asteroidClone = asteroid.clone("asteroidClone" + i);
+                asteroidClone.makeGeometryUnique();
+                asteroidClone.setParent(null);
+                asteroidClone.scaling.scaleInPlace(scalings[i]);
+                asteroidClone.bakeCurrentTransformIntoVertices();
+                asteroidClone.setEnabled(false);
+
+                Objects.ASTEROIDS.push(asteroidClone);
+
+                const physicsShapeClone = new PhysicsShapeMesh(asteroidClone, scene);
+                physicsShapeClone.filterMembershipMask = CollisionMask.ENVIRONMENT;
+                physicsShapeClone.filterCollideMask = CollisionMask.DYNAMIC_OBJECTS;
+
+                Objects.ASTEROID_PHYSICS_SHAPES.push(physicsShapeClone);
+            }
 
             console.log("Asteroid loaded");
         };

--- a/src/ts/asteroidFields/asteroidField.ts
+++ b/src/ts/asteroidFields/asteroidField.ts
@@ -118,9 +118,9 @@ export class AsteroidField implements IDisposable {
 
                 const cellCoords = new Vector3(cellX * this.patchSize, 0, cellZ * this.patchSize);
 
-                const [positions, rotations, scalings, rotationAxes, rotationSpeeds] = AsteroidField.CreateAsteroidBuffer(cellCoords, this.resolution, this.patchSize, this.patchThickness, this.minRadius, this.maxRadius, this.rng);
-                const patch = new AsteroidPatch(positions, rotations, scalings, rotationAxes, rotationSpeeds, this.parent);
-                patch.createInstances(Objects.ASTEROID);
+                const [positions, rotations, typeIndices, rotationAxes, rotationSpeeds] = AsteroidField.CreateAsteroidBuffer(cellCoords, this.resolution, this.patchSize, this.patchThickness, this.minRadius, this.maxRadius, this.rng);
+                const patch = new AsteroidPatch(positions, rotations, typeIndices, rotationAxes, rotationSpeeds, this.parent);
+                patch.createInstances();
 
 
                 this.patches.set(`${cellX};${cellZ}`, { patch: patch, cellX: cellX, cellZ: cellZ });
@@ -145,10 +145,10 @@ export class AsteroidField implements IDisposable {
      * @param rng A random number generator
      * @returns A new matrix 4x4 buffer
      */
-    static CreateAsteroidBuffer(position: Vector3, resolution: number, patchSize: number, patchThickness: number, minRadius: number, maxRadius: number, rng: (index: number) => number): [Vector3[], Quaternion[], Vector3[], Vector3[], number[]] {
+    static CreateAsteroidBuffer(position: Vector3, resolution: number, patchSize: number, patchThickness: number, minRadius: number, maxRadius: number, rng: (index: number) => number): [Vector3[], Quaternion[], number[], Vector3[], number[]] {
         const positions = [];
         const rotations = [];
-        const scalings = [];
+        const asteroidTypeIndices = [];
 
         const rotationAxes = [];
         const rotationSpeeds = [];
@@ -168,7 +168,8 @@ export class AsteroidField implements IDisposable {
                 if (positionX * positionX + positionZ * positionZ > maxRadius * maxRadius) continue;
 
                 const positionY = position.y + (rng(asteroidIndex + 8781) - 0.5) * 2 * patchThickness;
-                const scaling = 0.7 + rng(asteroidIndex + 6549) * 0.6;
+
+                const asteroidTypeIndex = Math.floor(rng(asteroidIndex + 6549) * Objects.ASTEROIDS.length);
 
                 positions.push(new Vector3(positionX, positionY, positionZ));
 
@@ -176,13 +177,13 @@ export class AsteroidField implements IDisposable {
                 const initialRotationAngle = rng(asteroidIndex + 4239) * 2 * Math.PI;
 
                 rotations.push(Quaternion.RotationAxis(initialRotationAxis, initialRotationAngle));
-                scalings.push(new Vector3(scaling, scaling, scaling));
+                asteroidTypeIndices.push(asteroidTypeIndex);
 
                 rotationAxes.push(new Vector3(rng(asteroidIndex + 9630) - 0.5, rng(asteroidIndex + 3256) - 0.5, rng(asteroidIndex + 8520) - 0.5).normalize());
                 rotationSpeeds.push(rng(asteroidIndex + 1569) * 0.5);
             }
         }
 
-        return [positions, rotations, scalings, rotationAxes, rotationSpeeds];
+        return [positions, rotations, asteroidTypeIndices, rotationAxes, rotationSpeeds];
     }
 }


### PR DESCRIPTION
Instead of creating one shape per instance, precompute shapes at startup and then use the precomputed ones for the instances. This avoid transfering the vertex data across the language boundary every time.

The issue is that shapes do not support scaling, so each different scaling requires a new shape. For each model, it is trivial to create 10 different versions with different scaling to use them for instancing.

The new version now also support different asteroid models, although I still have to create them.