### PR TITLE
Fix screenshot precision

### DIFF
--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -309,12 +309,11 @@ export class CosmosJourneyer {
 
     /**
      * Takes a screenshot of the current scene. By default, the screenshot is taken at a 4x the resolution of the canvas
-     * @param precision The resolution multiplier of the screenshot
      */
-    public takeScreenshot(precision = 4): void {
+    public takeScreenshot(): void {
         const camera = this.activeView.getMainScene().activeCamera;
         if (camera === null) throw new Error("Cannot take screenshot: camera is null");
-        Tools.CreateScreenshot(this.engine, camera, { precision: precision });
+        Tools.CreateScreenshot(this.engine, camera, { precision:1 });
     }
 
     public takeVideoCapture(): void {


### PR DESCRIPTION
Having a greater precision does not work with post-processes which have a fixed size