### PR TITLE
Fix #140

### DIFF
--- a/src/ts/orbit/axisRenderer.ts
+++ b/src/ts/orbit/axisRenderer.ts
@@ -15,17 +15,19 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { LinesMesh, MeshBuilder } from "@babylonjs/core/Meshes";
+import { CreateGreasedLine, GreasedLineBaseMesh, GreasedLineMesh, GreasedLineRibbonMesh } from "@babylonjs/core/Meshes";
 import { Vector3 } from "@babylonjs/core/Maths/math";
 import { BoundingSphere } from "../architecture/boundingSphere";
 import { Transformable } from "../architecture/transformable";
 import { Scene } from "@babylonjs/core/scene";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import { GreasedLineMeshColorMode } from "@babylonjs/core/Materials/GreasedLine/greasedLineMaterialInterfaces";
 
 /**
  * Visual helper designed to display the rotation axis of given objects
  */
 export class AxisRenderer {
-    private axisMeshes: LinesMesh[] = [];
+    private axisMeshes: (GreasedLineBaseMesh | GreasedLineMesh | GreasedLineRibbonMesh)[] = [];
 
     private _isVisible = false;
 
@@ -45,13 +47,21 @@ export class AxisRenderer {
     }
 
     private createAxisMesh(orbitalObject: Transformable & BoundingSphere, scene: Scene) {
-        const rotationAxisHelper = MeshBuilder.CreateLines(
-            `RotationAxisHelper`,
+        const rotationAxisHelper = CreateGreasedLine(
+            "orbit2",
             {
-                points: [new Vector3(0, -orbitalObject.getBoundingRadius() * 2, 0), new Vector3(0, orbitalObject.getBoundingRadius() * 2, 0)]
+                points: [new Vector3(0, -orbitalObject.getBoundingRadius() * 2, 0), new Vector3(0, orbitalObject.getBoundingRadius() * 2, 0)],
+                updatable: false
+            },
+            {
+                color: Color3.White(),
+                width: 5,
+                colorMode: GreasedLineMeshColorMode.COLOR_MODE_SET,
+                sizeAttenuation: true
             },
             scene
         );
+
         rotationAxisHelper.parent = orbitalObject.getTransform();
         this.axisMeshes.push(rotationAxisHelper);
     }

--- a/src/ts/orbit/orbitRenderer.ts
+++ b/src/ts/orbit/orbitRenderer.ts
@@ -15,15 +15,17 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { LinesMesh, MeshBuilder } from "@babylonjs/core/Meshes";
+import { CreateGreasedLine, GreasedLineBaseMesh, GreasedLineMesh, GreasedLineRibbonMesh } from "@babylonjs/core/Meshes";
 import { Vector3 } from "@babylonjs/core/Maths/math";
 import { setUpVector } from "../uberCore/transforms/basicTransform";
 import { getPointOnOrbitLocal } from "./orbit";
 import { OrbitalObject } from "../architecture/orbitalObject";
 import { Scene } from "@babylonjs/core/scene";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import { GreasedLineMeshColorMode } from "@babylonjs/core/Materials/GreasedLine/greasedLineMaterialInterfaces";
 
 export class OrbitRenderer {
-    private orbitMeshes: LinesMesh[] = [];
+    private orbitMeshes: (GreasedLineBaseMesh | GreasedLineMesh | GreasedLineRibbonMesh)[] = [];
 
     private orbitalObjects: OrbitalObject[] = [];
 
@@ -52,7 +54,20 @@ export class OrbitRenderer {
         }
         points.push(points[0]);
 
-        const orbitMesh = MeshBuilder.CreateLines("orbit", { points: points }, scene);
+        const orbitMesh = CreateGreasedLine(
+            "orbit2",
+            {
+                points: points,
+                updatable: false
+            },
+            {
+                color: Color3.White(),
+                width: 5,
+                colorMode: GreasedLineMeshColorMode.COLOR_MODE_SET,
+                sizeAttenuation: true
+            },
+            scene
+        );
         this.orbitMeshes.push(orbitMesh);
     }
 


### PR DESCRIPTION
![screenshot_24-9-6_23-16](https://github.com/user-attachments/assets/84bc79a8-4ded-4dc8-9dbf-1aa5b46a601f)

Orbits and axis are now rendered with greased lines for a more pleasing look

Closes #140 