### PR TITLE
Fix rendering order

### DIFF
--- a/src/ts/postProcesses/postProcessManager.ts
+++ b/src/ts/postProcesses/postProcessManager.ts
@@ -447,7 +447,8 @@ export class PostProcessManager {
 
         this.renderingPipeline.addEffect(shadowRenderEffect);
 
-        for (const postProcessType of this.currentRenderingOrder) {
+        // other objects are viewed in their space configuration
+        for (const postProcessType of spaceRenderingOrder) {
             switch (postProcessType) {
                 case PostProcessType.VOLUMETRIC_LIGHT:
                     this.renderingPipeline.addEffect(otherVolumetricLightsRenderEffect);
@@ -485,6 +486,7 @@ export class PostProcessManager {
             }
         }
 
+        // closest object is either in surface or space configuration depending on distance to camera
         for (const postProcessType of this.currentRenderingOrder) {
             switch (postProcessType) {
                 case PostProcessType.VOLUMETRIC_LIGHT:


### PR DESCRIPTION
When in space, it makes sense to draw atmospheres first and rings second as the rings will be in front of the atmospheres.

When going near the surface of a planet, this order changes because the rings are now behind the atmosphere.

The issue was that the rings of distant planets would also be rendered after their atmosphere, which is not correct and can be visible when looking at a planet from one of its moons.

This PR fixes the issue by only changing the rendering order for the nearest body, not for the more distant ones.