### PR TITLE
Fix memory leak when storing textures cpu side

### DIFF
--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -204,7 +204,8 @@ export class CosmosJourneyer {
             : new Engine(canvas, true, {
                   // the preserveDrawingBuffer option is required for the screenshot feature to work
                   preserveDrawingBuffer: true,
-                  useHighPrecisionMatrix: true
+                  useHighPrecisionMatrix: true,
+                  doNotHandleContextLost: true
               });
 
         engine.useReverseDepthBuffer = true;


### PR DESCRIPTION
Context lost handling does not make sense for a desktop game imo

Related discussion: https://forum.babylonjs.com/t/procedural-texture-memory-leak/53627/

Handling context loss means storing everything cpu side, which is very ram consuming. Moreover, the resources would not always get cleared when loading systems, creating leaks