### PR TITLE
Fix WebGPU shaders

### DIFF
--- a/src/shaders/cylinderHabitatMaterial/fragment.glsl
+++ b/src/shaders/cylinderHabitatMaterial/fragment.glsl
@@ -55,12 +55,12 @@ void main() {
     normalW = normalize(TBN * normalColor);
 
     vec3 Lo = vec3(0.0);
-    for(int i = 0; i < nbStars; i++) {
+    for (int i = 0; i < nbStars; i++) {
         vec3 lightDirectionW = normalize(star_positions[i] - vPositionW);
         Lo += calculateLight(albedoColor, normalW, roughnessColor, metallicColor, lightDirectionW, viewDirectionW, star_colors[i]);
     }
 
-    Lo += smoothstep(0.48, 0.5, fract(vUV.x)) * smoothstep(0.52, 0.5, fract(vUV.x)) * smoothstep(0.4, 0.45, fract(vUV.y)) * smoothstep(0.6, 0.55, fract(vUV.y)) * vec3(1.0, 1.0, 0.4);
+    Lo += smoothstep(0.48, 0.5, fract(vUV.x)) * (1.0 - smoothstep(0.5, 0.52, fract(vUV.x))) * smoothstep(0.4, 0.45, fract(vUV.y)) * (1.0 - smoothstep(0.55, 0.6, fract(vUV.y))) * vec3(1.0, 1.0, 0.4);
 
     // occlusion
     //Lo *= mix(1.0, occlusionColor, 0.5);

--- a/src/shaders/grassMaterial/grassVertex.glsl
+++ b/src/shaders/grassMaterial/grassVertex.glsl
@@ -88,7 +88,7 @@ void main() {
     vec3 playerDirection = (objectWorld - playerPosition) / objectDistance;
     float maxDistance = 3.0;
     float distance01 = objectDistance / maxDistance;
-    float influence = smoothstep(1.0, 0.0, distance01);
+    float influence = 1.0 - smoothstep(0.0, 1.0, distance01);
     curveAmount += influence;
     curveAmount += windLeanAngle * smoothstep(0.2, 1.0, distance01);
 
@@ -96,7 +96,7 @@ void main() {
     leanAxis = normalize(mix(cross(vec3(0.0, 1.0, 0.0), playerDirection), leanAxis, smoothstep(0.0, 1.0, 1.0 - distance01)));
 
     float scaling = 1.0 + 0.3 * (texture2D(perlinNoise, objectWorld.xz * 0.1).r * 2.0 - 1.0);
-    scaling *= smoothstep(90.0, 70.0, objectCameraDistance); // fade grass in the distance using scaling
+    scaling *= 1.0 - smoothstep(70.0, 90.0, objectCameraDistance); // fade grass in the distance using scaling
 
     vec3 terrainNormal = normalize(vec3(worldMatrix * vec4(0.0, 1.0, 0.0, 0.0)));
     vec3 sphereNormal = normalize(objectWorld - planetPosition);

--- a/src/shaders/helixHabitatMaterial/fragment.glsl
+++ b/src/shaders/helixHabitatMaterial/fragment.glsl
@@ -55,12 +55,12 @@ void main() {
     normalW = normalize(TBN * normalColor);
 
     vec3 Lo = vec3(0.0);
-    for(int i = 0; i < nbStars; i++) {
+    for (int i = 0; i < nbStars; i++) {
         vec3 lightDirectionW = normalize(star_positions[i] - vPositionW);
         Lo += calculateLight(albedoColor, normalW, roughnessColor, metallicColor, lightDirectionW, viewDirectionW, star_colors[i]);
     }
 
-    Lo += smoothstep(0.48, 0.5, fract(vUV.x)) * smoothstep(0.52, 0.5, fract(vUV.x)) * smoothstep(0.4, 0.45, fract(vUV.y)) * smoothstep(0.6, 0.55, fract(vUV.y)) * vec3(1.0, 1.0, 0.4);
+    Lo += smoothstep(0.48, 0.5, fract(vUV.x)) * (1.0 - smoothstep(0.5, 0.52, fract(vUV.x))) * smoothstep(0.4, 0.45, fract(vUV.y)) * (1.0 - smoothstep(0.55, 0.6, fract(vUV.y))) * vec3(1.0, 1.0, 0.4);
 
     // occlusion
     //Lo *= mix(1.0, occlusionColor, 0.5);

--- a/src/shaders/lensflare.glsl
+++ b/src/shaders/lensflare.glsl
@@ -101,7 +101,7 @@ vec3 anflares(vec2 uv, float intensity, float stretch, float brightness)
 {
     uv.x *= 1.0/(intensity*stretch);
     uv.y *= 0.5;
-    return vec3(smoothstep(0.009, 0.0, length(uv)))*brightness;
+    return vec3(1.0 - smoothstep(0.0, 0.009, length(uv)))*brightness;
 }
 
 void main() {
@@ -141,7 +141,7 @@ void main() {
 
     // if angular radius is to great, fade the anflare out
     float angularRadius = object_radius / length(object_position - camera_position);
-    anflare *= smoothstep(0.1, 0.0, angularRadius);
+    anflare *= 1.0 - smoothstep(0.0, 0.1, angularRadius);
 
     vec3 sun = getSun(uv-mouse) + (flare + anflare)*flareColor*2.0;
 
@@ -149,7 +149,7 @@ void main() {
     sun *= smoothstep(0.0, 0.1, dot(objectDirection, rayDir));
 
     // no lensflare when too close to the sun
-    sun *= smoothstep(0.08, 0.0, angularRadius);
+    sun *= 1.0 - smoothstep(0.0, 0.08, angularRadius);
 
     col += sun * visibility;
 

--- a/src/shaders/matterjet.glsl
+++ b/src/shaders/matterjet.glsl
@@ -99,7 +99,7 @@ float spiralDensity(vec3 pointOnCone, vec3 coneAxis, float coneMaxHeight) {
     float density = 1.0;
 
     // smoothstep fadeout when the height is too much (outside of cone)
-    density *= smoothstep(1.0, 0.0, heightFraction);
+    density *= 1.0 - smoothstep(0.0, 1.0, heightFraction);
 
     float d = spiralSDF(theta + time, 0.2 + sqrt(heightFraction) / 2.0) / (0.3 + heightFraction * 2.0);
     //d = pow(d, 4.0);

--- a/src/shaders/ringHabitatMaterial/fragment.glsl
+++ b/src/shaders/ringHabitatMaterial/fragment.glsl
@@ -59,12 +59,12 @@ void main() {
     normalW = normalize(TBN * normalColor);
 
     vec3 Lo = vec3(0.0);
-    for(int i = 0; i < nbStars; i++) {
+    for (int i = 0; i < nbStars; i++) {
         vec3 lightDirectionW = normalize(star_positions[i] - vPositionW);
         Lo += calculateLight(albedoColor, normalW, roughnessColor, metallicColor, lightDirectionW, viewDirectionW, star_colors[i]);
     }
 
-    Lo += smoothstep(0.48, 0.5, fract(vUV.x)) * smoothstep(0.52, 0.5, fract(vUV.x)) * smoothstep(0.4, 0.45, fract(vUV.y)) * smoothstep(0.6, 0.55, fract(vUV.y)) * vec3(1.0, 1.0, 0.4);
+    Lo += smoothstep(0.48, 0.5, fract(vUV.x)) * (1.0 - smoothstep(0.5, 0.52, fract(vUV.x))) * smoothstep(0.4, 0.45, fract(vUV.y)) * (1.0 - smoothstep(0.55, 0.6, fract(vUV.y))) * vec3(1.0, 1.0, 0.4);
 
     // occlusion
     //Lo *= mix(1.0, occlusionColor, 0.5);

--- a/src/shaders/telluricPlanetMaterial/fragment.glsl
+++ b/src/shaders/telluricPlanetMaterial/fragment.glsl
@@ -177,13 +177,13 @@ void main() {
     //beachFactor *= 1.0 - steepFactor;
 
     // blend with desert factor when above water
-    desertFactor = smoothstep(0.5, 0.3, moisture01);
+    desertFactor = 1.0 - smoothstep(0.3, 0.5, moisture01);
     desertFactor = smoothSharpener(desertFactor, 2.0);
     plainFactor *= 1.0 - desertFactor;
     beachFactor *= 1.0 - desertFactor;
 
     // blend with snow factor when above water
-    snowFactor = smoothstep(0.0, -2.0, temperature - abs(0.3 * (blendingNormal.z + blendingNormal.x + blendingNormal.y)) * 5.0);
+    snowFactor = 1.0 - smoothstep(-2.0, 0.0, temperature - abs(0.3 * (blendingNormal.z + blendingNormal.x + blendingNormal.y)) * 5.0);
     snowFactor = smoothSharpener(snowFactor, 2.0);
     plainFactor *= 1.0 - snowFactor;
     beachFactor *= 1.0 - snowFactor;

--- a/src/shaders/textures/ringsLUT.glsl
+++ b/src/shaders/textures/ringsLUT.glsl
@@ -35,7 +35,7 @@ void main() {
     float ringDensity = completeNoise(fract(seed) + normalizedDistance * frequency, 5, 2.0, 2.0);
     ringDensity = mix(ringDensity, macroRingDensity, 0.5);
     ringDensity *= smoothstep(ringStart, ringStart + 0.03, normalizedDistance);
-    ringDensity *= smoothstep(ringEnd, ringEnd - 0.03, normalizedDistance);
+    ringDensity *= 1.0 - smoothstep(ringEnd - 0.03, ringEnd, normalizedDistance);
 
     ringDensity *= ringDensity;
 

--- a/src/shaders/volumetricCloudsFragment.glsl
+++ b/src/shaders/volumetricCloudsFragment.glsl
@@ -63,7 +63,7 @@ float densityAtPoint(vec3 densitySamplePoint) {
     float density = cloudNoise * detailNoise;
 
     density *= smoothstep(0.1, 0.3, height01);
-    //density *= smoothstep(0.9, 0.7, height01);
+    //density *= 1.0 - smoothstep(0.7, 0.9, height01);
 
     //density = saturate(density);
 


### PR DESCRIPTION
shader compilation does not allow to use smoothstep with high first and low second.

Fortunately we have the following: smoothstep(high, low) = 1.0 - smoothstep(low, high)