### PR TITLE
Tidal locking & birth years

### DIFF
--- a/src/ts/alphaTestis.ts
+++ b/src/ts/alphaTestis.ts
@@ -83,7 +83,7 @@ const spaceStationModel = newSeededSpaceElevatorModel(0, [sunModel], systemCoord
     physicsViewer.showBody(landingpad.aggregate.body);
 }*/
 
-const moonModel = newSeededTelluricSatelliteModel(23, "Manaleth", [hecateModel]);
+const moonModel = newSeededTelluricSatelliteModel(23, "Manaleth", [hecateModel], [sunModel]);
 moonModel.physics.mass = 2;
 moonModel.physics.siderealDayDuration = 28 * 60 * 60;
 moonModel.physics.minTemperature = -180;

--- a/src/ts/architecture/stellarObject.ts
+++ b/src/ts/architecture/stellarObject.ts
@@ -29,5 +29,11 @@ export interface StellarObject extends CelestialBody {
 export type StellarObjectModel = CelestialBodyModel & {
     physics: StellarObjectPhysicsInfo;
 
+    /**
+     * The birth year of the star system. 0 corresponds to the big bang.
+     * The birth year corresponds to the year when a stellar object was formed in the star system (first fusion for a star, creation of a singularity for a black hole, etc.).
+     */
+    readonly birthYear: number;
+
     type: OrbitalObjectType.STAR | OrbitalObjectType.NEUTRON_STAR | OrbitalObjectType.BLACK_HOLE;
 };

--- a/src/ts/planets/gasPlanet/gasPlanetModel.ts
+++ b/src/ts/planets/gasPlanet/gasPlanetModel.ts
@@ -22,19 +22,21 @@ import { Axis } from "@babylonjs/core/Maths/math.axis";
 import { clamp } from "../../utils/math";
 import { getOrbitalPeriod, getPeriapsis, Orbit } from "../../orbit/orbit";
 import { PlanetaryMassObjectPhysicsInfo } from "../../architecture/physicsInfo";
-import { CelestialBodyModel } from "../../architecture/celestialBody";
 import { newSeededRingsModel } from "../../rings/ringsModel";
 import { GenerationSteps } from "../../utils/generationSteps";
 
 import { getRngFromSeed } from "../../utils/getRngFromSeed";
 import { OrbitalObjectType } from "../../architecture/orbitalObject";
 import { PlanetModel } from "../../architecture/planet";
+import { StellarObjectModel } from "../../architecture/stellarObject";
+import { getCurrentUniverseYear, getTidalLockingTimescale } from "../../utils/physics";
+import { Lerp } from "@babylonjs/core/Maths/math.scalar.functions";
 
 export type GasPlanetModel = PlanetModel & {
     readonly type: OrbitalObjectType.GAS_PLANET;
 };
 
-export function newSeededGasPlanetModel(seed: number, name: string, parentBodies: CelestialBodyModel[]): GasPlanetModel {
+export function newSeededGasPlanetModel(seed: number, name: string, parentBodies: StellarObjectModel[]): GasPlanetModel {
     const rng = getRngFromSeed(seed);
 
     const radius = randRangeInt(Settings.EARTH_RADIUS * 4, Settings.EARTH_RADIUS * 20, rng, GenerationSteps.RADIUS);
@@ -57,11 +59,22 @@ export function newSeededGasPlanetModel(seed: number, name: string, parentBodies
         orientation: Quaternion.RotationAxis(Axis.X, (rng(GenerationSteps.ORBIT + 20 - 0.5) * 0.2))
     };
 
+    //FIXME: when Settings.Earth radius gets to 1:1 scale, change this value by a variable in settings
+    const mass =Settings.JUPITER_MASS * (radius / 69_911e3) ** 3;
+
+    const tidalLockingTimescale = getTidalLockingTimescale(parentMassSum, mass, orbitRadius, radius, 0);
+
+    const parentMaxBirthYear = parentBodies.reduce((max, body) => Math.max(max, body.birthYear), 0);
+    const currentAge = getCurrentUniverseYear() - parentMaxBirthYear;
+
+    const tidalLockingFactor = Math.min(1, currentAge / tidalLockingTimescale);
+
+    const siderealDayDuration = Lerp(60 * 60 * 24, orbit.period, tidalLockingFactor);
+
     const physicalProperties: PlanetaryMassObjectPhysicsInfo = {
-        //FIXME: when Settings.Earth radius gets to 1:1 scale, change this value by a variable in settings
-        mass: Settings.JUPITER_MASS * (radius / 69_911e3) ** 3,
+        mass: mass,
         axialTilt: Quaternion.RotationAxis(Axis.X, normalRandom(0, 0.4, rng, GenerationSteps.AXIAL_TILT)),
-        siderealDayDuration: (24 * 60 * 60) / 10,
+        siderealDayDuration: siderealDayDuration,
         minTemperature: -180,
         maxTemperature: 200,
         pressure: 1

--- a/src/ts/planets/telluricPlanet/telluricPlanetModel.ts
+++ b/src/ts/planets/telluricPlanet/telluricPlanetModel.ts
@@ -17,34 +17,58 @@
 
 import { PlanetModel } from "../../architecture/planet";
 import { OrbitalObjectType } from "../../architecture/orbitalObject";
-import { CelestialBodyModel } from "../../architecture/celestialBody";
 import { getRngFromSeed } from "../../utils/getRngFromSeed";
 import { normalRandom, randRangeInt, uniformRandBool } from "extended-random";
 import { GenerationSteps } from "../../utils/generationSteps";
 import { Settings } from "../../settings";
 import { TelluricPlanetaryMassObjectPhysicsInfo } from "../../architecture/physicsInfo";
-import { hasLiquidWater } from "../../utils/physics";
+import { getCurrentUniverseYear, getTidalLockingTimescale, hasLiquidWater } from "../../utils/physics";
 import { CloudsModel, newCloudsModel } from "../../clouds/cloudsModel";
-import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { Axis } from "@babylonjs/core/Maths/math.axis";
 import { getOrbitalPeriod, Orbit } from "../../orbit/orbit";
 import { clamp } from "terrain-generation";
 import { newSeededRingsModel, RingsModel } from "../../rings/ringsModel";
 import { TelluricPlanetaryMassObjectModel } from "./telluricPlanetaryMassObjectModel";
+import { StellarObjectModel } from "../../architecture/stellarObject";
+import { Lerp } from "@babylonjs/core/Maths/math.scalar.functions";
 
 export type TelluricPlanetModel = PlanetModel &
     TelluricPlanetaryMassObjectModel & {
         readonly type: OrbitalObjectType.TELLURIC_PLANET;
     };
 
-export function newSeededTelluricPlanetModel(seed: number, name: string, parentBodies: CelestialBodyModel[]): TelluricPlanetModel {
+export function newSeededTelluricPlanetModel(seed: number, name: string, parentBodies: StellarObjectModel[]): TelluricPlanetModel {
     const rng = getRngFromSeed(seed);
 
     const radius = Math.max(0.3, normalRandom(1.0, 0.1, rng, GenerationSteps.RADIUS)) * Settings.EARTH_RADIUS;
 
+    const parentMaxBirthYear = parentBodies.reduce((max, body) => Math.max(max, body.birthYear), 0);
+
+    const parentMaxRadius = parentBodies.reduce((max, body) => Math.max(max, body.radius), 0);
+    // Todo: do not hardcode
+    const orbitRadius = 2e9 + rng(GenerationSteps.ORBIT) * 15e9 + parentMaxRadius * 1.5;
+
+    const orbitalP = 2; //clamp(normalRandom(2.0, 0.3, this.rng, GenerationSteps.Orbit + 80), 0.7, 3.0);
+
+    const parentMassSum = parentBodies.reduce((sum, body) => sum + body.physics.mass, 0);
+    const orbit: Orbit = {
+        radius: orbitRadius,
+        p: orbitalP,
+        period: getOrbitalPeriod(orbitRadius, parentMassSum),
+        orientation: Quaternion.RotationAxis(Axis.X, (rng(GenerationSteps.ORBIT + 20) - 0.5) * 0.2)
+    };
+
     //TODO: make mass dependent on more physical properties like density
     const mass = Settings.EARTH_MASS * (radius / 6_371e3) ** 3;
+
+    const tidalLockingTimescale = getTidalLockingTimescale(parentMassSum, mass, orbitRadius, radius, 0);
+
+    const currentAge = getCurrentUniverseYear() - parentMaxBirthYear;
+
+    const tidalLockingFactor = Math.min(1, currentAge / tidalLockingTimescale);
+
+    const siderealDayDuration = Lerp(60 * 60 * 24, orbit.period, tidalLockingFactor);
 
     let pressure = Math.max(normalRandom(0.9, 0.2, rng, GenerationSteps.PRESSURE), 0);
     if (radius <= 0.3 * Settings.EARTH_RADIUS) pressure = 0;
@@ -57,7 +81,7 @@ export function newSeededTelluricPlanetModel(seed: number, name: string, parentB
     const physicalProperties: TelluricPlanetaryMassObjectPhysicsInfo = {
         mass: mass,
         axialTilt: Quaternion.RotationAxis(Axis.X, normalRandom(0, 0.2, rng, GenerationSteps.AXIAL_TILT)),
-        siderealDayDuration: (60 * 60 * 24) / 10,
+        siderealDayDuration: siderealDayDuration,
         minTemperature: minTemperature,
         maxTemperature: maxTemperature,
         pressure: pressure,
@@ -74,20 +98,6 @@ export function newSeededTelluricPlanetModel(seed: number, name: string, parentB
     if (physicalProperties.oceanLevel > 0) {
         clouds = newCloudsModel(radius + physicalProperties.oceanLevel, Settings.CLOUD_LAYER_HEIGHT, physicalProperties.waterAmount, physicalProperties.pressure);
     }
-
-    const parentMaxRadius = parentBodies.reduce((max, body) => Math.max(max, body.radius), 0);
-    // Todo: do not hardcode
-    const orbitRadius = 2e9 + rng(GenerationSteps.ORBIT) * 15e9 + parentMaxRadius * 1.5;
-
-    const orbitalP = 2; //clamp(normalRandom(2.0, 0.3, this.rng, GenerationSteps.Orbit + 80), 0.7, 3.0);
-
-    const parentMassSum = parentBodies.reduce((sum, body) => sum + body.physics.mass, 0);
-    const orbit: Orbit = {
-        radius: orbitRadius,
-        p: orbitalP,
-        period: getOrbitalPeriod(orbitRadius, parentMassSum),
-        orientation: Quaternion.RotationAxis(Axis.X, (rng(GenerationSteps.ORBIT + 20) - 0.5) * 0.2)
-    };
 
     const terrainSettings = {
         continents_frequency: radius / Settings.EARTH_RADIUS,

--- a/src/ts/planets/telluricPlanet/telluricSatelliteModel.ts
+++ b/src/ts/planets/telluricPlanet/telluricSatelliteModel.ts
@@ -23,18 +23,24 @@ import { GenerationSteps } from "../../utils/generationSteps";
 import { Settings } from "../../settings";
 import { TelluricPlanetaryMassObjectPhysicsInfo } from "../../architecture/physicsInfo";
 import { Quaternion } from "@babylonjs/core/Maths/math";
-import { Axis } from "@babylonjs/core/Maths/math.axis";
 import { clamp } from "terrain-generation";
 import { getOrbitalPeriod, getPeriapsis, Orbit } from "../../orbit/orbit";
-import { hasLiquidWater } from "../../utils/physics";
+import { getCurrentUniverseYear, getTidalLockingTimescale, hasLiquidWater } from "../../utils/physics";
 import { CloudsModel, newCloudsModel } from "../../clouds/cloudsModel";
 import { TelluricPlanetaryMassObjectModel } from "./telluricPlanetaryMassObjectModel";
+import { StellarObjectModel } from "../../architecture/stellarObject";
+import { Lerp } from "@babylonjs/core/Maths/math.scalar.functions";
 
 export type TelluricSatelliteModel = TelluricPlanetaryMassObjectModel & {
     readonly type: OrbitalObjectType.TELLURIC_SATELLITE;
 };
 
-export function newSeededTelluricSatelliteModel(seed: number, name: string, parentBodies: CelestialBodyModel[]): TelluricSatelliteModel {
+export function newSeededTelluricSatelliteModel(
+    seed: number,
+    name: string,
+    parentBodies: CelestialBodyModel[],
+    parentStellarObjects: StellarObjectModel[]
+): TelluricSatelliteModel {
     const rng = getRngFromSeed(seed);
 
     const isSatelliteOfTelluric = parentBodies.some((parent) => parent.type === OrbitalObjectType.TELLURIC_PLANET);
@@ -59,35 +65,6 @@ export function newSeededTelluricSatelliteModel(seed: number, name: string, pare
         mass = Settings.EARTH_MASS * (radius / 6_371e3) ** 3;
     }
 
-    let pressure = Math.max(normalRandom(0.9, 0.2, rng, GenerationSteps.PRESSURE), 0);
-    if (isSatelliteOfTelluric || radius <= 0.3 * Settings.EARTH_RADIUS) {
-        pressure = 0;
-    }
-
-    //TODO: use distance to star to determine min temperature when using 1:1 scale
-    const minTemperature = Math.max(-273, normalRandom(-20, 30, rng, 80));
-    // when pressure is close to 1, the max temperature is close to the min temperature (the atmosphere does thermal regulation)
-    const maxTemperature = minTemperature + Math.exp(-pressure) * randRangeInt(30, 200, rng, 81);
-
-    // this average is an approximation of a quaternion average
-    // see https://math.stackexchange.com/questions/61146/averaging-quaternions
-    const parentAverageAxialTilt: Quaternion = parentBodies.reduce((sum, body) => sum.add(body.physics.axialTilt), Quaternion.Zero());
-    parentAverageAxialTilt.scaleInPlace(1 / parentBodies.length);
-    parentAverageAxialTilt.normalize();
-
-    const physicalProperties: TelluricPlanetaryMassObjectPhysicsInfo = {
-        mass: mass,
-        axialTilt: parentAverageAxialTilt,
-        siderealDayDuration: (60 * 60 * 24) / 10,
-        minTemperature: minTemperature,
-        maxTemperature: maxTemperature,
-        pressure: pressure,
-        waterAmount: Math.max(normalRandom(1.0, 0.3, rng, GenerationSteps.WATER_AMOUNT), 0),
-        oceanLevel: 0
-    };
-
-    physicalProperties.oceanLevel = Settings.OCEAN_DEPTH * physicalProperties.waterAmount * physicalProperties.pressure;
-
     // Todo: do not hardcode
     let orbitRadius = 2e9 + rng(GenerationSteps.ORBIT) * 15e9;
 
@@ -99,6 +76,12 @@ export function newSeededTelluricSatelliteModel(seed: number, name: string, pare
     orbitRadius += parentMaxRadius * clamp(normalRandom(10, 4, rng, GenerationSteps.ORBIT), 1, 50);
     orbitRadius += 2.0 * Math.max(0, parentMaxRadius - getPeriapsis(orbitRadius, orbitalP));
 
+    // this average is an approximation of a quaternion average
+    // see https://math.stackexchange.com/questions/61146/averaging-quaternions
+    const parentAverageAxialTilt: Quaternion = parentBodies.reduce((sum, body) => sum.add(body.physics.axialTilt), Quaternion.Zero());
+    parentAverageAxialTilt.scaleInPlace(1 / parentBodies.length);
+    parentAverageAxialTilt.normalize();
+
     const parentMassSum = parentBodies.reduce((sum, body) => sum + body.physics.mass, 0);
     const orbit: Orbit = {
         radius: orbitRadius,
@@ -106,6 +89,38 @@ export function newSeededTelluricSatelliteModel(seed: number, name: string, pare
         period: getOrbitalPeriod(orbitRadius, parentMassSum),
         orientation: parentAverageAxialTilt
     };
+
+    const tidalLockingTimescale = getTidalLockingTimescale(parentMassSum, mass, orbitRadius, radius, 0);
+
+    const parentMaxBirthYear = parentStellarObjects.reduce((max, body) => Math.max(max, body.birthYear), 0);
+    const currentAge = getCurrentUniverseYear() - parentMaxBirthYear;
+
+    const tidalLockingFactor = Math.min(1, currentAge / tidalLockingTimescale);
+
+    const siderealDayDuration = Lerp(60 * 60 * 24, orbit.period, tidalLockingFactor);
+
+    let pressure = Math.max(normalRandom(0.9, 0.2, rng, GenerationSteps.PRESSURE), 0);
+    if (isSatelliteOfTelluric || radius <= 0.3 * Settings.EARTH_RADIUS) {
+        pressure = 0;
+    }
+
+    //TODO: use distance to star to determine min temperature when using 1:1 scale
+    const minTemperature = Math.max(-273, normalRandom(-20, 30, rng, 80));
+    // when pressure is close to 1, the max temperature is close to the min temperature (the atmosphere does thermal regulation)
+    const maxTemperature = minTemperature + Math.exp(-pressure) * randRangeInt(30, 200, rng, 81);
+
+    const physicalProperties: TelluricPlanetaryMassObjectPhysicsInfo = {
+        mass: mass,
+        axialTilt: parentAverageAxialTilt,
+        siderealDayDuration: siderealDayDuration,
+        minTemperature: minTemperature,
+        maxTemperature: maxTemperature,
+        pressure: pressure,
+        waterAmount: Math.max(normalRandom(1.0, 0.3, rng, GenerationSteps.WATER_AMOUNT), 0),
+        oceanLevel: 0
+    };
+
+    physicalProperties.oceanLevel = Settings.OCEAN_DEPTH * physicalProperties.waterAmount * physicalProperties.pressure;
 
     // tidal lock
     physicalProperties.siderealDayDuration = orbit.period;

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -37,6 +37,16 @@ export const Settings = {
      */
     LIGHT_YEAR: 3e8 * 60 * 60 * 24 * 365.25,
 
+    /**
+     * Approximate conversion from Gregorian years to years from the big bang.
+     */
+    GREGORIAN_YEAR_0: 13_800_000_000,
+
+    /**
+     * @see https://en.wikipedia.org/wiki/Stefan%E2%80%93Boltzmann_law
+     */
+    STEFAN_BOLTZMANN_CONSTANT: 5.67e-8,
+
     VERTEX_RESOLUTION: 64,
     MIN_DISTANCE_BETWEEN_VERTICES: 1.5,
 
@@ -98,6 +108,11 @@ export const Settings = {
      * The radius of the sun in meters.
      */
     SOLAR_RADIUS: 696340e3,
+
+    /**
+     * The luminosity of the sun in watts.
+     */
+    SOLAR_LUMINOSITY: 3.828e26,
 
     /**
      * The gravitational acceleration in m/s^2.

--- a/src/ts/starSystem/seededStarSystemModel.ts
+++ b/src/ts/starSystem/seededStarSystemModel.ts
@@ -146,7 +146,7 @@ export function newSeededStarSystemModel(seed: SystemSeed): StarSystemModel {
         for (let j = 0; j < nbMoons; j++) {
             const satelliteName = `${planetarySystemName}${Alphabet[j]}`;
             const satelliteSeed = centeredRand(planetarySystemRng, GenerationSteps.MOONS + j) * Settings.SEED_HALF_RANGE;
-            const satelliteModel = newSeededTelluricSatelliteModel(satelliteSeed, satelliteName, planets);
+            const satelliteModel = newSeededTelluricSatelliteModel(satelliteSeed, satelliteName, planets, stellarObjects);
             satellites.push(satelliteModel);
         }
     });

--- a/src/ts/stellarObjects/blackHole/blackHoleModel.ts
+++ b/src/ts/stellarObjects/blackHole/blackHoleModel.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getOrbitalPeriod, Orbit } from "../../orbit/orbit";
-import { normalRandom } from "extended-random";
+import { normalRandom, randRangeInt, uniformRandBool } from "extended-random";
 import { BlackHolePhysicsInfo } from "../../architecture/physicsInfo";
 import { CelestialBodyModel } from "../../architecture/celestialBody";
 import { StellarObjectModel } from "../../architecture/stellarObject";
@@ -68,9 +68,13 @@ export function newSeededBlackHoleModel(seed: number, name: string, parentBodies
         blackBodyTemperature: 7_000
     };
 
+    // stellar black hole can pretty much have any birth year as they have an almost infinite lifespan
+    const birthYear = randRangeInt(0, Settings.GREGORIAN_YEAR_0, rng, GenerationSteps.BIRTH_YEAR);
+
     return {
         seed,
         name,
+        birthYear,
         rings: null,
         type: OrbitalObjectType.BLACK_HOLE,
         radius,

--- a/src/ts/stellarObjects/neutronStar/neutronStarModel.ts
+++ b/src/ts/stellarObjects/neutronStar/neutronStarModel.ts
@@ -27,6 +27,7 @@ import { GenerationSteps } from "../../utils/generationSteps";
 import { getRngFromSeed } from "../../utils/getRngFromSeed";
 import { OrbitalObjectType } from "../../architecture/orbitalObject";
 import { Quaternion } from "@babylonjs/core/Maths/math";
+import { Settings } from "../../settings";
 
 export type NeutronStarModel = StellarObjectModel & {
     readonly type: OrbitalObjectType.NEUTRON_STAR;
@@ -61,9 +62,13 @@ export function newSeededNeutronStarModel(seed: number, name: string, parentBodi
 
     const rings = uniformRandBool(ringProportion, rng, GenerationSteps.RINGS) ? newSeededRingsModel(rng) : null;
 
+    // neutron stars can pretty much have any birth year as they have a very, very long lifespan
+    const birthYear = randRangeInt(0, Settings.GREGORIAN_YEAR_0, rng, GenerationSteps.BIRTH_YEAR);
+
     return {
         name: name,
         seed: seed,
+        birthYear: birthYear,
         type: OrbitalObjectType.NEUTRON_STAR,
         physics: physicalProperties,
         radius: radius,

--- a/src/ts/stellarObjects/star/starModel.ts
+++ b/src/ts/stellarObjects/star/starModel.ts
@@ -28,6 +28,7 @@ import { GenerationSteps } from "../../utils/generationSteps";
 import { getRngFromSeed } from "../../utils/getRngFromSeed";
 import { OrbitalObjectType } from "../../architecture/orbitalObject";
 import { Quaternion } from "@babylonjs/core/Maths/math";
+import { getBlackBodyLuminosity, getMainSequenceStarLifetime } from "../../utils/physics";
 
 export type StarModel = StellarObjectModel & {
     readonly type: OrbitalObjectType.STAR;
@@ -64,9 +65,17 @@ export function newSeededStarModel(seed: number, name: string, parentBodies: Cel
 
     const rings = uniformRandBool(RING_PROPORTION, rng, GenerationSteps.RINGS) ? newSeededRingsModel(rng) : null;
 
+    const starLuminosity = getBlackBodyLuminosity(physicalProperties.blackBodyTemperature, radius);
+
+    // the lifetime of main sequence stars depends on its mass and luminosity
+    const lifeTime = getMainSequenceStarLifetime(physicalProperties.mass, starLuminosity);
+
+    const birthYear = randRangeInt(Math.max(0, Settings.GREGORIAN_YEAR_0 - lifeTime), Settings.GREGORIAN_YEAR_0, rng, GenerationSteps.BIRTH_YEAR);
+
     return {
         name: name,
         seed: seed,
+        birthYear: birthYear,
         type: OrbitalObjectType.STAR,
         radius: radius,
         orbit: orbit,

--- a/src/ts/utils/generationSteps.ts
+++ b/src/ts/utils/generationSteps.ts
@@ -31,5 +31,7 @@ export const enum GenerationSteps {
 
     PRESSURE = 1800,
     WATER_AMOUNT = 1700,
-    TERRAIN = 1500
+    TERRAIN = 1500,
+
+    BIRTH_YEAR = 2200,
 }

--- a/src/ts/utils/physics.ts
+++ b/src/ts/utils/physics.ts
@@ -16,6 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Settings } from "../settings";
+import { Lerp } from "@babylonjs/core/Maths/math.scalar.functions";
 
 /**
  * Applies Stefan-Boltzmann law to calculate the energy flux of a black body.
@@ -186,7 +187,7 @@ export function getBlackBodyLuminosity(temperature: number, radius: number) {
  * @see https://en.wikipedia.org/wiki/Main_sequence#Lifetime
  */
 export function getMainSequenceStarLifetime(mass: number, luminosity: number) {
-    return (mass / Settings.SOLAR_MASS) * (Settings.SOLAR_LUMINOSITY / luminosity) * 10 ** 10;
+    return (mass / Settings.SOLAR_MASS) * (Settings.SOLAR_LUMINOSITY / luminosity) * 1e10;
 }
 
 /**
@@ -195,4 +196,18 @@ export function getMainSequenceStarLifetime(mass: number, luminosity: number) {
  */
 export function getCurrentUniverseYear(): number {
     return Settings.GREGORIAN_YEAR_0 + new Date().getFullYear();
+}
+
+/**
+ * Returns the timescale for a satellite to become tidally locked to its parent
+ * @param massParent The mass of the parent object in kilograms
+ * @param massSatellite The mass of the satellite in kilograms
+ * @param semiMajorAxis The semi-major axis of the satellite in meters
+ * @param satelliteRadius The radius of the satellite in meters
+ * @param rockyIcy01 A factor to determine if the satellite is rocky or icy (between 0 and 1, 0 for rocky, 1 for icy)
+ * @see https://en.wikipedia.org/wiki/Tidal_locking#Timescale
+ */
+export function getTidalLockingTimescale(massParent: number, massSatellite: number, semiMajorAxis: number, satelliteRadius: number, rockyIcy01: number) {
+    const mu = Lerp(3e10, 4e9, rockyIcy01);
+    return (6e10 * (satelliteRadius * mu * semiMajorAxis ** 6)) / (massSatellite * massParent * massParent);
 }

--- a/src/ts/utils/physics.ts
+++ b/src/ts/utils/physics.ts
@@ -22,7 +22,7 @@ import { Settings } from "../settings";
  * @param temperatureKelvin The temperature of the black body in Kelvin.
  */
 export function getRadiatedEnergyFlux(temperatureKelvin: number) {
-    return 5.67e-8 * temperatureKelvin ** 4;
+    return Settings.STEFAN_BOLTZMANN_CONSTANT * temperatureKelvin ** 4;
 }
 
 /**
@@ -167,4 +167,32 @@ export function getApparentGravityOnSpaceTether(period: number, mass: number, di
 export function getTetherLengthForGravity(period: number, mass: number, gravity: number) {
     const omega = (2 * Math.PI) / period;
     return gravity / (omega * omega);
+}
+
+/**
+ * Returns the luminosity (W) of a black body given its temperature (K) and radius (m)
+ * @param temperature The temperature of the black body in Kelvin
+ * @param radius The radius of the black body in meters
+ * @see https://en.wikipedia.org/wiki/Main_sequence#Parameters
+ */
+export function getBlackBodyLuminosity(temperature: number, radius: number) {
+    return 4 * Math.PI * Settings.STEFAN_BOLTZMANN_CONSTANT * radius * radius * temperature ** 4;
+}
+
+/**
+ * Returns the lifetime (years) of a main sequence star given its mass (kg) and luminosity (W)
+ * @param mass The mass of the star in kilograms
+ * @param luminosity The luminosity of the star in watts
+ * @see https://en.wikipedia.org/wiki/Main_sequence#Lifetime
+ */
+export function getMainSequenceStarLifetime(mass: number, luminosity: number) {
+    return (mass / Settings.SOLAR_MASS) * (Settings.SOLAR_LUMINOSITY / luminosity) * 10 ** 10;
+}
+
+/**
+ * Returns the current year in the universe since the big bang
+ * This is based on the approximation that the year 0 in the Gregorian calendar corresponds to 13.8 billion years after the big bang
+ */
+export function getCurrentUniverseYear(): number {
+    return Settings.GREGORIAN_YEAR_0 + new Date().getFullYear();
 }


### PR DESCRIPTION
By adding a system to assign birth years to stellar objects, it is possible to use a tidal locking model to determine the timescale that will tidal lock an object around its parent.

While it works well, the fact that the universe is not at 1:1 scale at the moment (see #93) makes satellites much closer to their parents than in reality.

As the model is very sensible to this data, it results in every celestial body being tidally locked in the current 1:6 scale simulation.

This will be merged in 2.0 when 1:1 scale becomes possible with WebGPU