### PR TITLE
get rid of setTimeout for notifications

### DIFF
--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -42,7 +42,7 @@ import { updateInputDevices } from "./inputs/devices";
 import { AudioManager } from "./audio/audioManager";
 import { AudioMasks } from "./audio/audioMasks";
 import { GeneralInputs } from "./inputs/generalInputs";
-import { createNotification } from "./utils/notification";
+import { createNotification, updateNotifications } from "./utils/notification";
 import { LoadingScreen } from "./uberCore/loadingScreen";
 import i18n, { initI18n } from "./i18n";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
@@ -284,8 +284,10 @@ export class CosmosJourneyer {
         this.starSystemView.initStarSystem();
 
         this.engine.runRenderLoop(() => {
+            const deltaSeconds = this.engine.getDeltaTime() / 1000;
             updateInputDevices();
-            AudioManager.Update(this.engine.getDeltaTime() / 1000);
+            updateNotifications(deltaSeconds);
+            AudioManager.Update(deltaSeconds);
             Sounds.Update();
 
             if (this.isPaused()) return;


### PR DESCRIPTION
Now notifications are stored in a global array that must be updated every frame

setTimeout was bad because it would not be executed right away as the render loop tends to block it.

This would make notification persist long after their expiration duration