### PR TITLE
Play test feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,19 +139,21 @@ First, clone the repository and install the dependencies with `pnpm install`.
 
 ### Web
 
-To build the web version of Cosmos Journeyer, run `pnpm run build`. Everything will be built in the `dist` folder.
+To build the web version of Cosmos Journeyer, run `pnpm build`. Everything will be built in the `dist` folder.
+
+To start the production server version, run `pnpm serve:prod`. The development version can be started with `pnpm serve`. 
 
 ### Tauri
 
 Cosmos Journeyer can be built as a desktop application using Tauri!
 
-First you will need a bazillion dependencies, here is a list of some of them if you are using a Debian base OS:
+First you will need a bazillion dependencies, here is a list of some of them if you are using a Debian based OS:
 
 ```bash
 sudo apt install -y libwebkit2gtk-4.0-dev libgtk-3-dev libsoup2.4-dev libjavascriptcoregtk-4.0-dev librsvg2-dev libwebkit2gtk-4.0-dev libappindicator3-dev patchelf
 ```
 
-Then you can build the application with `pnpm tauri build`.
+Then you can build the application with `pnpm tauri build` or run it with `pnpm tauri dev`.
 
 ## Contributors
 

--- a/src/locales/en-US/missions/common.json
+++ b/src/locales/en-US/missions/common.json
@@ -1,5 +1,7 @@
 {
-    "travelToTargetSystem": "Travel to {{systemName}} ({{distance}}). Press {{starMapKey}} to open the Star Map.",
+    "travelToTargetSystem": "Travel to {{systemName}} ({{distance}}).",
+    "openStarMap": "Press {{starMapKey}} to open the Star Map.",
+    "travelToNextSystem": "Continue your journey by passing through {{systemName}} ({{distance}}). There are {{nbJumps}} jumps left before reaching your destination.",
     "getCloserToTarget": "Fly closer to {{objectName}}",
     "here": "here",
     "accept": "Accept",

--- a/src/locales/fr-FR/missions/common.json
+++ b/src/locales/fr-FR/missions/common.json
@@ -1,5 +1,7 @@
 {
-    "travelToTargetSystem": "Voyagez jusqu'à {{systemName}} ({{distance}}). Appuyez sur {{starMapKey}} pour ouvrir la carte stellaire.",
+    "travelToTargetSystem": "Voyagez jusqu'à {{systemName}} ({{distance}}).",
+    "openStarMap": "Appuyez sur {{starMapKey}} pour ouvrir la carte stellaire.",
+    "travelToNextSystem": "Poursuivez votre voyage en passant par {{systemName}} ({{distance}}). Il reste {{nbJumps}} sauts avant d'arriver à destination.",
     "getCloserToTarget": "Approchez vous de {{objectName}}",
     "here": "ici",
     "accept": "Accepter",

--- a/src/styles/helmetOverlay/helmetOverlay.scss
+++ b/src/styles/helmetOverlay/helmetOverlay.scss
@@ -44,7 +44,7 @@
     background: url('../asset/shipCursor.webp') no-repeat center;
     background-size: cover;
     pointer-events: none;
-    filter: drop-shadow(0 0 5px white) hue-rotate(-30deg);
+    filter: drop-shadow(0 0 1px black) hue-rotate(-30deg);
   }
 
   #bodyData {

--- a/src/styles/starMapUI.scss
+++ b/src/styles/starMapUI.scss
@@ -1,211 +1,222 @@
 @use "variables";
 
 @keyframes loadingAnimation {
-  0% {
-    background-position: 100% 0;
-  }
-  100% {
-    background-position: 0 0;
-  }
+    0% {
+        background-position: 100% 0;
+    }
+    100% {
+        background-position: 0 0;
+    }
 }
 
 .starMapUI {
-  cursor: none;
-  z-index: 30;
+    cursor: none;
+    z-index: 30;
 
-  .cursor {
-    position: absolute;
-    width: 2vh;
-    height: 2vh;
-    z-index: 31;
-    transform: translate(-50%, -50%);
-    outline: white 0.3vh solid;
-    background: rgba(0, 0, 0, 0.8);
-    border-radius: 50%;
-    pointer-events: none;
-    transform-origin: center;
-    scale: 1;
-    transition: scale variables.$transition-time variables.$bezier-overshoot;
-  }
-
-  .systemIcons {
-    position: absolute;
-    width: 30px;
-
-    display: flex;
-    flex-direction: column;
-
-    row-gap: 10px;
-
-    transform: translateY(-50%) translateX(calc(-100% - 25px));
-
-    &.transparent {
-      opacity: 0;
+    .cursor {
+        position: absolute;
+        width: 2vh;
+        height: 2vh;
+        z-index: 31;
+        transform: translate(-50%, -50%);
+        outline: white 0.3vh solid;
+        background: rgba(0, 0, 0, 0.8);
+        border-radius: 50%;
+        pointer-events: none;
+        transform-origin: center;
+        scale: 1;
+        transition: scale variables.$transition-time variables.$bezier-overshoot;
     }
 
-    .bookmarkIcon {
-      width: 100%;
-      aspect-ratio: 1;
+    .systemIcons {
+        position: absolute;
+        width: 30px;
 
-      background-image: url('../asset/icons/bookmark.webp');
-      background-size: contain;
-    }
+        display: flex;
+        flex-direction: column;
 
-    .missionIcon {
-      width: 100%;
-      aspect-ratio: 1;
+        row-gap: 10px;
 
-      background-image: url('../asset/icons/mission.webp');
-      background-size: contain;
-    }
-  }
+        transform: translateY(-50%) translateX(calc(-100% - 25px));
 
-  .shortHandUI {
-    position: absolute;
-    //background: rgba(0, 0, 0, 0.8);
-    //box-shadow: 0 0 10px rgba(0, 0, 0, 0.5), 0 0 10px rgba(255, 255, 255, 0.5) inset;
-    //backdrop-filter: $backdrop-blur;
-
-    display: flex;
-    row-gap: 1.0vmin;
-    flex-direction: column;
-
-    z-index: 5;
-
-    color: white;
-    font-family: variables.$main-font;
-    padding: 2vmin;
-
-    h2, p {
-      margin-block: 0;
-    }
-
-    h2 {
-      font-size: var(--h2-size);
-    }
-
-    p {
-      font-size: var(--text-size);
-    }
-
-    .buttonContainer {
-      display: flex;
-      column-gap: 0.5vmin;
-    }
-
-    button {
-      background: var(--accent-color);
-      outline: none;
-      border: none;
-      cursor: none;
-      color: white;
-      font-family: variables.$main-font;
-      padding: 1.0vmin;
-      font-size: var(--text-size);
-
-      transition: variables.$transition-time;
-
-      &:hover {
-        background: var(--accent-color-light);
-      }
-
-      &:disabled {
-        background: var(--disabled-color);
-        color: rgb(200, 200, 200);
-
-        &:hover {
-          background: var(--disabled-color);
+        div {
+            transition: 0.2s;
+            &:hover {
+                filter: brightness(1.2);
+            }
         }
 
-        &:active {
-          background: var(--disabled-color);
-        }
-      }
-
-      &:active {
-        background: var(--accent-color-dark);
-      }
-
-      &.bookmarked {
-        background: goldenrod;
-
-        &:active {
-          background: darkgoldenrod;
+        &.transparent {
+            opacity: 0;
         }
 
-        &:hover {
-          background: gold;
+        .bookmarkIcon {
+            width: 100%;
+            aspect-ratio: 1;
+
+            background-image: url("../asset/icons/bookmark.webp");
+            background-size: contain;
         }
-      }
 
-      &.loading {
-        // animate background with linear gradient going from accent color to light accent color to accent color again
-        background: linear-gradient(90deg, var(--accent-color), rgb(200, 200, 200), var(--accent-color)) 0 0 / 200% 100% no-repeat;
-        animation: loadingAnimation 1s infinite linear alternate;
-      }
-    }
-  }
+        .missionIcon {
+            width: 100%;
+            aspect-ratio: 1;
 
-  .starMapInfoPanel {
-    position: absolute;
-    height: 100vh;
-    width: 25vw;
-
-    overflow-y: auto;
-
-    box-shadow: 0 0 20px black;
-    background: rgba(0, 0, 0, 0.8);
-
-    display: flex;
-    flex-direction: column;
-
-    padding: 0 0.7vw;
-
-    color: white;
-    font-family: Nasalization, sans-serif;
-
-    h1, p {
-      margin-block: 0.5vh;
+            background-image: url("../asset/icons/mission.webp");
+            background-size: contain;
+        }
     }
 
-    .starMapInfoPanelStarPreview {
-      width: 15vmin;
-      height: 15vmin;
-      background: white;
-      align-self: center;
-      border-radius: 50%;
-      box-shadow: 0 0 30px white;
-      margin: 3vh 0;
+    .shortHandUI {
+        position: absolute;
+        //background: rgba(0, 0, 0, 0.8);
+        //box-shadow: 0 0 10px rgba(0, 0, 0, 0.5), 0 0 10px rgba(255, 255, 255, 0.5) inset;
+        //backdrop-filter: $backdrop-blur;
+
+        display: flex;
+        row-gap: 1vmin;
+        flex-direction: column;
+
+        z-index: 5;
+
+        color: white;
+        font-family: variables.$main-font;
+        padding: 2vmin;
+
+        h2,
+        p {
+            margin-block: 0;
+        }
+
+        h2 {
+            font-size: var(--h2-size);
+        }
+
+        p {
+            font-size: var(--text-size);
+        }
+
+        .buttonContainer {
+            display: flex;
+            column-gap: 0.5vmin;
+        }
+
+        button {
+            background: var(--accent-color);
+            outline: none;
+            border: none;
+            cursor: none;
+            color: white;
+            font-family: variables.$main-font;
+            padding: 1vmin;
+            font-size: var(--text-size);
+
+            transition: variables.$transition-time;
+
+            &:hover {
+                background: var(--accent-color-light);
+            }
+
+            &:disabled {
+                background: var(--disabled-color);
+                color: rgb(200, 200, 200);
+
+                &:hover {
+                    background: var(--disabled-color);
+                }
+
+                &:active {
+                    background: var(--disabled-color);
+                }
+            }
+
+            &:active {
+                background: var(--accent-color-dark);
+            }
+
+            &.bookmarked {
+                background: goldenrod;
+
+                &:active {
+                    background: darkgoldenrod;
+                }
+
+                &:hover {
+                    background: gold;
+                }
+            }
+
+            &.loading {
+                // animate background with linear gradient going from accent color to light accent color to accent color again
+                background: linear-gradient(90deg, var(--accent-color), rgb(200, 200, 200), var(--accent-color)) 0 0 / 200% 100% no-repeat;
+                animation: loadingAnimation 1s infinite linear alternate;
+            }
+        }
     }
 
-    .starMapInfoPanelTitle {
-      text-align: center;
-      font-size: var(--h1-size);
+    .starMapInfoPanel {
+        position: absolute;
+        height: 100vh;
+        width: 25vw;
+
+        overflow-y: auto;
+
+        box-shadow: 0 0 20px black;
+        background: rgba(0, 0, 0, 0.8);
+
+        display: flex;
+        flex-direction: column;
+
+        padding: 0 0.7vw;
+
+        color: white;
+        font-family: Nasalization, sans-serif;
+
+        z-index: 10;
+
+        h1,
+        p {
+            margin-block: 0.5vh;
+        }
+
+        .starMapInfoPanelStarPreview {
+            width: 15vmin;
+            height: 15vmin;
+            background: white;
+            align-self: center;
+            border-radius: 50%;
+            box-shadow: 0 0 30px white;
+            margin: 3vh 0;
+        }
+
+        .starMapInfoPanelTitle {
+            text-align: center;
+            font-size: var(--h1-size);
+        }
+
+        .starMapInfoPanelStarSector {
+            padding: 0 1vw;
+            font-size: var(--h2-size);
+            text-align: center;
+        }
+
+        h2 {
+            font-size: var(--h2-size);
+        }
+
+        p {
+            font-size: var(--text-size);
+        }
+
+        hr {
+            width: 100%;
+            margin: 1vh auto;
+            border: 0;
+            border-top: 1px solid white;
+        }
     }
 
-    .starMapInfoPanelStarSector {
-      padding: 0 1vw;
-      font-size: var(--h2-size);
-      text-align: center;
+    &.hidden {
+        display: none;
     }
-
-    h2 {
-      font-size: var(--h2-size);
-    }
-
-    p {
-      font-size: var(--text-size);
-    }
-
-    hr {
-      width: 100%;
-      margin: 1vh auto;
-      border: 0;
-      border-top: 1px solid white;
-    }
-  }
-
-  &.hidden {
-    display: none;
-  }
 }

--- a/src/styles/targetCursors.scss
+++ b/src/styles/targetCursors.scss
@@ -8,7 +8,12 @@
   column-gap: max(3vh, 20px);
 
   translate: calc(var(--dim) * -0.5) -50%;
-  pointer-events: none;
+  transition: opacity 0.2s;
+
+  &.transparent {
+    opacity: 0;
+    pointer-events: none;
+  }
 
   .targetCursor {
     --s: max(2.0vmin, calc(var(--dim) * 0.4)); /* the size on the corner */
@@ -41,10 +46,6 @@
     &.target {
       outline-color: goldenrod;
       scale: 1.05;
-    }
-
-    &.transparent {
-      opacity: 0;
     }
   }
 

--- a/src/styles/targetCursors.scss
+++ b/src/styles/targetCursors.scss
@@ -10,6 +10,8 @@
   translate: calc(var(--dim) * -0.5) -50%;
   transition: opacity 0.2s;
 
+  cursor: none;
+
   &.transparent {
     opacity: 0;
     pointer-events: none;

--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -312,6 +312,7 @@ export class CosmosJourneyer {
 
     public pause(): void {
         if (this.isPaused()) return;
+        if (this.mainMenu.isVisible()) return;
         this.state = EngineState.PAUSED;
 
         if (this.activeView === this.starSystemView) this.starSystemView.stopBackgroundSounds();

--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -162,6 +162,13 @@ export class CosmosJourneyer {
         this.mainMenu.onStartObservable.add(async () => {
             await this.tutorialLayer.setTutorial(FlightTutorial);
             this.starSystemView.switchToSpaceshipControls();
+            const spaceshipPosition = this.starSystemView.getSpaceshipControls().getTransform().getAbsolutePosition();
+            const closestSpaceStation = this.starSystemView.getStarSystem().getOrbitalFacilities().reduce((closest, current) => {
+                const currentDistance = Vector3.DistanceSquared(spaceshipPosition, current.getTransform().getAbsolutePosition());
+                const closestDistance = Vector3.DistanceSquared(spaceshipPosition, closest.getTransform().getAbsolutePosition());
+                return currentDistance < closestDistance ? current : closest;
+            });
+            this.starSystemView.setTarget(closestSpaceStation);
             this.createAutoSave();
         });
 

--- a/src/ts/missions/common.ts
+++ b/src/ts/missions/common.ts
@@ -1,0 +1,37 @@
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import i18n from "../i18n";
+import { StarSystemCoordinates, starSystemCoordinatesEquals } from "../utils/coordinates/universeCoordinates";
+import { parseDistance } from "../utils/strings/parseToStrings";
+import { MissionContext } from "./missionContext";
+import { getStarGalacticPosition } from "../utils/coordinates/starSystemCoordinatesUtils";
+import { Settings } from "../settings";
+import { GeneralInputs } from "../inputs/generalInputs";
+import { pressInteractionToStrings } from "../utils/strings/inputControlsString";
+import { getSystemModelFromCoordinates } from "../starSystem/modelFromCoordinates";
+
+export function getGoToSystemInstructions(missionContext: MissionContext, targetSystemCoordinates: StarSystemCoordinates, keyboardLayout: Map<string, string>): string {
+    const currentPlayerDestination = missionContext.currentItinerary.at(-1);
+    const isPlayerGoingToTargetSystem = currentPlayerDestination !== undefined && starSystemCoordinatesEquals(currentPlayerDestination, targetSystemCoordinates);
+
+    const currentSystemPosition = getStarGalacticPosition(missionContext.currentSystem.model.coordinates);
+
+    if (!isPlayerGoingToTargetSystem) {
+        return i18n.t("missions:common:openStarMap", {
+            starMapKey: pressInteractionToStrings(GeneralInputs.map.toggleStarMap, keyboardLayout).join(` ${i18n.t("common:or")} `)
+        });
+    } else {
+        const nextSystemCoordinates = missionContext.currentItinerary[1];
+        const nextSystemModel = nextSystemCoordinates !== undefined ? getSystemModelFromCoordinates(nextSystemCoordinates) : undefined;
+        if (nextSystemModel === undefined) {
+            throw new Error("Next system model in itinerary is undefined and yet the player has an itinerary to the target system?!");
+        }
+
+        const distanceToNextSystem = Vector3.Distance(getStarGalacticPosition(nextSystemModel.coordinates), currentSystemPosition);
+
+        return i18n.t("missions:common:travelToNextSystem", {
+            systemName: nextSystemModel.name,
+            distance: parseDistance(distanceToNextSystem * Settings.LIGHT_YEAR),
+            nbJumps: missionContext.currentItinerary.length - 1
+        });
+    }
+}

--- a/src/ts/missions/missionContext.ts
+++ b/src/ts/missions/missionContext.ts
@@ -18,6 +18,7 @@
 import { StarSystemController } from "../starSystem/starSystemController";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import { StarSystemCoordinates } from "../utils/coordinates/universeCoordinates";
 
 /**
  * Describes information used by mission nodes to update their state
@@ -27,6 +28,10 @@ export type MissionContext = {
      * The current star system the player is in
      */
     currentSystem: StarSystemController;
+    /**
+     * The current itinerary of the player
+     */
+    currentItinerary: StarSystemCoordinates[];
     /**
      * The world position of the player
      */

--- a/src/ts/missions/nodes/actions/sightseeing/missionAsteroidFieldNode.ts
+++ b/src/ts/missions/nodes/actions/sightseeing/missionAsteroidFieldNode.ts
@@ -28,6 +28,7 @@ import { Settings } from "../../../../settings";
 import { pressInteractionToStrings } from "../../../../utils/strings/inputControlsString";
 import { GeneralInputs } from "../../../../inputs/generalInputs";
 import { getSystemModelFromCoordinates } from "../../../../starSystem/modelFromCoordinates";
+import { getGoToSystemInstructions } from "../../../common";
 
 const enum AsteroidFieldMissionState {
     NOT_IN_SYSTEM,
@@ -138,22 +139,11 @@ export class MissionAsteroidFieldNode implements MissionNode {
             return i18n.t("missions:asteroidField:missionCompleted");
         }
 
-        const targetSystemModel = getSystemModelFromCoordinates(this.targetSystemCoordinates);
-        const currentSystemModel = context.currentSystem.model;
-
-        const targetSystemPosition = getStarGalacticPosition(this.targetSystemCoordinates);
-        const currentSystemPosition = getStarGalacticPosition(currentSystemModel.coordinates);
-        const distance = Vector3.Distance(targetSystemPosition, currentSystemPosition);
-
         const targetObject = getObjectModelByUniverseId(this.objectId);
 
         switch (this.state) {
             case AsteroidFieldMissionState.NOT_IN_SYSTEM:
-                return i18n.t("missions:common:travelToTargetSystem", {
-                    systemName: targetSystemModel.name,
-                    distance: parseDistance(distance * Settings.LIGHT_YEAR),
-                    starMapKey: pressInteractionToStrings(GeneralInputs.map.toggleStarMap, keyboardLayout).join(` ${i18n.t("common:or")} `)
-                });
+                return getGoToSystemInstructions(context, this.targetSystemCoordinates, keyboardLayout);
             case AsteroidFieldMissionState.TOO_FAR_IN_SYSTEM:
                 return i18n.t("missions:common:getCloserToTarget", {
                     objectName: targetObject.name

--- a/src/ts/missions/nodes/actions/sightseeing/missionFlyByNode.ts
+++ b/src/ts/missions/nodes/actions/sightseeing/missionFlyByNode.ts
@@ -30,6 +30,7 @@ import { getSystemModelFromCoordinates } from "../../../../starSystem/modelFromC
 
 import { orbitalObjectTypeToDisplay } from "../../../../utils/strings/orbitalObjectTypeToDisplay";
 import { getGoToSystemInstructions } from "../../../common";
+import { OrbitalObjectType } from "../../../../architecture/orbitalObject";
 
 const enum FlyByState {
     NOT_IN_SYSTEM,
@@ -95,7 +96,27 @@ export class MissionFlyByNode implements MissionNode {
 
         const distance = Vector3.Distance(playerPosition, targetObject.getTransform().getAbsolutePosition());
 
-        const distanceThreshold = targetObject.getBoundingRadius() * 3;
+        let thresholdMultiplier = 1;
+        switch (targetObject.model.type) {
+            case OrbitalObjectType.STAR:
+            case OrbitalObjectType.TELLURIC_PLANET:
+            case OrbitalObjectType.TELLURIC_SATELLITE:
+            case OrbitalObjectType.GAS_PLANET:
+            case OrbitalObjectType.MANDELBULB:
+            case OrbitalObjectType.JULIA_SET:
+            case OrbitalObjectType.SPACE_STATION:
+            case OrbitalObjectType.SPACE_ELEVATOR:
+                thresholdMultiplier = 3;
+                break;
+            case OrbitalObjectType.NEUTRON_STAR:
+                thresholdMultiplier = 50;
+                break;
+            case OrbitalObjectType.BLACK_HOLE:
+                thresholdMultiplier = 10;
+                break;
+        }
+
+        const distanceThreshold = targetObject.getBoundingRadius() * thresholdMultiplier;
 
         if (distance < distanceThreshold) {
             this.state = FlyByState.CLOSE_ENOUGH;

--- a/src/ts/missions/nodes/actions/sightseeing/missionFlyByNode.ts
+++ b/src/ts/missions/nodes/actions/sightseeing/missionFlyByNode.ts
@@ -29,6 +29,7 @@ import { GeneralInputs } from "../../../../inputs/generalInputs";
 import { getSystemModelFromCoordinates } from "../../../../starSystem/modelFromCoordinates";
 
 import { orbitalObjectTypeToDisplay } from "../../../../utils/strings/orbitalObjectTypeToDisplay";
+import { getGoToSystemInstructions } from "../../../common";
 
 const enum FlyByState {
     NOT_IN_SYSTEM,
@@ -119,22 +120,11 @@ export class MissionFlyByNode implements MissionNode {
             return i18n.t("missions:flyBy:missionCompleted");
         }
 
-        const targetSystemModel = getSystemModelFromCoordinates(this.targetSystemCoordinates);
-        const currentSystemModel = context.currentSystem.model;
-
-        const targetSystemPosition = getStarGalacticPosition(this.targetSystemCoordinates);
-        const currentSystemPosition = getStarGalacticPosition(currentSystemModel.coordinates);
-        const distance = Vector3.Distance(targetSystemPosition, currentSystemPosition);
-
         const targetObject = getObjectModelByUniverseId(this.objectId);
 
         switch (this.state) {
             case FlyByState.NOT_IN_SYSTEM:
-                return i18n.t("missions:common:travelToTargetSystem", {
-                    systemName: targetSystemModel.name,
-                    distance: parseDistance(distance * Settings.LIGHT_YEAR),
-                    starMapKey: pressInteractionToStrings(GeneralInputs.map.toggleStarMap, keyboardLayout).join(` ${i18n.t("common:or")} `)
-                });
+                return getGoToSystemInstructions(context, this.targetSystemCoordinates, keyboardLayout);
             case FlyByState.TOO_FAR_IN_SYSTEM:
                 return i18n.t("missions:common:getCloserToTarget", {
                     objectName: targetObject.name

--- a/src/ts/missions/nodes/actions/sightseeing/missionTerminatorLandingNode.ts
+++ b/src/ts/missions/nodes/actions/sightseeing/missionTerminatorLandingNode.ts
@@ -28,6 +28,7 @@ import { parseDistance } from "../../../../utils/strings/parseToStrings";
 import { pressInteractionToStrings } from "../../../../utils/strings/inputControlsString";
 import { GeneralInputs } from "../../../../inputs/generalInputs";
 import { getSystemModelFromCoordinates } from "../../../../starSystem/modelFromCoordinates";
+import { getGoToSystemInstructions } from "../../../common";
 
 const enum LandMissionState {
     NOT_IN_SYSTEM,
@@ -150,22 +151,11 @@ export class MissionTerminatorLandingNode implements MissionNode {
             return i18n.t("missions:terminatorLanding:missionCompleted");
         }
 
-        const targetSystemModel = getSystemModelFromCoordinates(this.targetSystemCoordinates);
-        const currentSystemModel = context.currentSystem.model;
-
-        const targetSystemPosition = getStarGalacticPosition(this.targetSystemCoordinates);
-        const currentSystemPosition = getStarGalacticPosition(currentSystemModel.coordinates);
-        const distance = Vector3.Distance(targetSystemPosition, currentSystemPosition);
-
         const targetObject = getObjectModelByUniverseId(this.objectId);
 
         switch (this.state) {
             case LandMissionState.NOT_IN_SYSTEM:
-                return i18n.t("missions:common:travelToTargetSystem", {
-                    systemName: targetSystemModel.name,
-                    distance: parseDistance(distance * Settings.LIGHT_YEAR),
-                    starMapKey: pressInteractionToStrings(GeneralInputs.map.toggleStarMap, keyboardLayout).join(` ${i18n.t("common:or")} `)
-                });
+                return getGoToSystemInstructions(context, this.targetSystemCoordinates, keyboardLayout);
             case LandMissionState.TOO_FAR_IN_SYSTEM:
                 return i18n.t("missions:terminatorLanding:getCloserToTerminator", {
                     objectName: targetObject.name

--- a/src/ts/player/player.ts
+++ b/src/ts/player/player.ts
@@ -146,19 +146,18 @@ export class Player {
      * @param player the player to copy from
      */
     public copyFrom(player: Player) {
-        const playerClone = structuredClone(player);
-        this.uuid = playerClone.uuid;
-        this.name = playerClone.name;
-        this.balance = playerClone.balance;
-        this.creationDate = playerClone.creationDate;
-        this.timePlayedSeconds = playerClone.timePlayedSeconds;
-        this.visitedSystemHistory = playerClone.visitedSystemHistory;
-        this.currentItinerary = playerClone.currentItinerary;
-        this.systemBookmarks = playerClone.systemBookmarks;
-        this.currentMissions = playerClone.currentMissions;
-        this.completedMissions = playerClone.completedMissions;
-        this.serializedSpaceships = playerClone.serializedSpaceships;
-        this.instancedSpaceships = playerClone.instancedSpaceships;
-        this.tutorials = playerClone.tutorials;
+        this.uuid = player.uuid;
+        this.name = player.name;
+        this.balance = player.balance;
+        this.creationDate = new Date(player.creationDate);
+        this.timePlayedSeconds = player.timePlayedSeconds;
+        this.visitedSystemHistory = player.visitedSystemHistory.map((system) => structuredClone(system));
+        this.currentItinerary = player.currentItinerary.map((system) => structuredClone(system));
+        this.systemBookmarks = player.systemBookmarks.map((system) => structuredClone(system));
+        this.currentMissions = [...player.currentMissions];
+        this.completedMissions = [...player.completedMissions];
+        this.serializedSpaceships = player.serializedSpaceships.map((spaceship) => structuredClone(spaceship));
+        this.instancedSpaceships = [...player.instancedSpaceships];
+        this.tutorials = structuredClone(player.tutorials);
     }
 }

--- a/src/ts/player/player.ts
+++ b/src/ts/player/player.ts
@@ -154,8 +154,8 @@ export class Player {
         this.visitedSystemHistory = player.visitedSystemHistory.map((system) => structuredClone(system));
         this.currentItinerary = player.currentItinerary.map((system) => structuredClone(system));
         this.systemBookmarks = player.systemBookmarks.map((system) => structuredClone(system));
-        this.currentMissions = [...player.currentMissions];
-        this.completedMissions = [...player.completedMissions];
+        this.currentMissions = player.currentMissions.map(mission => Mission.Deserialize(mission.serialize()))
+        this.completedMissions = player.completedMissions.map(mission => Mission.Deserialize(mission.serialize()))
         this.serializedSpaceships = player.serializedSpaceships.map((spaceship) => structuredClone(spaceship));
         this.instancedSpaceships = [...player.instancedSpaceships];
         this.tutorials = structuredClone(player.tutorials);

--- a/src/ts/spaceship/shipControls.ts
+++ b/src/ts/spaceship/shipControls.ts
@@ -84,7 +84,7 @@ export class ShipControls implements Controls {
             scene
         );
         this.thirdPersonCamera.parent = this.getTransform();
-        this.thirdPersonCamera.lowerRadiusLimit = 10;
+        this.thirdPersonCamera.lowerRadiusLimit = 1.2 * Math.max(this.spaceship.boundingExtent.x, this.spaceship.boundingExtent.y, this.spaceship.boundingExtent.z) / 2;
         this.thirdPersonCamera.upperRadiusLimit = 500;
 
         this.cameraShakeAnimation = new CameraShakeAnimation(this.thirdPersonCamera, 0.006, 1.0);

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -749,6 +749,9 @@ export class Spaceship implements Transformable {
         AudioManager.DisposeSound(this.deceleratingWarpDriveSound);
         AudioManager.DisposeSound(this.thrusterSound);
 
+        this.mainThrusters.forEach((thruster) => thruster.dispose());
+        this.mainThrusters.length = 0;
+
         this.warpTunnel.dispose();
         this.hyperSpaceTunnel.dispose();
         this.aggregate.dispose();

--- a/src/ts/spaceship/thruster.ts
+++ b/src/ts/spaceship/thruster.ts
@@ -21,6 +21,7 @@ import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { SolidPlume } from "../utils/solidPlume";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import { Materials } from "../assets/materials";
+import { PointLight } from "@babylonjs/core";
 
 export class Thruster {
     protected readonly maxAuthority = 3e3;
@@ -34,6 +35,10 @@ export class Thruster {
     readonly plume: SolidPlume;
 
     readonly parentAggregate: PhysicsAggregate;
+
+    readonly light: PointLight;
+    readonly lightMinIntensity = 10.0;
+    readonly lightMaxIntensity = 100.0;
 
     constructor(mesh: AbstractMesh, direction: Vector3, parentAggregate: PhysicsAggregate) {
         this.mesh = mesh;
@@ -49,6 +54,10 @@ export class Thruster {
 
         this.helperMesh = thrusterHelper;
         this.helperMesh.isVisible = true;
+
+        this.light = new PointLight("thrusterLight", Vector3.Zero(), mesh.getScene());
+        this.light.parent = mesh;
+        this.light.position.addInPlace(direction.scale(1.0));
     }
 
     public setThrottle(throttle: number): void {
@@ -67,10 +76,19 @@ export class Thruster {
         this.plume.update(deltaSeconds);
         this.plume.setThrottle(this.throttle);
 
+        this.light.intensity = this.lightMinIntensity + (this.lightMaxIntensity - this.lightMinIntensity) * this.throttle;
+
         if (this.throttle > 0) {
             this.helperMesh.scaling = new Vector3(0.8, 0.8, 0.8);
         } else {
             this.helperMesh.scaling = new Vector3(0.5, 0.5, 0.5);
         }
+    }
+
+    public dispose() {
+        this.plume.solidParticleSystem.dispose();
+        this.helperMesh.dispose();
+        this.mesh.dispose();
+        this.light.dispose();
     }
 }

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -74,6 +74,9 @@ import { OrbitalFacility } from "../spacestation/orbitalFacility";
 import { getStarGalacticPosition } from "../utils/coordinates/starSystemCoordinatesUtils";
 import { Spaceship } from "../spaceship/spaceship";
 import { Inspector } from '@babylonjs/inspector';
+import { Transformable } from "../architecture/transformable";
+import { HasBoundingSphere } from "../architecture/hasBoundingSphere";
+import { TypedObject } from "../architecture/typedObject";
 
 // register cosmos journeyer as part of window object
 declare global {
@@ -246,19 +249,7 @@ export class StarSystemView implements View {
 
         StarSystemInputs.map.setTarget.on("complete", () => {
             const closestObjectToCenter = this.targetCursorLayer.getClosestToScreenCenterOrbitalObject();
-
-            if (this.targetCursorLayer.getTarget() === closestObjectToCenter) {
-                this.spaceShipLayer.setTarget(null);
-                this.targetCursorLayer.setTarget(null);
-                Sounds.TARGET_UNLOCK_SOUND.play();
-                return;
-            }
-
-            if (closestObjectToCenter === null) return;
-
-            this.spaceShipLayer.setTarget(closestObjectToCenter.getTransform());
-            this.targetCursorLayer.setTarget(closestObjectToCenter);
-            Sounds.TARGET_LOCK_SOUND.play();
+            this.setTarget(closestObjectToCenter);
         });
 
         StarSystemInputs.map.jumpToSystem.on("complete", async () => {
@@ -888,6 +879,21 @@ export class StarSystemView implements View {
 
     public setUIEnabled(enabled: boolean) {
         this.isUiEnabled = enabled;
+    }
+
+    public setTarget(target: Transformable & HasBoundingSphere & TypedObject | null) {
+        if (this.targetCursorLayer.getTarget() === target) {
+            this.spaceShipLayer.setTarget(null);
+            this.targetCursorLayer.setTarget(null);
+            Sounds.TARGET_UNLOCK_SOUND.play();
+            return;
+        }
+
+        if (target === null) return;
+
+        this.spaceShipLayer.setTarget(target.getTransform());
+        this.targetCursorLayer.setTarget(target);
+        Sounds.TARGET_LOCK_SOUND.play();
     }
 
     /**

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -672,6 +672,7 @@ export class StarSystemView implements View {
         // update missions
         const missionContext: MissionContext = {
             currentSystem: starSystem,
+            currentItinerary: this.player.currentItinerary,
             playerPosition: this.scene.getActiveControls().getTransform().getAbsolutePosition(),
             physicsEngine: this.scene.getPhysicsEngine() as PhysicsEngineV2
         };
@@ -716,6 +717,7 @@ export class StarSystemView implements View {
 
         const missionContext: MissionContext = {
             currentSystem: starSystem,
+            currentItinerary: this.player.currentItinerary,
             playerPosition: activeControls.getTransform().getAbsolutePosition(),
             physicsEngine: this.scene.getPhysicsEngine() as PhysicsEngineV2
         };

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -492,7 +492,7 @@ export class StarSystemView implements View {
 
         const activeControls = this.scene.getActiveControls();
         let controllerDistanceFactor = 4;
-        if (firstBody instanceof BlackHole) controllerDistanceFactor = 5;
+        if (firstBody instanceof BlackHole) controllerDistanceFactor = 50;
         else if (firstBody instanceof NeutronStar) controllerDistanceFactor = 100_000;
         if (this.player.visitedSystemHistory.length === 0) {
             positionNearObjectBrightSide(activeControls, firstBody, starSystem, controllerDistanceFactor);

--- a/src/ts/starmap/starMapBookmarkButton.ts
+++ b/src/ts/starmap/starMapBookmarkButton.ts
@@ -39,7 +39,7 @@ export class StarMapBookmarkButton {
 
     setSelectedSystemSeed(starSystemCoordinates: StarSystemCoordinates) {
         this.selectedSystemCoordinates = starSystemCoordinates;
-        this.isSelectedSystemBookmarked = this.player.systemBookmarks.find((bookmark) => !starSystemCoordinatesEquals(bookmark, starSystemCoordinates)) !== undefined;
+        this.isSelectedSystemBookmarked = this.player.systemBookmarks.find((bookmark) => starSystemCoordinatesEquals(bookmark, starSystemCoordinates)) !== undefined;
         this.rootNode.classList.toggle("bookmarked", this.isSelectedSystemBookmarked);
         this.rootNode.textContent = this.isSelectedSystemBookmarked ? i18n.t("starMap:bookmarked") : i18n.t("starMap:bookmark");
     }

--- a/src/ts/starmap/starMapUI.ts
+++ b/src/ts/starmap/starMapUI.ts
@@ -224,7 +224,7 @@ export class StarMapUI {
         this.rebuildSystemIcons();
 
         this.systemIcons.forEach((systemIcons) => {
-            const systemPosition = getStarGalacticPosition(systemIcons.systemCoordinates);
+            const systemPosition = getStarGalacticPosition(systemIcons.getSystemCoordinates());
             const systemUniversePosition = systemPosition.add(centerOfUniversePosition);
             const screenCoordinates = Vector3.Project(systemUniversePosition, Matrix.IdentityReadOnly, camera.getTransformationMatrix(), camera.viewport);
             systemIcons.htmlRoot.classList.toggle("transparent", screenCoordinates.z < 0);
@@ -371,13 +371,13 @@ export class StarMapUI {
         const systemIconsToKeep: SystemIcons[] = [];
 
         this.systemIcons.forEach((systemIcons) => {
-            const system = systemIcons.systemCoordinates;
+            const system = systemIcons.getSystemCoordinates();
             if (!systemsWithIcons.includes(system)) {
                 systemIcons.dispose();
                 return;
             }
 
-            systemIcons.update(SystemIcons.IconMaskForSystem(system, bookmarkedSystems, targetSystems));
+            systemIcons.update(system, SystemIcons.IconMaskForSystem(system, bookmarkedSystems, targetSystems));
 
             systemIconsToKeep.push(systemIcons);
             systemsWithIcons.splice(systemsWithIcons.indexOf(system), 1);
@@ -387,6 +387,10 @@ export class StarMapUI {
 
         systemsWithIcons.forEach((system) => {
             const icon = new SystemIcons(system, SystemIcons.IconMaskForSystem(system, bookmarkedSystems, targetSystems));
+            icon.htmlRoot.addEventListener("click", () => {
+                this.onSystemFocusObservable.notifyObservers(icon.getSystemCoordinates());
+            });
+            
             this.htmlRoot.appendChild(icon.htmlRoot);
             this.systemIcons.push(icon);
         });

--- a/src/ts/starmap/systemIcons.ts
+++ b/src/ts/starmap/systemIcons.ts
@@ -8,14 +8,18 @@ export const enum SystemIconMask {
 export class SystemIcons {
     readonly htmlRoot: HTMLElement;
 
-    readonly systemCoordinates: StarSystemCoordinates;
+    private systemCoordinates: StarSystemCoordinates;
 
     private readonly bookmarkIcon: HTMLElement;
 
     private readonly missionIcon: HTMLElement;
 
+    private iconMask: number;
+
     constructor(starSystemCoordinates: StarSystemCoordinates, iconMask: number) {
         this.systemCoordinates = starSystemCoordinates;
+
+        this.iconMask = iconMask;
 
         this.htmlRoot = document.createElement("div");
         this.htmlRoot.classList.add("systemIcons");
@@ -33,18 +37,32 @@ export class SystemIcons {
         }
     }
 
-    update(iconMask: number): void {
-        if (iconMask & SystemIconMask.BOOKMARK) {
+    update(systemCoordinates: StarSystemCoordinates, iconMask: number): void {
+        this.systemCoordinates = systemCoordinates;
+
+        const doesDisplayBookmark = this.iconMask & SystemIconMask.BOOKMARK;
+        const shouldDisplayBookmark = iconMask & SystemIconMask.BOOKMARK;
+
+        if (shouldDisplayBookmark && !doesDisplayBookmark) {
             this.htmlRoot.appendChild(this.bookmarkIcon);
-        } else {
+        } else if (!shouldDisplayBookmark && doesDisplayBookmark) {
             this.bookmarkIcon.remove();
         }
 
-        if (iconMask & SystemIconMask.MISSION) {
+        const doesDisplayMission = this.iconMask & SystemIconMask.MISSION;
+        const shouldDisplayMission = iconMask & SystemIconMask.MISSION;
+
+        if (shouldDisplayMission && !doesDisplayMission) {
             this.htmlRoot.appendChild(this.missionIcon);
-        } else {
+        } else if (!shouldDisplayMission && doesDisplayMission) {
             this.missionIcon.remove();
         }
+
+        this.iconMask = iconMask;
+    }
+
+    getSystemCoordinates(): StarSystemCoordinates {
+        return this.systemCoordinates;
     }
 
     dispose() {

--- a/src/ts/stellarObjects/blackHole/blackHole.ts
+++ b/src/ts/stellarObjects/blackHole/blackHole.ts
@@ -91,7 +91,7 @@ export class BlackHole implements StellarObject, Cullable {
     }
 
     public getBoundingRadius(): number {
-        return Math.max(this.getRadius(), this.model.physics.accretionDiskRadius);
+        return this.getRadius();
     }
 
     public dispose(): void {

--- a/src/ts/ui/currentMissionDisplay.ts
+++ b/src/ts/ui/currentMissionDisplay.ts
@@ -129,10 +129,19 @@ export class CurrentMissionDisplay {
         if (this.activeMission === null && this.player.currentMissions.length !== 0) {
             this.setMission(this.player.currentMissions[0]);
         } else if (this.activeMission === null && allMissions.length !== 0) {
-            this.setMission(allMissions[0]);
+            const defaultMission = allMissions.at(0);
+            if (defaultMission !== undefined) this.setMission(defaultMission);
+            else this.setNoMissionActive();
         }
 
         if (this.activeMission === null) return;
+
+        if (allMissions.indexOf(this.activeMission) === -1) {
+            const defaultMission = allMissions.at(0);
+            if (defaultMission !== undefined) this.setMission(defaultMission);
+            else this.setNoMissionActive();
+            return;
+        }
 
         this.rootNode.classList.toggle("completed", this.activeMission.tree.isCompleted());
 
@@ -148,7 +157,10 @@ export class CurrentMissionDisplay {
         const allMissions = this.player.completedMissions.concat(this.player.currentMissions);
         const currentMissionIndex = allMissions.indexOf(this.activeMission);
         if (currentMissionIndex === -1) {
-            throw new Error("Could not find current mission in all missions");
+            const defaultMission = allMissions.at(0);
+            if (defaultMission !== undefined) this.setMission(defaultMission);
+            else this.setNoMissionActive();
+            return;
         }
 
         const nextMission = allMissions.at(currentMissionIndex + 1);
@@ -167,7 +179,10 @@ export class CurrentMissionDisplay {
         const allMissions = this.player.completedMissions.concat(this.player.currentMissions);
         const currentMissionIndex = allMissions.indexOf(this.activeMission);
         if (currentMissionIndex === -1) {
-            throw new Error("Could not find current mission in all missions");
+            const defaultMission = allMissions.at(0);
+            if (defaultMission !== undefined) this.setMission(defaultMission);
+            else this.setNoMissionActive();
+            return;
         }
 
         if (currentMissionIndex === 0) return;
@@ -191,9 +206,13 @@ export class CurrentMissionDisplay {
     }
 
     private setNoMissionActive() {
+        this.activeMission = null;
+
         this.missionPanelTitle.innerText = i18n.t("missions:common:noActiveMission");
         this.missionPanelDescription.innerText = i18n.t("missions:common:whereToGetMissions");
         this.missionCounter.innerText = "0/0";
+
+        this.rootNode.classList.remove("completed");
     }
 
     public dispose() {

--- a/src/ts/ui/spaceShipLayer.ts
+++ b/src/ts/ui/spaceShipLayer.ts
@@ -66,7 +66,7 @@ export class SpaceShipLayer {
             const distanceToCenter = Math.sqrt((event.clientX - window.innerWidth / 2) ** 2 + (event.clientY - window.innerHeight / 2) ** 2);
             const normalizedDistance = Math.min(distanceToCenter / Math.min(window.innerWidth, window.innerHeight), 1);
 
-            this.cursor.style.opacity = `${smoothstep(0.1, 0.3, normalizedDistance)}`;
+            this.cursor.style.opacity = `${smoothstep(0.1, 0.2, normalizedDistance)}`;
         });
     }
 

--- a/src/ts/utils/notification.ts
+++ b/src/ts/utils/notification.ts
@@ -106,7 +106,7 @@ export function createNotification(text: string, durationMillis: number) {
 export function warnIfUndefined<T>(value: T | undefined, defaultValue: T, message: string): T {
     if (value === undefined) {
         console.warn(message);
-        createNotification(message, 60_000);
+        createNotification(message, 10_000);
         return defaultValue;
     }
     return value;

--- a/src/ts/utils/systemTarget.ts
+++ b/src/ts/utils/systemTarget.ts
@@ -4,6 +4,7 @@ import i18n from "../i18n";
 import { StarSystemCoordinates } from "./coordinates/universeCoordinates";
 import { getSystemModelFromCoordinates } from "../starSystem/modelFromCoordinates";
 import { ObjectTargetCursorType, Targetable } from "../architecture/targetable";
+import { Settings } from "../settings";
 
 export class SystemTarget implements Targetable {
     readonly name: string;
@@ -13,8 +14,8 @@ export class SystemTarget implements Targetable {
 
     readonly targetInfo = {
         type: ObjectTargetCursorType.STAR_SYSTEM,
-        minDistance: 0,
-        maxDistance: 0
+        minDistance: Settings.LIGHT_YEAR * 2,
+        maxDistance: Settings.LIGHT_YEAR * 0.2,
     };
 
     constructor(systemCoordinates: StarSystemCoordinates, scene: Scene) {


### PR DESCRIPTION
This PR implements the low hanging fruits of recent playtest feedback.

- better missions messages by displaying the number of jumps left to the destination
- automatically target the closest space station when creating a new game
- add back lights to spaceship to be able to see it in the dark
- make spaceship cursor more visible when the background is bright (e.g close to a star)
- hide most of neighbor star system cursors to avoid visual noise. They will still be displayed when targeted from the starmap
- Make missions and bookmark icons clickable in the starmap to ease the navigation
- add instructions for local hosting 
- fix shallow copies when loading a save
- fix camera clipping in spaceship
- fix spawn distance and fly by distance for black holes and neutron stars