### PR TITLE
Prevent pause menu from being displayed on top of main menu

### DIFF
--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -228,11 +228,11 @@ export class CosmosJourneyer {
         });
 
         window.addEventListener("blur", () => {
-            if (!this.mainMenu?.isVisible()) this.pause();
+            if (!this.mainMenu?.isVisible() && !this.starSystemView.isLoadingSystem()) this.pause();
         });
 
         window.addEventListener("mouseleave", () => {
-            if (!this.mainMenu?.isVisible()) this.pause();
+            if (!this.mainMenu?.isVisible() && !this.starSystemView.isLoadingSystem()) this.pause();
         });
 
         window.addEventListener("resize", () => {

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -193,7 +193,7 @@ export class StarSystemView implements View {
      * Whether the star system is currently loading or not
      * @private
      */
-    private isLoadingSystem = false;
+    private _isLoadingSystem = false;
 
     readonly postProcessManager: PostProcessManager;
 
@@ -434,10 +434,10 @@ export class StarSystemView implements View {
      * @param starSystemModel
      */
     public async loadStarSystem(starSystemModel: StarSystemModel) {
-        if (this.isLoadingSystem) {
+        if (this._isLoadingSystem) {
             throw new Error("Cannot load a new star system while the current one is loading");
         }
-        this.isLoadingSystem = true;
+        this._isLoadingSystem = true;
 
         if (this.starSystem !== null) {
             this.spaceshipControls?.setClosestLandableFacility(null);
@@ -546,7 +546,7 @@ export class StarSystemView implements View {
         this.onInitStarSystem.notifyObservers();
         this.scene.getEngine().loadingScreen.hideLoadingUI();
 
-        this.isLoadingSystem = false;
+        this._isLoadingSystem = false;
     }
 
     /**
@@ -600,12 +600,16 @@ export class StarSystemView implements View {
         return this.jumpLock;
     }
 
+    public isLoadingSystem() {
+        return this._isLoadingSystem;
+    }
+
     /**
      * Updates the system view. It updates the underlying star system, the UI, the chunk forge and the controls
      * @param deltaSeconds the time elapsed since the last update in seconds
      */
     public updateBeforePhysics(deltaSeconds: number) {
-        if (this.isLoadingSystem) return;
+        if (this._isLoadingSystem) return;
 
         const starSystem = this.getStarSystem();
 
@@ -615,7 +619,7 @@ export class StarSystemView implements View {
     }
 
     public updateBeforeRender(deltaSeconds: number) {
-        if (this.isLoadingSystem) return;
+        if (this._isLoadingSystem) return;
 
         const starSystem = this.getStarSystem();
         if (this.spaceshipControls === null) throw new Error("Spaceship controls is null");
@@ -692,7 +696,7 @@ export class StarSystemView implements View {
     }
 
     public updateAfterRender() {
-        if (this.isLoadingSystem) return;
+        if (this._isLoadingSystem) return;
 
         const starSystem = this.getStarSystem();
         if (this.spaceshipControls === null) throw new Error("Spaceship controls is null");


### PR DESCRIPTION
Sometimes, unfocusing the game window while loading would result in the pause menu being displayed on top of the main menu. This is really first-experience breaking so this PR fixes that with an additional check before generating the pause menu.