### PR TITLE
Overhaul local save system

### DIFF
--- a/src/locales/en-US/notifications.json
+++ b/src/locales/en-US/notifications.json
@@ -9,5 +9,6 @@
     "notEnoughFuel": "Cannot perform the hyperspace jump. Not enough fuel! You can refuel at a station or scooping around a star or gas giant.",
     "saveVersionMismatch": "[VERSION_WARNING] The save file version ({{saveVersion}}) does not match the current version ({{currentVersion}}). Loading may result in unexpected behavior.",
     "invalidSaveFileJson": "[JSON_ERROR] The save file is invalid: {{error}}. Fix the file before trying to load it again.",
-    "saveOk": "Saved to local storage successfully"
+    "saveOk": "Saved to local storage successfully",
+    "cantSaveTutorial": "Cannot save during a tutorial"
 }

--- a/src/locales/fr-FR/notifications.json
+++ b/src/locales/fr-FR/notifications.json
@@ -9,5 +9,6 @@
     "notEnoughFuel": "Saut hyperspatial impossible. Carburant insuffisant! Le carburant peut être acheté en station ou récolté autour d'une étoile ou d'une géante gazeuse.",
     "saveVersionMismatch": "[VERSION_WARNING] La version du fichier de sauvegarde ({{saveVersion}}) ne correspond pas à la version actuelle ({{currentVersion}}). Le chargement peut entraîner un comportement inattendu.",
     "invalidSaveFileJson": "[JSON_ERROR] Le fichier de sauvegarde est invalide: {{error}}. Réparez le fichier avant de réessayer de le charger.",
-    "saveOk": "Sauvegardé avec succès dans le stockage local."
+    "saveOk": "Sauvegardé avec succès dans le stockage local.",
+    "cantSaveTutorial": "Impossible de sauvegarder pendant un tutoriel."
 }

--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -31,7 +31,7 @@ import { PauseMenu } from "./ui/pauseMenu";
 import { StarSystemView } from "./starSystem/starSystemView";
 import { EngineFactory } from "@babylonjs/core/Engines/engineFactory";
 import { MainMenu } from "./ui/mainMenu";
-import { LocalStorageSaves, SaveFileData } from "./saveFile/saveFileData";
+import { getSavesFromLocalStorage, SaveFileData, writeSavesToLocalStorage } from "./saveFile/saveFileData";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { setRotationQuaternion } from "./uberCore/transforms/basicTransform";
@@ -497,14 +497,12 @@ export class CosmosJourneyer {
         // use player uuid as key to avoid overwriting other cmdr's save
         const uuid = saveData.player.uuid;
 
-        const localStorageKey = Settings.SAVES_KEY;
-
         // store in a hashmap in local storage
-        const saves: LocalStorageSaves = JSON.parse(localStorage.getItem(localStorageKey) || "{}");
+        const saves = getSavesFromLocalStorage();
         saves[uuid] = saves[uuid] || { manual: [], auto: [] };
         saves[uuid].manual.unshift(saveData);
 
-        localStorage.setItem(localStorageKey, JSON.stringify(saves));
+        writeSavesToLocalStorage(saves);
 
         return true;
     }
@@ -527,16 +525,14 @@ export class CosmosJourneyer {
         if (uuid === Settings.SHARED_POSITION_SAVE_UUID) return; // don't autosave shared position
         if (uuid === Settings.TUTORIAL_SAVE_UUID) return; // don't autosave in tutorial
 
-        const localStorageKey = Settings.SAVES_KEY;
-
         // store in a hashmap in local storage
-        const saves: LocalStorageSaves = JSON.parse(localStorage.getItem(localStorageKey) || "{}");
+        const saves = getSavesFromLocalStorage();
         saves[uuid] = saves[uuid] || { manual: [], auto: [] };
         saves[uuid].auto.unshift(saveData); // enqueue the new autosave
         while (saves[uuid].auto.length > Settings.MAX_AUTO_SAVES) {
             saves[uuid].auto.pop(); // dequeue the oldest autosave
         }
-        localStorage.setItem(localStorageKey, JSON.stringify(saves));
+        writeSavesToLocalStorage(saves);
 
         this.autoSaveTimerSeconds = 0;
     }

--- a/src/ts/cosmosJourneyer.ts
+++ b/src/ts/cosmosJourneyer.ts
@@ -31,7 +31,7 @@ import { PauseMenu } from "./ui/pauseMenu";
 import { StarSystemView } from "./starSystem/starSystemView";
 import { EngineFactory } from "@babylonjs/core/Engines/engineFactory";
 import { MainMenu } from "./ui/mainMenu";
-import { LocalStorageAutoSaves, LocalStorageManualSaves, SaveFileData } from "./saveFile/saveFileData";
+import { LocalStorageSaves, SaveFileData } from "./saveFile/saveFileData";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { setRotationQuaternion } from "./uberCore/transforms/basicTransform";
@@ -497,14 +497,14 @@ export class CosmosJourneyer {
         // use player uuid as key to avoid overwriting other cmdr's save
         const uuid = saveData.player.uuid;
 
-        const localStorageKey = Settings.MANUAL_SAVE_KEY;
+        const localStorageKey = Settings.SAVES_KEY;
 
         // store in a hashmap in local storage
-        const manualSaves: LocalStorageManualSaves = JSON.parse(localStorage.getItem(localStorageKey) || "{}");
-        manualSaves[uuid] = manualSaves[uuid] || [];
-        manualSaves[uuid].unshift(saveData);
+        const saves: LocalStorageSaves = JSON.parse(localStorage.getItem(localStorageKey) || "{}");
+        saves[uuid] = saves[uuid] || { manual: [], auto: [] };
+        saves[uuid].manual.unshift(saveData);
 
-        localStorage.setItem(localStorageKey, JSON.stringify(manualSaves));
+        localStorage.setItem(localStorageKey, JSON.stringify(saves));
 
         return true;
     }
@@ -527,16 +527,16 @@ export class CosmosJourneyer {
         if (uuid === Settings.SHARED_POSITION_SAVE_UUID) return; // don't autosave shared position
         if (uuid === Settings.TUTORIAL_SAVE_UUID) return; // don't autosave in tutorial
 
-        const localStorageKey = Settings.AUTO_SAVE_KEY;
+        const localStorageKey = Settings.SAVES_KEY;
 
         // store in a hashmap in local storage
-        const autosaves: LocalStorageAutoSaves = JSON.parse(localStorage.getItem(localStorageKey) || "{}");
-        autosaves[uuid] = autosaves[uuid] || [];
-        autosaves[uuid].unshift(saveData); // enqueue the new autosave
-        while (autosaves[uuid].length > Settings.MAX_AUTO_SAVES) {
-            autosaves[uuid].pop(); // dequeue the oldest autosave
+        const saves: LocalStorageSaves = JSON.parse(localStorage.getItem(localStorageKey) || "{}");
+        saves[uuid] = saves[uuid] || { manual: [], auto: [] };
+        saves[uuid].auto.unshift(saveData); // enqueue the new autosave
+        while (saves[uuid].auto.length > Settings.MAX_AUTO_SAVES) {
+            saves[uuid].auto.pop(); // dequeue the oldest autosave
         }
-        localStorage.setItem(localStorageKey, JSON.stringify(autosaves));
+        localStorage.setItem(localStorageKey, JSON.stringify(saves));
 
         this.autoSaveTimerSeconds = 0;
     }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -33,9 +33,10 @@ const saveString = urlParams.get("save");
 
 if (universeCoordinatesString !== null) {
     engine.player.copyFrom(Player.Default());
-    engine.player.name = Settings.SHARED_POSITION_SAVE_UUID;
+    engine.player.uuid = Settings.SHARED_POSITION_SAVE_UUID;
     const jsonString = decodeBase64(universeCoordinatesString);
-    engine.loadUniverseCoordinates(JSON.parse(jsonString));
+    await engine.loadUniverseCoordinates(JSON.parse(jsonString));
+    engine.starSystemView.setUIEnabled(true);
 } else if (saveString !== null) {
     const jsonString = decodeBase64(saveString);
     const result = parseSaveFileData(jsonString);
@@ -44,7 +45,8 @@ if (universeCoordinatesString !== null) {
         console.warn(log);
     });
     if (result.data !== null) {
-        engine.loadSave(result.data);
+        await engine.loadSave(result.data);
+        engine.starSystemView.setUIEnabled(true);
     } else {
         await alertModal("Error, this save file is invalid. See the console for more details.");
     }

--- a/src/ts/player/player.ts
+++ b/src/ts/player/player.ts
@@ -2,6 +2,7 @@ import { Mission, MissionSerialized } from "../missions/mission";
 import { StarSystemCoordinates } from "../utils/coordinates/universeCoordinates";
 import { warnIfUndefined } from "../utils/notification";
 import { DefaultSerializedSpaceship, SerializedSpaceship, Spaceship } from "../spaceship/spaceship";
+import { Observable } from "@babylonjs/core/Misc/observable";
 
 export type CompletedTutorials = {
     stationLandingCompleted: boolean;
@@ -34,7 +35,7 @@ export type SerializedPlayer = {
 
 export class Player {
     uuid: string;
-    name: string;
+    private name: string;
     balance: number;
     creationDate: Date;
     timePlayedSeconds: number;
@@ -54,6 +55,8 @@ export class Player {
 
     static DEFAULT_NAME = "Python";
     static DEFAULT_BALANCE = 10_000;
+
+    readonly onNameChangedObservable = new Observable<string>();
 
     private constructor(serializedPlayer: SerializedPlayer) {
         this.uuid = warnIfUndefined(serializedPlayer.uuid, crypto.randomUUID(), `[PLAYER_DATA_WARNING] Uuid was undefined. Defaulting to random UUID`);
@@ -159,5 +162,14 @@ export class Player {
         this.serializedSpaceships = player.serializedSpaceships.map((spaceship) => structuredClone(spaceship));
         this.instancedSpaceships = [...player.instancedSpaceships];
         this.tutorials = structuredClone(player.tutorials);
+    }
+
+    public setName(name: string) {
+        this.name = name;
+        this.onNameChangedObservable.notifyObservers(name);
+    }
+
+    public getName(): string {
+        return this.name;
     }
 }

--- a/src/ts/saveFile/saveFileData.ts
+++ b/src/ts/saveFile/saveFileData.ts
@@ -71,13 +71,17 @@ export function createUrlFromSave(data: SaveFileData): URL {
 }
 
 /**
- * Describes the structure of the local storage manual saves object.
- * Each cmdr has a unique key and the value is an array of save file data.
+ * Describes the structure of the local storage saves object.
  */
-export type LocalStorageManualSaves = { [key: string]: SaveFileData[] };
-
-/**
- * Describes the structure of the local storage auto saves object.
- * Each cmdr has a unique key and the value is a save file data. Auto saves are overwritten on each auto save.
- */
-export type LocalStorageAutoSaves = { [key: string]: SaveFileData[] };
+export type LocalStorageSaves = {
+    [uuid: string]: {
+        /**
+         * The manual saves of the cmdr.
+         */
+        manual: SaveFileData[];
+        /**
+         * The auto saves of the cmdr.
+         */
+        auto: SaveFileData[];
+    };
+};

--- a/src/ts/saveFile/saveFileData.ts
+++ b/src/ts/saveFile/saveFileData.ts
@@ -4,6 +4,7 @@ import i18n from "../i18n";
 
 import { SerializedPlayer } from "../player/player";
 import { encodeBase64 } from "../utils/base64";
+import { Settings } from "../settings";
 
 /**
  * Data structure for the save file to allow restoring current star system and position.
@@ -85,3 +86,11 @@ export type LocalStorageSaves = {
         auto: SaveFileData[];
     };
 };
+
+export function getSavesFromLocalStorage(): LocalStorageSaves {
+    return JSON.parse(localStorage.getItem(Settings.SAVES_KEY) ?? "{}");
+}
+
+export function writeSavesToLocalStorage(saves: LocalStorageSaves): void {
+    localStorage.setItem(Settings.SAVES_KEY, JSON.stringify(saves));
+}

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -117,9 +117,7 @@ export const Settings = {
 
     MAIN_FONT: "Nasalization",
 
-    MANUAL_SAVE_KEY: "saves",
-
-    AUTO_SAVE_KEY: "autosaves",
+    SAVES_KEY: "saves",
 
     MAX_AUTO_SAVES: 5,
 

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -123,7 +123,9 @@ export const Settings = {
 
     MAX_AUTO_SAVES: 5,
 
-    SHARED_POSITION_SAVE_UUID: "sharedPositionSave"
+    SHARED_POSITION_SAVE_UUID: "sharedPositionSave",
+
+    TUTORIAL_SAVE_UUID: "tutorialSave"
 };
 
 export const CollisionMask = {

--- a/src/ts/ui/saveLoadingPanelContent.ts
+++ b/src/ts/ui/saveLoadingPanelContent.ts
@@ -323,12 +323,17 @@ export class SaveLoadingPanelContent {
 
             if (isAutoSave) {
                 autoSavesDict[save.player.uuid] = autoSavesDict[save.player.uuid].filter((autoSave) => autoSave.timestamp !== save.timestamp);
+                if (autoSavesDict[save.player.uuid].length === 0) {
+                    delete autoSavesDict[save.player.uuid];
+                }
             } else {
                 manualSavesDict[save.player.uuid] = manualSavesDict[save.player.uuid].filter((manualSave) => manualSave.timestamp !== save.timestamp);
+                if (manualSavesDict[save.player.uuid].length === 0) {
+                    delete manualSavesDict[save.player.uuid];
+                }
             }
 
-            if (autoSavesDict[save.player.uuid] === undefined && (manualSavesDict[save.player.uuid] ?? []).length === 0) {
-                delete manualSavesDict[save.player.uuid];
+            if (autoSavesDict[save.player.uuid] === undefined && manualSavesDict[save.player.uuid] === undefined) {
                 saveDiv.parentElement?.parentElement?.remove();
             }
 

--- a/src/ts/ui/saveLoadingPanelContent.ts
+++ b/src/ts/ui/saveLoadingPanelContent.ts
@@ -94,6 +94,12 @@ export class SaveLoadingPanelContent {
         const autoSavesDict: LocalStorageAutoSaves = JSON.parse(localStorage.getItem(Settings.AUTO_SAVE_KEY) ?? "{}");
         const manualSavesDict: LocalStorageManualSaves = JSON.parse(localStorage.getItem(Settings.MANUAL_SAVE_KEY) ?? "{}");
 
+        // concatenate all saves and sort them by timestamp for each cmdr
+        const allSavesDict: { [key: string]: SaveFileData[] } = { ...autoSavesDict, ...manualSavesDict };
+        for (const cmdrUuid in allSavesDict) {
+            allSavesDict[cmdrUuid].sort((a, b) => b.timestamp - a.timestamp);
+        }
+
         // Get all cmdr UUIDs (union of auto saves and manual saves)
         const cmdrUuids = Object.keys(autoSavesDict);
         Object.keys(manualSavesDict).forEach((cmdrUuid) => {
@@ -102,8 +108,8 @@ export class SaveLoadingPanelContent {
 
         // Sort cmdr UUIDs by latest save timestamp to have the most recent save at the top
         cmdrUuids.sort((a, b) => {
-            const aLatestSave = autoSavesDict[a][0] ?? manualSavesDict[a][0];
-            const bLatestSave = autoSavesDict[b][0] ?? manualSavesDict[b][0];
+            const aLatestSave = allSavesDict[a][0];
+            const bLatestSave = allSavesDict[b][0];
             return bLatestSave.timestamp - aLatestSave.timestamp;
         });
 
@@ -116,7 +122,10 @@ export class SaveLoadingPanelContent {
 
             const manualSaves = manualSavesDict[cmdrUuid] ?? [];
 
-            const latestSave = autoSaves[0] ?? manualSaves[0];
+            const allSaves = autoSaves.concat(manualSaves);
+            allSaves.sort((a, b) => b.timestamp - a.timestamp);
+
+            const latestSave = allSaves[0];
 
             const cmdrHeader = document.createElement("div");
             cmdrHeader.classList.add("cmdrHeader");
@@ -205,9 +214,6 @@ export class SaveLoadingPanelContent {
             savesList.classList.add("savesList");
             savesList.classList.add("hidden"); // Hidden by default
             cmdrDiv.appendChild(savesList);
-
-            const allSaves = autoSaves.concat(manualSaves);
-            allSaves.sort((a, b) => b.timestamp - a.timestamp);
 
             allSaves.forEach((save) => {
                 const saveDiv = this.createSaveDiv(save, autoSaves.includes(save));

--- a/src/ts/ui/saveLoadingPanelContent.ts
+++ b/src/ts/ui/saveLoadingPanelContent.ts
@@ -322,7 +322,7 @@ export class SaveLoadingPanelContent {
             const manualSavesDict: LocalStorageManualSaves = JSON.parse(localStorage.getItem(Settings.MANUAL_SAVE_KEY) ?? "{}");
 
             if (isAutoSave) {
-                delete autoSavesDict[save.player.uuid];
+                autoSavesDict[save.player.uuid] = autoSavesDict[save.player.uuid].filter((autoSave) => autoSave.timestamp !== save.timestamp);
             } else {
                 manualSavesDict[save.player.uuid] = manualSavesDict[save.player.uuid].filter((manualSave) => manualSave.timestamp !== save.timestamp);
             }

--- a/src/ts/ui/saveLoadingPanelContent.ts
+++ b/src/ts/ui/saveLoadingPanelContent.ts
@@ -1,8 +1,7 @@
 import { Observable } from "@babylonjs/core/Misc/observable";
 import i18n from "../i18n";
-import { createUrlFromSave, LocalStorageSaves, parseSaveFileData, SaveFileData } from "../saveFile/saveFileData";
+import { createUrlFromSave, getSavesFromLocalStorage, parseSaveFileData, SaveFileData, writeSavesToLocalStorage } from "../saveFile/saveFileData";
 import { createNotification } from "../utils/notification";
-import { Settings } from "../settings";
 import { Sounds } from "../assets/sounds";
 import expandIconPath from "../../asset/icons/expand.webp";
 import collapseIconPath from "../../asset/icons/collapse.webp";
@@ -90,7 +89,7 @@ export class SaveLoadingPanelContent {
     populateCmdrList() {
         this.cmdrList.innerHTML = "";
 
-        const saves: LocalStorageSaves = JSON.parse(localStorage.getItem(Settings.SAVES_KEY) ?? "{}");
+        const saves = getSavesFromLocalStorage();
 
         const flatSortedSaves: Map<string, SaveFileData[]> = new Map();
         for (const uuid in saves) {
@@ -200,7 +199,7 @@ export class SaveLoadingPanelContent {
 
                 cmdrName.innerText = newName;
 
-                localStorage.setItem(Settings.SAVES_KEY, JSON.stringify(saves));
+                writeSavesToLocalStorage(saves);
             });
             cmdrHeaderButtons.appendChild(editNameButton);
 
@@ -317,7 +316,7 @@ export class SaveLoadingPanelContent {
             const shouldProceed = await promptModalBoolean(i18n.t("sidePanel:deleteSavePrompt"));
             if (!shouldProceed) return;
 
-            const saves: LocalStorageSaves = JSON.parse(localStorage.getItem(Settings.SAVES_KEY) ?? "{}");
+            const saves = getSavesFromLocalStorage();
 
             if (isAutoSave) {
                 saves[save.player.uuid].auto = saves[save.player.uuid].auto.filter((autoSave) => autoSave.timestamp !== save.timestamp);
@@ -332,7 +331,7 @@ export class SaveLoadingPanelContent {
 
             saveDiv.remove();
 
-            localStorage.setItem(Settings.SAVES_KEY, JSON.stringify(saves));
+            writeSavesToLocalStorage(saves);
         });
         saveButtons.appendChild(deleteButton);
 

--- a/src/ts/ui/spaceStation/spaceStationLayer.ts
+++ b/src/ts/ui/spaceStation/spaceStationLayer.ts
@@ -77,9 +77,9 @@ export class SpaceStationLayer {
         this.editPlayerNameButton = document.querySelector<HTMLElement>("#spaceStationUI .playerName button") as HTMLElement;
         this.editPlayerNameButton.addEventListener("click", async () => {
             Sounds.MENU_SELECT_SOUND.play();
-            const newName = await promptModalString(i18n.t("spaceStation:cmdrNameChangePrompt"), player.name);
+            const newName = await promptModalString(i18n.t("spaceStation:cmdrNameChangePrompt"), player.getName());
             if (newName === null) return;
-            player.name = newName;
+            player.setName(newName);
             this.updatePlayerName();
         });
 
@@ -177,7 +177,7 @@ export class SpaceStationLayer {
     }
 
     private updatePlayerName() {
-        this.playerName.textContent = `CMDR ${this.player.name}`;
+        this.playerName.textContent = `CMDR ${this.player.getName()}`;
     }
 
     private updatePlayerBalance() {


### PR DESCRIPTION
- prevent saves to be created during tutorials (Closes #204) 
- renaming the player will also change all previous saves for consistency
- saves are now stored in a single local storage key
- reading from and writing to local storage is much safer now
- player will be prompted for a cmdr name when performing a manual save on a shared position game state. It will then be treated like anyother save 