### PR TITLE
Add defaultThrottle and set it in enable method

### DIFF
--- a/src/ts/spaceship/warpDrive.ts
+++ b/src/ts/spaceship/warpDrive.ts
@@ -74,6 +74,11 @@ export interface ReadonlyWarpDrive {
 
 export class WarpDrive implements ReadonlyWarpDrive {
     /**
+     * The default throttle value for the warp drive.
+     */
+    public readonly defaultThrottle: number = 0.5;
+
+    /**
      * The throttle of the warp drive (target speed is modulated by this value).
      */
     private throttle = 1;
@@ -109,6 +114,7 @@ export class WarpDrive implements ReadonlyWarpDrive {
      */
     public enable(): void {
         this.state = WarpDriveState.ENABLED;
+        this.throttle = this.defaultThrottle;
     }
 
     /**


### PR DESCRIPTION
- This PR adds a new readonly member `defaultThrottle` with a value of 0.5 to the `WarpDrive` class.
-  In the `WarpDrive::enable` method, the `throttle` is now set to the value of `defaultThrottle`. 
- Now `defaultThrottle` set to 0.5 by which new players not gets confused.
- Fixes #230 