### PR TITLE
Add ESLint rule to enforce an error on missing comparison functions in array sort

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,5 +99,6 @@ export default [{
             format: ["PascalCase"],
             leadingUnderscore: "forbid",
         }],
+        "@typescript-eslint/require-array-sort-compare": "error"
     },
 }];


### PR DESCRIPTION
I added the ESLint rule, but it didn't trigger any errors in the code, all the sorts had a comparison function