### PR TITLE
Add landed spaceships to space stations

### DIFF
--- a/src/ts/player/aiPlayerControls.ts
+++ b/src/ts/player/aiPlayerControls.ts
@@ -1,0 +1,29 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Player } from "./player";
+
+export class AiPlayerControls {
+    readonly player: Player;
+
+    constructor() {
+        this.player = Player.Default();
+        this.player.setName("AI");
+    }
+
+    dispose() {}
+}

--- a/src/ts/player/aiPlayerControls.ts
+++ b/src/ts/player/aiPlayerControls.ts
@@ -15,15 +15,30 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { Scene } from "@babylonjs/core/scene";
+import { AiSpaceshipControls } from "../spaceship/aiSpaceshipControls";
+import { Spaceship } from "../spaceship/spaceship";
 import { Player } from "./player";
 
 export class AiPlayerControls {
     readonly player: Player;
+    readonly spaceshipControls: AiSpaceshipControls;
 
-    constructor() {
+    constructor(scene: Scene) {
         this.player = Player.Default();
         this.player.setName("AI");
+
+        const spaceshipSerialized = this.player.serializedSpaceships.shift();
+        if (spaceshipSerialized === undefined) {
+            throw new Error("No spaceship serialized for AI player");
+        }
+
+        const spaceship = Spaceship.Deserialize(spaceshipSerialized, scene);
+
+        this.spaceshipControls = new AiSpaceshipControls(spaceship, scene);
     }
 
-    dispose() {}
+    dispose() {
+        this.spaceshipControls.dispose();
+    }
 }

--- a/src/ts/spaceship/aiSpaceshipControls.ts
+++ b/src/ts/spaceship/aiSpaceshipControls.ts
@@ -1,0 +1,56 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Camera } from "@babylonjs/core/Cameras/camera";
+import { Controls } from "../uberCore/controls";
+import { Spaceship } from "./spaceship";
+import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Scene } from "@babylonjs/core/scene";
+
+export class AiSpaceshipControls implements Controls {
+    readonly spaceship: Spaceship;
+
+    readonly thirdPersonCamera: Camera;
+
+    constructor(spaceship: Spaceship, scene: Scene) {
+        this.spaceship = spaceship;
+
+        this.thirdPersonCamera = new ArcRotateCamera("shipThirdPersonCamera", 0, 0, 50, Vector3.Zero(), scene);
+    }
+
+    getTransform(): TransformNode {
+        return this.spaceship.getTransform();
+    }
+
+    getActiveCamera(): Camera {
+        return this.thirdPersonCamera;
+    }
+
+    getCameras(): Camera[] {
+        return [this.thirdPersonCamera];
+    }
+
+    update(deltaSeconds: number): Vector3 {
+        return Vector3.Zero();
+    }
+
+    dispose() {
+        this.spaceship.dispose();
+    }
+}

--- a/src/ts/spaceship/shipControls.ts
+++ b/src/ts/spaceship/shipControls.ts
@@ -275,8 +275,16 @@ export class ShipControls implements Controls {
 
             if (SpaceShipControlsInputs.map.upDown.value !== 0) {
                 if (spaceship.isLanded()) {
+                    const currentLandingPad = spaceship.getTargetLandingPad();
+                    if (currentLandingPad !== null) {
+                        this.closestLandableFacility?.cancelLandingRequest(currentLandingPad);
+                    }
                     spaceship.takeOff();
                 } else if (spaceship.isLanding()) {
+                    const currentLandingPad = spaceship.getTargetLandingPad();
+                    if (currentLandingPad !== null) {
+                        this.closestLandableFacility?.cancelLandingRequest(currentLandingPad);
+                    }
                     spaceship.cancelLanding();
                 }
                 spaceship.aggregate.body.applyForce(

--- a/src/ts/spacestation/spaceElevator.ts
+++ b/src/ts/spacestation/spaceElevator.ts
@@ -74,6 +74,8 @@ export class SpaceElevator implements OrbitalFacility {
 
     readonly targetInfo: TargetInfo;
 
+    private readonly unavailableLandingPads = new Set<LandingPad>();
+
     constructor(model: SpaceElevatorModel, scene: Scene) {
         this.model = model;
 
@@ -146,6 +148,9 @@ export class SpaceElevator implements OrbitalFacility {
     handleLandingRequest(request: LandingRequest): LandingPad | null {
         const availableLandingPads = this.getLandingPads()
             .filter((landingPad) => {
+                return !this.unavailableLandingPads.has(landingPad);
+            })
+            .filter((landingPad) => {
                 return landingPad.padSize >= request.minimumPadSize;
             })
             .sort((a, b) => {
@@ -154,7 +159,20 @@ export class SpaceElevator implements OrbitalFacility {
 
         if (availableLandingPads.length === 0) return null;
 
+        this.markPadAsUnavailable(availableLandingPads[0]);
         return availableLandingPads[0];
+    }
+
+    public cancelLandingRequest(landingPad: LandingPad) {
+        this.markPadAsAvailable(landingPad);
+    }
+
+    private markPadAsUnavailable(landingPad: LandingPad) {
+        this.unavailableLandingPads.add(landingPad);
+    }
+
+    private markPadAsAvailable(landingPad: LandingPad) {
+        this.unavailableLandingPads.delete(landingPad);
     }
 
     getRotationAxis(): Vector3 {

--- a/src/ts/spacestation/spaceStation.ts
+++ b/src/ts/spacestation/spaceStation.ts
@@ -62,6 +62,8 @@ export class SpaceStation implements OrbitalFacility {
 
     readonly targetInfo: TargetInfo;
 
+    private readonly unavailableLandingPads: Set<LandingPad> = new Set();
+
     constructor(model: SpaceStationModel, scene: Scene) {
         this.model = model;
 
@@ -103,8 +105,11 @@ export class SpaceStation implements OrbitalFacility {
         return this.getLandingPads();
     }
 
-    handleLandingRequest(request: LandingRequest): LandingPad | null {
+    public handleLandingRequest(request: LandingRequest): LandingPad | null {
         const availableLandingPads = this.getLandingPads()
+            .filter((landingPad) => {
+                return !this.unavailableLandingPads.has(landingPad);
+            })
             .filter((landingPad) => {
                 return landingPad.padSize >= request.minimumPadSize;
             })
@@ -114,7 +119,20 @@ export class SpaceStation implements OrbitalFacility {
 
         if (availableLandingPads.length === 0) return null;
 
+        this.markPadAsUnavailable(availableLandingPads[0]);
         return availableLandingPads[0];
+    }
+
+    public cancelLandingRequest(landingPad: LandingPad) {
+        this.markPadAsAvailable(landingPad);
+    }
+
+    private markPadAsUnavailable(landingPad: LandingPad) {
+        this.unavailableLandingPads.add(landingPad);
+    }
+
+    private markPadAsAvailable(landingPad: LandingPad) {
+        this.unavailableLandingPads.delete(landingPad);
     }
 
     getRotationAxis(): Vector3 {

--- a/src/ts/starSystem/starSystemController.ts
+++ b/src/ts/starSystem/starSystemController.ts
@@ -52,6 +52,7 @@ import { SpaceStationModel } from "../spacestation/spacestationModel";
 import { SpaceElevator } from "../spacestation/spaceElevator";
 import { SpaceElevatorModel } from "../spacestation/spaceElevatorModel";
 import { StarSystemDatabase } from "./starSystemDatabase";
+import { AiPlayerControls } from "../player/aiPlayerControls";
 
 export type PlanetarySystem = {
     readonly planets: Planet[];
@@ -108,6 +109,8 @@ export class StarSystemController {
 
     private maxLoadingIndex = 0;
 
+    readonly aiPlayers: AiPlayerControls[] = [];
+
     /**
      * Creates a new star system controller from a given model and scene
      * Note that the star system is not loaded until the load method is called
@@ -147,6 +150,11 @@ export class StarSystemController {
             this.subSystems.push(await this.loadSubSystem(subSystem));
         }
         await wait(1000);
+
+        for (let i = 0; i < 7; i++) {
+            const aiPlayer = new AiPlayerControls();
+            this.aiPlayers.push(aiPlayer);
+        }
     }
 
     private async loadSubSystem(subSystemModel: SubStarSystemModel): Promise<SubStarSystem> {
@@ -740,6 +748,9 @@ export class StarSystemController {
      * Disposes all the bodies in the system
      */
     public dispose() {
+        this.aiPlayers.forEach((aiPlayer) => aiPlayer.dispose());
+        this.aiPlayers.length = 0;
+
         this.objectToParents.clear();
         this.telluricBodies.length = 0;
         this.gasPlanets.length = 0;

--- a/src/ts/starSystem/starSystemController.ts
+++ b/src/ts/starSystem/starSystemController.ts
@@ -52,7 +52,6 @@ import { SpaceStationModel } from "../spacestation/spacestationModel";
 import { SpaceElevator } from "../spacestation/spaceElevator";
 import { SpaceElevatorModel } from "../spacestation/spaceElevatorModel";
 import { StarSystemDatabase } from "./starSystemDatabase";
-import { AiPlayerControls } from "../player/aiPlayerControls";
 
 export type PlanetarySystem = {
     readonly planets: Planet[];
@@ -83,7 +82,6 @@ export class StarSystemController {
 
     /**
      * Translation of the system data model in terms of actual 3D objects
-     * @type {StarSystemModel}
      */
     readonly subSystems: SubStarSystem[] = [];
 
@@ -108,8 +106,6 @@ export class StarSystemController {
     private offset = 1e8;
 
     private maxLoadingIndex = 0;
-
-    readonly aiPlayers: AiPlayerControls[] = [];
 
     /**
      * Creates a new star system controller from a given model and scene
@@ -150,11 +146,6 @@ export class StarSystemController {
             this.subSystems.push(await this.loadSubSystem(subSystem));
         }
         await wait(1000);
-
-        for (let i = 0; i < 7; i++) {
-            const aiPlayer = new AiPlayerControls();
-            this.aiPlayers.push(aiPlayer);
-        }
     }
 
     private async loadSubSystem(subSystemModel: SubStarSystemModel): Promise<SubStarSystem> {
@@ -748,9 +739,6 @@ export class StarSystemController {
      * Disposes all the bodies in the system
      */
     public dispose() {
-        this.aiPlayers.forEach((aiPlayer) => aiPlayer.dispose());
-        this.aiPlayers.length = 0;
-
         this.objectToParents.clear();
         this.telluricBodies.length = 0;
         this.gasPlanets.length = 0;

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -545,7 +545,7 @@ export class StarSystemView implements View {
                 this.targetCursorLayer.addObject(landingPad);
             });
 
-            for (let i = 0; i < 7; i++) {
+            for (let i = 0; i < Math.ceil(Math.random() * 15); i++) {
                 const aiPlayer = new AiPlayerControls(this.scene);
 
                 const landingPad = spaceStation.handleLandingRequest({
@@ -556,8 +556,6 @@ export class StarSystemView implements View {
                     aiPlayer.dispose();
                     break;
                 }
-
-                console.log("allow AI player to landing pad", landingPad.padNumber);
 
                 this.aiPlayers.push(aiPlayer);
                 aiPlayer.spaceshipControls.spaceship.spawnOnPad(landingPad);

--- a/src/ts/uberCore/controls.ts
+++ b/src/ts/uberCore/controls.ts
@@ -29,7 +29,7 @@ export interface Controls extends Transformable {
 
     /**
      * Makes the controller listen to all its inputs and returns the displacement to apply to the player
-     * @param deltaTime the time between 2 frames
+     * @param deltaSeconds the time between 2 frames
      */
-    update(deltaTime: number): Vector3;
+    update(deltaSeconds: number): Vector3;
 }

--- a/src/ts/utils/managesLandingPads.ts
+++ b/src/ts/utils/managesLandingPads.ts
@@ -7,5 +7,7 @@ export type LandingRequest = {
 export interface ManagesLandingPads {
     handleLandingRequest(request: LandingRequest): LandingPad | null;
 
+    cancelLandingRequest(pad: LandingPad): void;
+
     getLandingPads(): LandingPad[];
 }


### PR DESCRIPTION
![screenshot_25-1-19_19-16](https://github.com/user-attachments/assets/02e75abd-2564-44fa-a859-27d6940e4605)

This is the first step toward AI players in Cosmos Journeyer. For now, players will spawn in each star system and will instantiate one spaceship that will be landed in one of the available stations.

In the future, I want AI players to be moving inside the system, flying over planets and such to given even more life to the universe. Beyond that, they will also have their own controllable characters to interact with the world.

Closes #240 