### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Related Tickets
+
+<!--
+Please use this format link issue numbers: Fixes #123 / Closes #123
+https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+-->
+
+## Description
+
+<!--
+This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
+-->
+
+## Unexpected difficulties
+
+<!--
+Did you encounter unexpected difficulties while making this PR?
+Tell us about it, and what you did to overcome them!
+-->
+
+## How to test
+
+<!--
+Make sure you test your work before opening a PR.
+Include the precise steps to reproduce in order to peer review your work.
+Also include screenshots if you can so that reviewers can compare with a baseline.
+-->
+
+## Follow-up
+
+<!--
+What should we do next to take advantage of this work?
+-->


### PR DESCRIPTION
## Related Tickets

Does not apply / Spontaneous.

## Description

The repo already has issue templates, and PR templates can be helpful:

- better readability
- reduce the amount of back and forth by including key info in the PR

## Unexpected difficulties

None

## How to test

Create a new PR on the repo, the template should be injected in the description field

## Follow-up

Maybe having multiple templates? Right now I don't see it as useful, but there might be some valid use-cases