### PR TITLE
Improve spaceship automatic landing

### DIFF
--- a/src/html/helmetOverlay.html
+++ b/src/html/helmetOverlay.html
@@ -10,5 +10,3 @@
         <img src="../asset/icons/fuel_canister.webp" alt="Fuel canister icon" />
     </div>
 </section>
-
-<div id="notificationContainer"></div>

--- a/src/locales/en-US/notifications.json
+++ b/src/locales/en-US/notifications.json
@@ -3,6 +3,8 @@
     "landingSequenceEngaged": "Landing sequence engaged",
     "landingComplete": "Landing complete! Use {{bindingsString}} to disembark.",
     "landingCancelled": "Landing cancelled",
+    "autoPilotEngaged": "Auto-pilot engaged. Sit back and relax.",
+    "takeOffSuccess": "Take off successful",
     "copiedToClipboard": "Copied to clipboard",
     "howToLiftOff": "Hold {{bindingsString}} to lift off.",
     "howToHyperSpace": "Align your ship with the system target using the target helper on the bottom right of your screen then press {{bindingsString}} to make a hyperspace jump.",

--- a/src/locales/fr-FR/notifications.json
+++ b/src/locales/fr-FR/notifications.json
@@ -3,6 +3,8 @@
     "landingSequenceEngaged": "Début de la séquence d'atterrissage.",
     "landingComplete": "Atterrissage réussi ! Utilisez {{bindingsString}} pour sortir du vaisseau.",
     "landingCancelled": "Atterrissage annulé.",
+    "autoPilotEngaged": "Pilote automatique activé. Détendez-vous.",
+    "takeOffSuccess": "Décollage réussi.",
     "copiedToClipboard": "Copié dans le presse-papiers.",
     "howToLiftOff": "Maintenez {{bindingsString}} pour décoller.",
     "howToHyperSpace": "Alignez votre vaisseau avec la cible du système de destination à l'aide du radar de cible en bas à droite de l'écran. Appuyez ensuite sur {{bindingsString}} pour enclencher le saut hyperspatial.",

--- a/src/ts/planets/telluricPlanet/telluricPlanet.ts
+++ b/src/ts/planets/telluricPlanet/telluricPlanet.ts
@@ -48,8 +48,7 @@ export class TelluricPlanet
 {
     readonly model: TelluricPlanetModel | TelluricSatelliteModel;
 
-    readonly type: OrbitalObjectType.TELLURIC_PLANET | OrbitalObjectType.TELLURIC_SATELLITE =
-        OrbitalObjectType.TELLURIC_PLANET | OrbitalObjectType.TELLURIC_SATELLITE;
+    readonly type: OrbitalObjectType.TELLURIC_PLANET | OrbitalObjectType.TELLURIC_SATELLITE;
 
     readonly sides: ChunkTree[]; // stores the 6 sides of the sphere
 
@@ -76,6 +75,8 @@ export class TelluricPlanet
      */
     constructor(model: TelluricPlanetModel | TelluricSatelliteModel, scene: Scene) {
         this.model = model;
+
+        this.type = model.type;
 
         this.transform = new TransformNode(this.model.name, scene);
         this.transform.rotationQuaternion = Quaternion.Identity();

--- a/src/ts/playgrounds/automaticLanding.ts
+++ b/src/ts/playgrounds/automaticLanding.ts
@@ -21,13 +21,14 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { LandingPad, LandingPadSize } from "../assets/procedural/landingPad/landingPad";
 import { Transformable } from "../architecture/transformable";
-import { AssetsManager, TransformNode } from "@babylonjs/core";
+import { AssetsManager, Quaternion, TransformNode } from "@babylonjs/core";
 import { enablePhysics } from "./utils";
 import { DefaultControls } from "../defaultControls/defaultControls";
 import { Spaceship } from "../spaceship/spaceship";
 import { Objects } from "../assets/objects";
 import { Textures } from "../assets/textures";
 import { Sounds } from "../assets/sounds";
+import { randRange } from "extended-random";
 
 export async function createAutomaticLandingScene(engine: AbstractEngine): Promise<Scene> {
     const scene = new Scene(engine);
@@ -42,7 +43,12 @@ export async function createAutomaticLandingScene(engine: AbstractEngine): Promi
     await assetsManager.loadAsync();
 
     const ship = Spaceship.CreateDefault(scene);
-    ship.getTransform().position.copyFromFloats(0, 20, 0);
+    ship.getTransform().position.copyFromFloats(
+        randRange(-50, 50, Math.random, 0),
+        randRange(0, 50, Math.random, 0),
+        randRange(-50, 50, Math.random, 0)
+    );
+    ship.getTransform().rotationQuaternion = Quaternion.Random().normalize();
 
     const defaultControls = new DefaultControls(scene);
     defaultControls.getTransform().position.copyFromFloats(0, 10, -50);
@@ -64,6 +70,8 @@ export async function createAutomaticLandingScene(engine: AbstractEngine): Promi
         getTransform: () => sunTransform,
         dispose: () => sunTransform.dispose()
     };
+
+    ship.engageLandingOnPad(landingPad);
 
     scene.onBeforeRenderObservable.add(() => {
         const deltaSeconds = engine.getDeltaTime() / 1000;

--- a/src/ts/playgrounds/automaticLanding.ts
+++ b/src/ts/playgrounds/automaticLanding.ts
@@ -21,7 +21,14 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { LandingPad, LandingPadSize } from "../assets/procedural/landingPad/landingPad";
 import { Transformable } from "../architecture/transformable";
-import { AssetsManager, Quaternion, TransformNode } from "@babylonjs/core";
+import {
+    AssetsManager,
+    MeshBuilder,
+    PhysicsAggregate,
+    PhysicsShapeType,
+    Quaternion,
+    TransformNode
+} from "@babylonjs/core";
 import { enablePhysics } from "./utils";
 import { DefaultControls } from "../defaultControls/defaultControls";
 import { Spaceship } from "../spaceship/spaceship";
@@ -29,6 +36,7 @@ import { Objects } from "../assets/objects";
 import { Textures } from "../assets/textures";
 import { Sounds } from "../assets/sounds";
 import { randRange } from "extended-random";
+import { CollisionMask } from "../settings";
 
 export async function createAutomaticLandingScene(engine: AbstractEngine): Promise<Scene> {
     const scene = new Scene(engine);
@@ -45,7 +53,7 @@ export async function createAutomaticLandingScene(engine: AbstractEngine): Promi
     const ship = Spaceship.CreateDefault(scene);
     ship.getTransform().position.copyFromFloats(
         randRange(-50, 50, Math.random, 0),
-        randRange(0, 50, Math.random, 0),
+        randRange(30, 50, Math.random, 0),
         randRange(-50, 50, Math.random, 0)
     );
     ship.getTransform().rotationQuaternion = Quaternion.Random().normalize();
@@ -60,6 +68,14 @@ export async function createAutomaticLandingScene(engine: AbstractEngine): Promi
 
     const landingPad = new LandingPad(42, LandingPadSize.SMALL, scene);
 
+    const ground = MeshBuilder.CreateBox("ground", { width: 100, height: 1, depth: 100 }, scene);
+    ground.position.y = -2;
+    ground.position.x = 75;
+
+    const groundAggregate = new PhysicsAggregate(ground, PhysicsShapeType.BOX, { mass: 0 }, scene);
+    groundAggregate.shape.filterMembershipMask = CollisionMask.ENVIRONMENT;
+    groundAggregate.shape.filterCollideMask = CollisionMask.DYNAMIC_OBJECTS;
+
     const hemi = new HemisphericLight("hemi", Vector3.Up(), scene);
     hemi.intensity = 1.0;
 
@@ -71,7 +87,8 @@ export async function createAutomaticLandingScene(engine: AbstractEngine): Promi
         dispose: () => sunTransform.dispose()
     };
 
-    ship.engageLandingOnPad(landingPad);
+    //ship.engageLandingOnPad(landingPad);
+    ship.engageSurfaceLanding(ground);
 
     scene.onBeforeRenderObservable.add(() => {
         const deltaSeconds = engine.getDeltaTime() / 1000;

--- a/src/ts/spaceship/landingComputer.spec.ts
+++ b/src/ts/spaceship/landingComputer.spec.ts
@@ -33,6 +33,8 @@ describe("LandingComputer", () => {
             }),
             absoluteRotationQuaternion: new Quaternion(),
             up: Vector3.Up(),
+            right: Vector3.Right(),
+            forward: Vector3.Forward(),
             position: new Vector3(0, 0, 0)
         } as unknown as TransformNode;
 

--- a/src/ts/spaceship/landingComputer.spec.ts
+++ b/src/ts/spaceship/landingComputer.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { LandingComputer, LandingTargetKind, LandingComputerStatusBit } from "./landingComputer";
+import { Vector3, Quaternion } from "@babylonjs/core/Maths/math.vector";
+import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { LandingPad } from "../assets/procedural/landingPad/landingPad";
+import { PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
+
+// Mock BabylonJS classes
+vi.mock("@babylonjs/core/Physics/v2/physicsAggregate", () => ({
+    PhysicsAggregate: vi.fn()
+}));
+
+vi.mock("@babylonjs/core/Physics/v2/physicsBody", () => ({
+    PhysicsBody: vi.fn()
+}));
+
+describe("LandingComputer", () => {
+    let landingComputer: LandingComputer;
+    let mockAggregate: PhysicsAggregate;
+    let mockPhysicsEngine: PhysicsEngineV2;
+    let mockTransform: TransformNode;
+    let mockPhysicsBody: PhysicsBody;
+
+    beforeEach(() => {
+        // Setup mocks
+        mockTransform = {
+            getAbsolutePosition: vi.fn().mockReturnValue(new Vector3(0, 0, 0)),
+            getHierarchyBoundingVectors: vi.fn().mockReturnValue({
+                min: new Vector3(-1, -1, -1),
+                max: new Vector3(1, 1, 1)
+            }),
+            absoluteRotationQuaternion: new Quaternion(),
+            up: Vector3.Up(),
+            position: new Vector3(0, 0, 0)
+        } as unknown as TransformNode;
+
+        mockPhysicsBody = {
+            getLinearVelocity: vi.fn().mockReturnValue(new Vector3(0, 0, 0)),
+            getAngularVelocity: vi.fn().mockReturnValue(new Vector3(0, 0, 0)),
+            getMassProperties: vi.fn().mockReturnValue({ mass: 1 }),
+            applyForce: vi.fn(),
+            applyAngularImpulse: vi.fn()
+        } as unknown as PhysicsBody;
+
+        mockAggregate = {
+            transformNode: mockTransform,
+            body: mockPhysicsBody
+        } as unknown as PhysicsAggregate;
+
+        mockPhysicsEngine = {
+            raycastToRef: vi.fn().mockImplementation((start, end, result) => {
+                result.hasHit = true;
+                result.hitPointWorld = new Vector3(0, 0, 0);
+                result.hitNormalWorld = Vector3.Up();
+            })
+        } as unknown as PhysicsEngineV2;
+
+        landingComputer = new LandingComputer(mockAggregate, mockPhysicsEngine);
+    });
+
+    it("should initialize with null target", () => {
+        expect(landingComputer.getTarget()).toBeNull();
+    });
+
+    it("should set landing pad target", () => {
+        const mockLandingPad = {
+            getTransform: () => ({
+                getAbsolutePosition: () => new Vector3(0, 10, 0),
+                up: Vector3.Up(),
+                absoluteRotationQuaternion: new Quaternion()
+            }),
+            padHeight: 2
+        } as unknown as LandingPad;
+
+        landingComputer.setTarget({
+            kind: LandingTargetKind.LANDING_PAD,
+            landingPad: mockLandingPad
+        });
+
+        expect(landingComputer.getTarget()).not.toBeNull();
+        expect(landingComputer.getTarget()?.kind).toBe(LandingTargetKind.LANDING_PAD);
+    });
+
+    it("should set celestial body target", () => {
+        const mockCelestialBody = {
+            position: new Vector3(0, 100, 0)
+        } as unknown as TransformNode;
+
+        landingComputer.setTarget({
+            kind: LandingTargetKind.CELESTIAL_BODY,
+            celestialBody: mockCelestialBody
+        });
+
+        expect(landingComputer.getTarget()).not.toBeNull();
+        expect(landingComputer.getTarget()?.kind).toBe(LandingTargetKind.CELESTIAL_BODY);
+    });
+
+    it("should return IDLE status when no target", () => {
+        const status = landingComputer.update(0.016);
+        expect(status).toBe(LandingComputerStatusBit.IDLE);
+    });
+
+    it("should timeout after max seconds", () => {
+        const mockLandingPad = {
+            getTransform: () => ({
+                getAbsolutePosition: () => new Vector3(0, 10, 0),
+                up: Vector3.Up(),
+                absoluteRotationQuaternion: new Quaternion()
+            }),
+            padHeight: 2
+        } as unknown as LandingPad;
+
+        landingComputer.setTarget({
+            kind: LandingTargetKind.LANDING_PAD,
+            landingPad: mockLandingPad
+        });
+
+        // Simulate passage of time beyond timeout
+        const status = landingComputer.update(91);
+        expect(status).toBe(LandingComputerStatusBit.TIMEOUT);
+        expect(landingComputer.getTarget()).toBeNull();
+    });
+
+    it("should report progress during normal operation", () => {
+        const mockLandingPad = {
+            getTransform: () => ({
+                getAbsolutePosition: () => new Vector3(0, 10, 0),
+                up: Vector3.Up(),
+                absoluteRotationQuaternion: new Quaternion()
+            }),
+            padHeight: 2
+        } as unknown as LandingPad;
+
+        landingComputer.setTarget({
+            kind: LandingTargetKind.LANDING_PAD,
+            landingPad: mockLandingPad
+        });
+
+        const status = landingComputer.update(0.016);
+        expect(status).toBe(LandingComputerStatusBit.PROGRESS);
+    });
+});

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -16,7 +16,6 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { Transformable } from "../architecture/transformable";
 import { LandingPad } from "../assets/procedural/landingPad/landingPad";
 import { PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
 import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
@@ -37,7 +36,7 @@ export type LandingTargetPad = {
 
 export type LandingTargetCelestialBody = {
     kind: LandingTargetKind.CELESTIAL_BODY;
-    celestialBody: Transformable;
+    celestialBody: TransformNode;
 };
 
 export type LandingTarget = LandingTargetPad | LandingTargetCelestialBody;
@@ -147,7 +146,7 @@ export class LandingComputer {
                 this.actionPlan = this.createLandingPadActionPlan(this.target.landingPad);
                 break;
             case LandingTargetKind.CELESTIAL_BODY:
-                this.actionPlan = this.createCelestialBodyActionPlan(this.target.celestialBody);
+                this.actionPlan = this.createSurfaceActionPlan(this.target.celestialBody);
                 break;
         }
     }
@@ -205,12 +204,12 @@ export class LandingComputer {
         ];
     }
 
-    private createCelestialBodyActionPlan(celestialBody: Transformable): ReadonlyArray<LandingPlanStep> {
+    private createSurfaceActionPlan(celestialBody: TransformNode): ReadonlyArray<LandingPlanStep> {
         return [
             {
                 getTargetTransform: () => {
                     const shipPosition = this.transform.getAbsolutePosition();
-                    const gravityDir = celestialBody.getTransform().position.subtract(shipPosition).normalize();
+                    const gravityDir = celestialBody.position.subtract(shipPosition).normalize();
 
                     const start = shipPosition.add(gravityDir.scale(-50e3));
                     const end = shipPosition.add(gravityDir.scale(50e3));

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -224,12 +224,16 @@ export class LandingComputer {
 
                     const landingSpotNormal = this.raycastResult.hitNormalWorld;
 
+                    const landingSpotPosition = this.raycastResult.hitPointWorld.add(
+                        landingSpotNormal.scale(this.boundingExtent.y / 2)
+                    );
+
                     const currentUp = this.transform.up;
                     const targetUp = landingSpotNormal;
 
                     if (currentUp.equalsWithEpsilon(targetUp)) {
                         return {
-                            position: this.raycastResult.hitPointWorld,
+                            position: landingSpotPosition,
                             rotation: this.transform.absoluteRotationQuaternion
                         };
                     }
@@ -238,7 +242,7 @@ export class LandingComputer {
                     const theta = Math.acos(Vector3.Dot(currentUp, targetUp));
 
                     return {
-                        position: this.raycastResult.hitPointWorld,
+                        position: landingSpotPosition,
                         rotation: this.transform.absoluteRotationQuaternion.multiply(
                             Quaternion.RotationAxis(axis, theta)
                         )

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -249,12 +249,12 @@ export class LandingComputer {
                     rotation: 0.1
                 },
                 maxVelocity: {
-                    linear: 5,
+                    linear: 15,
                     rotation: 0.5
                 },
                 tolerance: {
-                    position: 0.5,
-                    rotation: 0.1
+                    position: 2.0,
+                    rotation: 0.2
                 }
             }
         ];

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -1,0 +1,332 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Transformable } from "../architecture/transformable";
+import { LandingPad } from "../assets/procedural/landingPad/landingPad";
+import { PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
+import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { Observable } from "@babylonjs/core/Misc/observable";
+import { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import { CollisionMask } from "../settings";
+import { getAngleFromQuaternion, getAxisFromQuaternion, getDeltaQuaternion } from "../utils/algebra";
+
+export const enum LandingTargetKind {
+    LANDING_PAD,
+    CELESTIAL_BODY
+}
+
+export type LandingTargetPad = {
+    kind: LandingTargetKind.LANDING_PAD;
+    landingPad: LandingPad;
+};
+
+export type LandingTargetCelestialBody = {
+    kind: LandingTargetKind.CELESTIAL_BODY;
+    celestialBody: Transformable;
+};
+
+export type LandingTarget = LandingTargetPad | LandingTargetCelestialBody;
+
+/**
+ * One step in a plan of action for a transformable object subject to physics
+ */
+type LandingPlanStep = {
+    /**
+     * @returns The target position and rotation for the transformable object in this step
+     */
+    getTargetTransform: () => {
+        /**
+         * The position to reach
+         */
+        position: Vector3;
+
+        /**
+         * The rotation to reach
+         */
+        rotation: Quaternion;
+    };
+
+    /**
+     * The maximum velocity at any point during the step
+     */
+    maxVelocity: {
+        linear: number;
+        rotation: number;
+    };
+
+    /**
+     * The maximum velocity when reaching the target before the step is considered complete
+     */
+    maxVelocityAtTarget: {
+        linear: number;
+        rotation: number;
+    };
+
+    /**
+     * The tolerance margin to consider the step complete
+     */
+    tolerance: {
+        /**
+         * The maximum distance to the target position
+         */
+        position: number;
+
+        /**
+         * The maximum deviation between the target and current up vectors
+         */
+        rotation: number;
+    };
+};
+
+export class LandingComputer {
+    private readonly physicsEngine: PhysicsEngineV2;
+
+    private target: LandingTarget | null = null;
+
+    private actionPlan: ReadonlyArray<LandingPlanStep> | null = null;
+
+    private currentActionIndex = 0;
+
+    private readonly aggregate: PhysicsAggregate;
+    private readonly transform: TransformNode;
+    private readonly raycastResult = new PhysicsRaycastResult();
+
+    private readonly boundingExtent: Vector3;
+
+    readonly onLandingComplete: Observable<void> = new Observable<void>();
+
+    constructor(aggregate: PhysicsAggregate, physicsEngine: PhysicsEngineV2) {
+        this.aggregate = aggregate;
+        this.transform = aggregate.transformNode;
+
+        this.physicsEngine = physicsEngine;
+
+        const boundingVectors = this.transform.getHierarchyBoundingVectors();
+        this.boundingExtent = boundingVectors.max.subtract(boundingVectors.min);
+    }
+
+    getTarget() {
+        return this.target;
+    }
+
+    setTarget(target: LandingTarget | null) {
+        this.target = target;
+        this.currentActionIndex = 0;
+
+        if (this.target === null) {
+            this.actionPlan = null;
+            return;
+        }
+
+        switch (this.target.kind) {
+            case LandingTargetKind.LANDING_PAD:
+                this.actionPlan = this.createLandingPadActionPlan(this.target.landingPad);
+                break;
+            case LandingTargetKind.CELESTIAL_BODY:
+                this.actionPlan = this.createCelestialBodyActionPlan(this.target.celestialBody);
+                break;
+        }
+    }
+
+    private createLandingPadActionPlan(landingPad: LandingPad): ReadonlyArray<LandingPlanStep> {
+        return [
+            {
+                getTargetTransform: () => {
+                    return {
+                        position: landingPad
+                            .getTransform()
+                            .getAbsolutePosition()
+                            .add(landingPad.getTransform().up.scale(50)),
+                        rotation: landingPad.getTransform().absoluteRotationQuaternion
+                    };
+                },
+                maxVelocityAtTarget: {
+                    linear: 3,
+                    rotation: 0.1
+                },
+                maxVelocity: {
+                    linear: 20,
+                    rotation: 0.5
+                },
+                tolerance: {
+                    position: 1.5,
+                    rotation: 0.1
+                }
+            },
+            {
+                getTargetTransform: () => {
+                    return {
+                        position: landingPad
+                            .getTransform()
+                            .getAbsolutePosition()
+                            .add(
+                                landingPad.getTransform().up.scale((landingPad.padHeight + this.boundingExtent.y) / 2)
+                            ),
+                        rotation: landingPad.getTransform().absoluteRotationQuaternion
+                    };
+                },
+                maxVelocityAtTarget: {
+                    linear: 3,
+                    rotation: 0.1
+                },
+                maxVelocity: {
+                    linear: 5,
+                    rotation: 0.5
+                },
+                tolerance: {
+                    position: 0.5,
+                    rotation: 0.1
+                }
+            }
+        ];
+    }
+
+    private createCelestialBodyActionPlan(celestialBody: Transformable): ReadonlyArray<LandingPlanStep> {
+        const shipPosition = this.transform.getAbsolutePosition();
+        const gravityDir = celestialBody.getTransform().getAbsolutePosition().subtract(shipPosition).normalize();
+        const start = shipPosition.add(gravityDir.scale(-50e3));
+        const end = shipPosition.add(gravityDir.scale(50e3));
+
+        return [
+            {
+                getTargetTransform: () => {
+                    this.physicsEngine.raycastToRef(start, end, this.raycastResult, {
+                        collideWith: CollisionMask.ENVIRONMENT
+                    });
+
+                    if (!this.raycastResult.hasHit) {
+                        throw new Error("No landing spot found");
+                    }
+
+                    const landingSpotNormal = this.raycastResult.hitNormalWorld;
+
+                    const currentUp = this.transform.up;
+                    const targetUp = landingSpotNormal;
+
+                    if (currentUp.equalsWithEpsilon(targetUp)) {
+                        return {
+                            position: this.raycastResult.hitPointWorld,
+                            rotation: this.transform.absoluteRotationQuaternion
+                        };
+                    }
+
+                    const axis = Vector3.Cross(currentUp, targetUp);
+                    const theta = Math.acos(Vector3.Dot(currentUp, targetUp));
+
+                    return {
+                        position: this.raycastResult.hitPointWorld,
+                        rotation: this.transform.absoluteRotationQuaternion.multiply(
+                            Quaternion.RotationAxis(axis, theta)
+                        )
+                    };
+                },
+                maxVelocityAtTarget: {
+                    linear: 3,
+                    rotation: 0.1
+                },
+                maxVelocity: {
+                    linear: 5,
+                    rotation: 0.5
+                },
+                tolerance: {
+                    position: 0.5,
+                    rotation: 0.1
+                }
+            }
+        ];
+    }
+
+    update() {
+        if (this.target === null || this.actionPlan === null) {
+            return;
+        }
+
+        const currentAction = this.actionPlan.at(this.currentActionIndex);
+        if (currentAction === undefined) {
+            return;
+        }
+
+        const { position: targetPosition, rotation: targetRotation } = currentAction.getTargetTransform();
+        const { position: positionTolerance, rotation: rotationTolerance } = currentAction.tolerance;
+        const { linear: maxSpeedAtTarget, rotation: maxRotationSpeedAtTarget } = currentAction.maxVelocityAtTarget;
+        const { linear: maxLinearSpeed, rotation: maxRotationSpeed } = currentAction.maxVelocity;
+
+        const currentPosition = this.transform.getAbsolutePosition();
+        const currentRotation = this.transform.absoluteRotationQuaternion;
+
+        const currentLinearVelocity = this.aggregate.body.getLinearVelocity();
+        const currentAngularVelocity = this.aggregate.body.getAngularVelocity();
+
+        const distance = Vector3.Distance(targetPosition, currentPosition);
+        const directionToTarget = targetPosition.subtract(currentPosition).normalize();
+
+        const shipUp = this.transform.up;
+        const targetUp = Vector3.Up().applyRotationQuaternionInPlace(targetRotation);
+
+        if (
+            distance <= positionTolerance &&
+            shipUp.equalsWithEpsilon(targetUp, rotationTolerance) &&
+            currentLinearVelocity.length() < maxSpeedAtTarget &&
+            currentAngularVelocity.length() < maxRotationSpeedAtTarget
+        ) {
+            if (this.currentActionIndex === this.actionPlan.length - 1) {
+                this.onLandingComplete.notifyObservers();
+                this.setTarget(null);
+                return;
+            }
+
+            this.currentActionIndex++;
+            return;
+        }
+
+        const currentSpeedTowardTarget = currentLinearVelocity.dot(directionToTarget);
+
+        const otherSpeed = currentLinearVelocity.subtract(directionToTarget.scale(currentSpeedTowardTarget));
+
+        const mass = this.aggregate.body.getMassProperties().mass ?? 1;
+
+        // move toward target
+        const targetSpeedTowardTarget = Math.min(distance * 3.0, maxLinearSpeed);
+        this.aggregate.body.applyForce(
+            directionToTarget.scale(mass * (targetSpeedTowardTarget - currentSpeedTowardTarget)),
+            currentPosition
+        );
+
+        // damp speed along other directions
+        this.aggregate.body.applyForce(otherSpeed.scale(-2 * mass), currentPosition);
+
+        const deltaRotation = getDeltaQuaternion(currentRotation, targetRotation);
+        const rotationAngle = getAngleFromQuaternion(deltaRotation);
+        const rotationAxis = getAxisFromQuaternion(deltaRotation);
+
+        const angularVelocity = this.aggregate.body.getAngularVelocity();
+
+        const currentRotationSpeed = angularVelocity.dot(rotationAxis);
+        const targetRotationSpeed =
+            Math.sign(rotationAngle) * Math.min(maxRotationSpeed, 0.4 * Math.sqrt(Math.abs(rotationAngle)));
+
+        const otherRotationSpeed = angularVelocity.subtract(rotationAxis.scale(currentRotationSpeed));
+
+        const rotationImpulseStrength = 20 * (targetRotationSpeed - currentRotationSpeed);
+
+        this.aggregate.body.applyAngularImpulse(rotationAxis.scale(rotationImpulseStrength));
+
+        this.aggregate.body.applyAngularImpulse(otherRotationSpeed.scale(-2));
+    }
+}

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -22,12 +22,7 @@ import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
 import { CollisionMask } from "../settings";
-import {
-    getAngleFromQuaternion,
-    getAxisFromQuaternion,
-    getDeltaQuaternion,
-    getTransformationQuaternion
-} from "../utils/algebra";
+import { getAngleFromQuaternion, getAxisFromQuaternion, getDeltaQuaternion } from "../utils/algebra";
 
 export const enum LandingTargetKind {
     LANDING_PAD,
@@ -343,7 +338,7 @@ export class LandingComputer {
         const otherSpeed = currentLinearVelocity.subtract(directionToTarget.scale(currentSpeedTowardTarget));
 
         // damp speed along other directions
-        this.aggregate.body.applyForce(otherSpeed.scale(-2 * mass), currentPosition);
+        this.aggregate.body.applyForce(otherSpeed.scale(-5 * mass), currentPosition);
 
         const deltaRotation = getDeltaQuaternion(currentRotation, targetRotation);
         const rotationAngle = getAngleFromQuaternion(deltaRotation);
@@ -360,9 +355,7 @@ export class LandingComputer {
         this.aggregate.body.applyAngularImpulse(rotationAxis.scale(rotationImpulseStrength));
 
         const otherRotationSpeed = angularVelocity.subtract(rotationAxis.scale(currentRotationSpeed));
-        if (otherRotationSpeed.length() > 1) {
-            this.aggregate.body.applyAngularImpulse(otherRotationSpeed.scale(-2));
-        }
+        this.aggregate.body.applyAngularImpulse(otherRotationSpeed.scale(-2));
 
         if (this.elapsedSeconds > this.maxSecondsPerPlan) {
             this.setTarget(null);

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -259,7 +259,7 @@ export class LandingComputer {
                     rotation: 0.1
                 },
                 maxVelocity: {
-                    linearY: 15,
+                    linearY: 5,
                     rotation: 0.5
                 },
                 tolerance: {

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -206,14 +206,15 @@ export class LandingComputer {
     }
 
     private createCelestialBodyActionPlan(celestialBody: Transformable): ReadonlyArray<LandingPlanStep> {
-        const shipPosition = this.transform.getAbsolutePosition();
-        const gravityDir = celestialBody.getTransform().getAbsolutePosition().subtract(shipPosition).normalize();
-        const start = shipPosition.add(gravityDir.scale(-50e3));
-        const end = shipPosition.add(gravityDir.scale(50e3));
-
         return [
             {
                 getTargetTransform: () => {
+                    const shipPosition = this.transform.getAbsolutePosition();
+                    const gravityDir = celestialBody.getTransform().position.subtract(shipPosition).normalize();
+
+                    const start = shipPosition.add(gravityDir.scale(-50e3));
+                    const end = shipPosition.add(gravityDir.scale(50e3));
+
                     this.physicsEngine.raycastToRef(start, end, this.raycastResult, {
                         collideWith: CollisionMask.ENVIRONMENT
                     });

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -258,7 +258,7 @@ export class LandingComputer {
                     rotation: 0.5
                 },
                 tolerance: {
-                    position: 2.0,
+                    position: 5.0,
                     rotation: 0.2
                 }
             }

--- a/src/ts/spaceship/landingComputer.ts
+++ b/src/ts/spaceship/landingComputer.ts
@@ -249,8 +249,8 @@ export class LandingComputer {
 
                     return {
                         position: landingSpotPosition,
-                        rotation: this.transform.absoluteRotationQuaternion.multiply(
-                            Quaternion.RotationAxis(axis, theta)
+                        rotation: Quaternion.RotationAxis(axis, theta).multiplyInPlace(
+                            this.transform.absoluteRotationQuaternion
                         )
                     };
                 },

--- a/src/ts/spaceship/shipControls.ts
+++ b/src/ts/spaceship/shipControls.ts
@@ -183,7 +183,7 @@ export class ShipControls implements Controls {
                 return;
             }
 
-            spaceship.engagePlanetaryLanding(closestWalkableObject);
+            spaceship.engageSurfaceLanding(closestWalkableObject.getTransform());
         };
 
         SpaceShipControlsInputs.map.landing.on("complete", this.landingHandler);

--- a/src/ts/spaceship/shipControls.ts
+++ b/src/ts/spaceship/shipControls.ts
@@ -303,21 +303,21 @@ export class ShipControls implements Controls {
                 const shipUp = getUpwardDirection(this.getTransform());
                 const shipRight = getRightDirection(this.getTransform());
 
-                const angularVelocity = spaceship.aggregate.body.getAngularVelocity();
+                const angularImpulse = Vector3.Zero();
 
-                const currentRoll = angularVelocity.dot(shipForward);
+                const currentRoll = angularImpulse.dot(shipForward);
                 const targetRoll = this.spaceship.maxRollSpeed * inputRoll;
-                angularVelocity.addInPlace(shipForward.scale(0.5 * (targetRoll - currentRoll)));
+                angularImpulse.addInPlace(shipForward.scale(0.5 * (targetRoll - currentRoll)));
 
-                const currentYaw = angularVelocity.dot(shipUp);
+                const currentYaw = angularImpulse.dot(shipUp);
                 const targetYaw = -this.spaceship.maxYawSpeed * inputRoll;
-                angularVelocity.addInPlace(shipUp.scale(0.5 * (targetYaw - currentYaw)));
+                angularImpulse.addInPlace(shipUp.scale(0.5 * (targetYaw - currentYaw)));
 
-                const currentPitch = angularVelocity.dot(shipRight);
+                const currentPitch = angularImpulse.dot(shipRight);
                 const targetPitch = -this.spaceship.maxPitchSpeed * inputPitch;
-                angularVelocity.addInPlace(shipRight.scale(0.5 * (targetPitch - currentPitch)));
+                angularImpulse.addInPlace(shipRight.scale(0.5 * (targetPitch - currentPitch)));
 
-                spaceship.aggregate.body.setAngularVelocity(angularVelocity);
+                spaceship.aggregate.body.applyAngularImpulse(angularImpulse);
             }
         } else {
             spaceship.getWarpDrive().increaseThrottle(0.5 * deltaSeconds * SpaceShipControlsInputs.map.throttle.value);

--- a/src/ts/spaceship/shipControls.ts
+++ b/src/ts/spaceship/shipControls.ts
@@ -390,8 +390,21 @@ export class ShipControls implements Controls {
         });
 
         this.spaceship.onTakeOff.add(() => {
-            //FIXME: localize
-            createNotification(NotificationOrigin.SPACESHIP, NotificationIntent.INFO, "Takeoff successful", 2000);
+            createNotification(
+                NotificationOrigin.SPACESHIP,
+                NotificationIntent.INFO,
+                i18n.t("notifications:takeOffSuccess"),
+                2000
+            );
+        });
+
+        this.spaceship.onAutoPilotEngaged.add(() => {
+            createNotification(
+                NotificationOrigin.SPACESHIP,
+                NotificationIntent.INFO,
+                i18n.t("notifications:autoPilotEngaged"),
+                30_000
+            );
         });
 
         this.spaceship.onWarpDriveDisabled.add((isEmergency) => {

--- a/src/ts/spaceship/shipControls.ts
+++ b/src/ts/spaceship/shipControls.ts
@@ -47,6 +47,7 @@ import { quickAnimation } from "../uberCore/transforms/animations/quickAnimation
 import { Observable } from "@babylonjs/core/Misc/observable";
 import { lerpSmooth } from "../utils/math";
 import { HasBoundingSphere } from "../architecture/hasBoundingSphere";
+import { canEngageWarpDrive } from "./warpDriveUtils";
 
 export class ShipControls implements Controls {
     private spaceship: Spaceship;
@@ -106,7 +107,12 @@ export class ShipControls implements Controls {
 
         this.toggleWarpDriveHandler = async () => {
             const spaceship = this.getSpaceship();
-            if (!spaceship.canEngageWarpDrive() && spaceship.getWarpDrive().isDisabled()) {
+            const nearestOrbitalObject = spaceship.getNearestOrbitalObject();
+            if (
+                spaceship.getWarpDrive().isDisabled() &&
+                nearestOrbitalObject !== null &&
+                !canEngageWarpDrive(spaceship.getTransform(), 0, nearestOrbitalObject)
+            ) {
                 Sounds.CANNOT_ENGAGE_WARP_DRIVE.play();
                 return;
             }

--- a/src/ts/spaceship/shipControls.ts
+++ b/src/ts/spaceship/shipControls.ts
@@ -264,7 +264,7 @@ export class ShipControls implements Controls {
         if (!this.cameraShakeAnimation.isFinished()) this.cameraShakeAnimation.update(deltaSeconds);
 
         let [inputRoll, inputPitch] = SpaceShipControlsInputs.map.rollPitch.value;
-        if (SpaceShipControlsInputs.map.ignorePointer.value > 0) {
+        if (SpaceShipControlsInputs.map.ignorePointer.value > 0 || spaceship.isAutoPiloted()) {
             inputRoll *= 0;
             inputPitch *= 0;
         }

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -184,6 +184,8 @@ export class Spaceship implements Transformable {
                 continue;
             }
             const childShape = new PhysicsShapeMesh(child as Mesh, scene);
+            childShape.filterMembershipMask = CollisionMask.DYNAMIC_OBJECTS;
+            childShape.filterCollideMask = CollisionMask.ENVIRONMENT | CollisionMask.DYNAMIC_OBJECTS;
             this.aggregate.shape.addChildFromParent(this.instanceRoot, childShape, child);
         }
         this.aggregate.body.disablePreStep = false;

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -66,6 +66,7 @@ export const enum ShipType {
 }
 
 export type SerializedSpaceship = {
+    id: string;
     name: string;
     type: ShipType;
     fuelTanks: SerializedFuelTank[];
@@ -73,6 +74,7 @@ export type SerializedSpaceship = {
 };
 
 export const DefaultSerializedSpaceship: SerializedSpaceship = {
+    id: crypto.randomUUID(),
     name: "Wanderer",
     type: ShipType.WANDERER,
     fuelTanks: [{ currentFuel: 100, maxFuel: 100 }],
@@ -82,6 +84,8 @@ export const DefaultSerializedSpaceship: SerializedSpaceship = {
 };
 
 export class Spaceship implements Transformable {
+    readonly id: string;
+
     readonly name: string;
 
     readonly instanceRoot: AbstractMesh;
@@ -152,6 +156,8 @@ export class Spaceship implements Transformable {
     readonly boundingExtent: Vector3;
 
     private constructor(serializedSpaceShip: SerializedSpaceship, scene: Scene) {
+        this.id = serializedSpaceShip.id ?? crypto.randomUUID();
+
         this.name = serializedSpaceShip.name;
 
         this.instanceRoot = Objects.CreateWandererInstance();
@@ -856,6 +862,7 @@ export class Spaceship implements Transformable {
 
     public serialize(): SerializedSpaceship {
         return {
+            id: this.id,
             name: this.name,
             type: ShipType.WANDERER,
             fuelTanks: this.fuelTanks.map((tank) => tank.serialize()),

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -523,7 +523,7 @@ export class Spaceship implements Transformable {
 
         if (this.warpDrive.isEnabled()) {
             if (this.nearestOrbitalObject !== null) {
-                if (!canEngageWarpDrive(this.getTransform(), currentForwardSpeed, this.nearestOrbitalObject)) {
+                if (!canEngageWarpDrive(this.getTransform(), this.getSpeed(), this.nearestOrbitalObject)) {
                     this.emergencyStopWarpDrive();
                 }
 

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -151,6 +151,8 @@ export class Spaceship implements Transformable {
 
     readonly onTakeOff = new Observable<void>();
 
+    readonly onAutoPilotEngaged = new Observable<void>();
+
     readonly boundingExtent: Vector3;
 
     private constructor(serializedSpaceShip: SerializedSpaceship, scene: Scene) {
@@ -375,7 +377,6 @@ export class Spaceship implements Transformable {
     }
 
     public engageLandingOnPad(landingPad: LandingPad) {
-        console.log("Landing on pad", landingPad.getTransform().name);
         this.targetLandingPad = landingPad;
     }
 
@@ -384,7 +385,6 @@ export class Spaceship implements Transformable {
     }
 
     private completeLanding() {
-        console.log("Landing sequence complete");
         this.state = ShipState.LANDED;
 
         this.aggregate.body.setMotionType(PhysicsMotionType.STATIC);
@@ -696,20 +696,14 @@ export class Spaceship implements Transformable {
                 const verticalDistance = Vector3.Dot(shipRelativePosition, this.targetLandingPad.getTransform().up);
                 if (distanceToPad < 600 && verticalDistance > 0) {
                     if (this.state !== ShipState.LANDING) {
-                        //FIXME: move this in ship controls before adding NPC ships
-                        createNotification(
-                            NotificationOrigin.SPACESHIP,
-                            NotificationIntent.INFO,
-                            "Automatic landing procedure engaged",
-                            10000
-                        );
-
                         this.landingComputer.setTarget({
                             kind: LandingTargetKind.LANDING_PAD,
                             landingPad: this.targetLandingPad
                         });
 
                         this.state = ShipState.LANDING;
+
+                        this.onAutoPilotEngaged.notifyObservers();
                     }
                 }
             }

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -650,6 +650,10 @@ export class Spaceship implements Transformable {
 
         this.landingComputer?.update();
 
+        if (this.isAutoPiloted()) {
+            this.setMainEngineThrottle(0);
+        }
+
         const distanceTravelledLY = (this.getSpeed() * deltaSeconds) / Settings.LIGHT_YEAR;
         const fuelToBurn = this.warpDrive.getFuelConsumption(distanceTravelledLY);
         if (fuelToBurn < this.getRemainingFuel()) {

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -582,6 +582,9 @@ export class Spaceship implements Transformable {
 
     public update(deltaSeconds: number) {
         this.mainEngineTargetSpeed = this.mainEngineThrottle * this.maxSpeed;
+        if (this.targetLandingPad !== null) {
+            this.mainEngineTargetSpeed /= 8;
+        }
 
         this.updateWarpDrive(deltaSeconds);
 

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -727,16 +727,19 @@ export class Spaceship implements Transformable {
             if (this.mainEngineThrottle !== 0) this.thrusterSound.setTargetVolume(1);
             else this.thrusterSound.setTargetVolume(0);
 
-            if (forwardSpeed < this.mainEngineTargetSpeed) {
-                this.aggregate.body.applyForce(
-                    forwardDirection.scale(this.thrusterForce),
-                    this.aggregate.body.getObjectCenterWorld()
-                );
-            } else {
-                this.aggregate.body.applyForce(
-                    forwardDirection.scale(-0.7 * this.thrusterForce),
-                    this.aggregate.body.getObjectCenterWorld()
-                );
+            const speedDifference = forwardSpeed - this.mainEngineTargetSpeed;
+            if (Math.abs(speedDifference) > 2) {
+                if (speedDifference < 0) {
+                    this.aggregate.body.applyForce(
+                        forwardDirection.scale(this.thrusterForce),
+                        this.aggregate.body.getObjectCenterWorld()
+                    );
+                } else {
+                    this.aggregate.body.applyForce(
+                        forwardDirection.scale(-0.7 * this.thrusterForce),
+                        this.aggregate.body.getObjectCenterWorld()
+                    );
+                }
             }
 
             this.mainThrusters.forEach((thruster) => {

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -612,7 +612,7 @@ export class Spaceship implements Transformable {
 
                 // damp other speed
                 const otherSpeed = linearVelocity.subtract(forwardDirection.scale(forwardSpeed));
-                this.aggregate.body.applyForce(otherSpeed.scale(-2), this.aggregate.body.getObjectCenterWorld());
+                this.aggregate.body.applyForce(otherSpeed.scale(-5), this.aggregate.body.getObjectCenterWorld());
             }
 
             this.mainThrusters.forEach((thruster) => {

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -367,8 +367,7 @@ export class Spaceship implements Transformable {
         return this.nearestOrbitalObject;
     }
 
-    public engagePlanetaryLanding(landingTarget: Transformable) {
-        this.aggregate.body.setMotionType(PhysicsMotionType.ANIMATED);
+    public engageSurfaceLanding(landingTarget: TransformNode) {
         this.state = ShipState.LANDING;
         this.landingComputer?.setTarget({
             kind: LandingTargetKind.CELESTIAL_BODY,

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -376,6 +376,10 @@ export class Spaceship implements Transformable {
         this.onPlanetaryLandingEngaged.notifyObservers();
     }
 
+    public isAutoPiloted() {
+        return this.landingComputer?.getTarget() !== null;
+    }
+
     public engageLandingOnPad(landingPad: LandingPad) {
         this.targetLandingPad = landingPad;
     }
@@ -660,7 +664,7 @@ export class Spaceship implements Transformable {
             if (this.mainEngineThrottle !== 0) this.thrusterSound.setTargetVolume(1);
             else this.thrusterSound.setTargetVolume(0);
 
-            if (this.landingComputer?.getTarget() === null) {
+            if (!this.isAutoPiloted()) {
                 const speedDifference = forwardSpeed - this.mainEngineTargetSpeed;
                 if (Math.abs(speedDifference) > 2) {
                     if (speedDifference < 0) {

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -413,6 +413,8 @@ export class Spaceship implements Transformable {
         this.aggregate.shape.filterCollideMask = CollisionMask.DYNAMIC_OBJECTS | CollisionMask.ENVIRONMENT;
         this.aggregate.shape.filterMembershipMask = CollisionMask.DYNAMIC_OBJECTS;
 
+        this.landingComputer?.setTarget(null);
+
         this.onLandingCancelled.notifyObservers();
     }
 

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -659,6 +659,8 @@ export class Spaceship implements Transformable {
                     break;
                 case LandingComputerStatusBit.IDLE:
                     break;
+                case LandingComputerStatusBit.NO_LANDING_SPOT:
+                    this.cancelLanding();
             }
         }
 

--- a/src/ts/spaceship/warpDriveUtils.ts
+++ b/src/ts/spaceship/warpDriveUtils.ts
@@ -1,0 +1,83 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { OrbitalObject } from "../architecture/orbitalObject";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { getForwardDirection } from "../uberCore/transforms/basicTransform";
+import { OrbitalObjectType } from "../architecture/orbitalObjectType";
+
+export function canEngageWarpDrive(
+    shipTransform: TransformNode,
+    currentVelocity: number,
+    nearestOrbitalObject: OrbitalObject
+) {
+    const shipPosition = shipTransform.getAbsolutePosition();
+    if (nearestOrbitalObject !== null) {
+        const distanceToObject = Vector3.Distance(
+            shipPosition,
+            nearestOrbitalObject.getTransform().getAbsolutePosition()
+        );
+        if (distanceToObject < nearestOrbitalObject.getBoundingRadius() * 1.03) {
+            return false;
+        }
+    }
+
+    if (
+        nearestOrbitalObject.type === OrbitalObjectType.GAS_PLANET ||
+        nearestOrbitalObject.type === OrbitalObjectType.TELLURIC_PLANET ||
+        nearestOrbitalObject.type === OrbitalObjectType.STAR ||
+        nearestOrbitalObject.type === OrbitalObjectType.NEUTRON_STAR
+    ) {
+        // if the spaceship goes too close to planetary rings, stop the warp drive to avoid collision with asteroids
+        const asteroidField = nearestOrbitalObject.asteroidField;
+        if (asteroidField === null) {
+            return true;
+        }
+
+        const inverseWorld = nearestOrbitalObject.getTransform().getWorldMatrix().clone().invert();
+        const relativePosition = Vector3.TransformCoordinates(shipPosition, inverseWorld);
+        const relativeForward = Vector3.TransformNormal(getForwardDirection(shipTransform), inverseWorld);
+        const distanceAboveRings = relativePosition.y;
+        const planarDistance = Math.sqrt(
+            relativePosition.x * relativePosition.x + relativePosition.z * relativePosition.z
+        );
+
+        const nbSecondsPrediction = 0.5;
+        const nextRelativePosition = relativePosition.add(relativeForward.scale(currentVelocity * nbSecondsPrediction));
+        const nextDistanceAboveRings = nextRelativePosition.y;
+        const nextPlanarDistance = Math.sqrt(
+            nextRelativePosition.x * nextRelativePosition.x + nextRelativePosition.z * nextRelativePosition.z
+        );
+
+        const ringsMinDistance = asteroidField.minRadius;
+        const ringsMaxDistance = asteroidField.maxRadius;
+
+        const isAboveRing = planarDistance > ringsMinDistance && planarDistance < ringsMaxDistance;
+        const willBeAboveRing = nextPlanarDistance > ringsMinDistance && nextPlanarDistance < ringsMaxDistance;
+
+        const isInRing = Math.abs(distanceAboveRings) < asteroidField.patchThickness / 2 && isAboveRing;
+        const willCrossRing =
+            Math.sign(distanceAboveRings) !== Math.sign(nextDistanceAboveRings) && (willBeAboveRing || isAboveRing);
+
+        if (isInRing || willCrossRing) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/ts/spaceship/warpDriveUtils.ts
+++ b/src/ts/spaceship/warpDriveUtils.ts
@@ -38,45 +38,45 @@ export function canEngageWarpDrive(
     }
 
     if (
-        nearestOrbitalObject.type === OrbitalObjectType.GAS_PLANET ||
-        nearestOrbitalObject.type === OrbitalObjectType.TELLURIC_PLANET ||
-        nearestOrbitalObject.type === OrbitalObjectType.STAR ||
-        nearestOrbitalObject.type === OrbitalObjectType.NEUTRON_STAR
+        nearestOrbitalObject.type !== OrbitalObjectType.GAS_PLANET &&
+        nearestOrbitalObject.type !== OrbitalObjectType.TELLURIC_PLANET &&
+        nearestOrbitalObject.type !== OrbitalObjectType.STAR &&
+        nearestOrbitalObject.type !== OrbitalObjectType.NEUTRON_STAR
     ) {
-        // if the spaceship goes too close to planetary rings, stop the warp drive to avoid collision with asteroids
-        const asteroidField = nearestOrbitalObject.asteroidField;
-        if (asteroidField === null) {
-            return true;
-        }
+        return true;
+    }
 
-        const inverseWorld = nearestOrbitalObject.getTransform().getWorldMatrix().clone().invert();
-        const relativePosition = Vector3.TransformCoordinates(shipPosition, inverseWorld);
-        const relativeForward = Vector3.TransformNormal(getForwardDirection(shipTransform), inverseWorld);
-        const distanceAboveRings = relativePosition.y;
-        const planarDistance = Math.sqrt(
-            relativePosition.x * relativePosition.x + relativePosition.z * relativePosition.z
-        );
+    // if the spaceship goes too close to planetary rings, stop the warp drive to avoid collision with asteroids
+    const asteroidField = nearestOrbitalObject.asteroidField;
+    if (asteroidField === null) {
+        return true;
+    }
 
-        const nbSecondsPrediction = 0.5;
-        const nextRelativePosition = relativePosition.add(relativeForward.scale(currentVelocity * nbSecondsPrediction));
-        const nextDistanceAboveRings = nextRelativePosition.y;
-        const nextPlanarDistance = Math.sqrt(
-            nextRelativePosition.x * nextRelativePosition.x + nextRelativePosition.z * nextRelativePosition.z
-        );
+    const inverseWorld = nearestOrbitalObject.getTransform().getWorldMatrix().clone().invert();
+    const relativePosition = Vector3.TransformCoordinates(shipPosition, inverseWorld);
+    const relativeForward = Vector3.TransformNormal(getForwardDirection(shipTransform), inverseWorld);
+    const distanceAboveRings = relativePosition.y;
+    const planarDistance = Math.sqrt(relativePosition.x * relativePosition.x + relativePosition.z * relativePosition.z);
 
-        const ringsMinDistance = asteroidField.minRadius;
-        const ringsMaxDistance = asteroidField.maxRadius;
+    const nbSecondsPrediction = 0.5;
+    const nextRelativePosition = relativePosition.add(relativeForward.scale(currentVelocity * nbSecondsPrediction));
+    const nextDistanceAboveRings = nextRelativePosition.y;
+    const nextPlanarDistance = Math.sqrt(
+        nextRelativePosition.x * nextRelativePosition.x + nextRelativePosition.z * nextRelativePosition.z
+    );
 
-        const isAboveRing = planarDistance > ringsMinDistance && planarDistance < ringsMaxDistance;
-        const willBeAboveRing = nextPlanarDistance > ringsMinDistance && nextPlanarDistance < ringsMaxDistance;
+    const ringsMinDistance = asteroidField.minRadius;
+    const ringsMaxDistance = asteroidField.maxRadius;
 
-        const isInRing = Math.abs(distanceAboveRings) < asteroidField.patchThickness / 2 && isAboveRing;
-        const willCrossRing =
-            Math.sign(distanceAboveRings) !== Math.sign(nextDistanceAboveRings) && (willBeAboveRing || isAboveRing);
+    const isAboveRing = planarDistance > ringsMinDistance && planarDistance < ringsMaxDistance;
+    const willBeAboveRing = nextPlanarDistance > ringsMinDistance && nextPlanarDistance < ringsMaxDistance;
 
-        if (isInRing || willCrossRing) {
-            return false;
-        }
+    const isInRing = Math.abs(distanceAboveRings) < asteroidField.patchThickness / 2 && isAboveRing;
+    const willCrossRing =
+        Math.sign(distanceAboveRings) !== Math.sign(nextDistanceAboveRings) && (willBeAboveRing || isAboveRing);
+
+    if (isInRing || willCrossRing) {
+        return false;
     }
 
     return true;

--- a/src/ts/spacestation/spaceStationModelGenerator.ts
+++ b/src/ts/spacestation/spaceStationModelGenerator.ts
@@ -50,6 +50,15 @@ export function newSeededSpaceStationModel(
             radius += body.accretionDiskRadius;
         }
 
+        if (
+            body.type === OrbitalObjectType.GAS_PLANET ||
+            body.type === OrbitalObjectType.TELLURIC_PLANET ||
+            body.type === OrbitalObjectType.STAR ||
+            body.type === OrbitalObjectType.NEUTRON_STAR
+        ) {
+            radius += (body.rings?.ringEnd ?? 0) * body.radius;
+        }
+
         return radius;
     }, 0);
     const orbitRadius = (2 + clamp(normalRandom(2, 1, rng, GenerationSteps.ORBIT), 0, 10)) * parentMaxRadius;

--- a/src/ts/starSystem/starSystemController.ts
+++ b/src/ts/starSystem/starSystemController.ts
@@ -576,10 +576,7 @@ export class StarSystemController {
             controlsPosition
         );
 
-        const shouldCompensateTranslation =
-            distanceOfNearestToControls <
-            nearestOrbitalObject.getBoundingRadius() *
-                (nearestOrbitalObject.model.type === OrbitalObjectType.SPACE_STATION ? 200 : 10);
+        const shouldCompensateTranslation = true;
 
         // compensate rotation when close to the body
         let shouldCompensateRotation = distanceOfNearestToControls < nearestOrbitalObject.getBoundingRadius() * 3;

--- a/src/ts/utils/algebra.ts
+++ b/src/ts/utils/algebra.ts
@@ -27,6 +27,18 @@ export function getTransformationQuaternion(from: Vector3, to: Vector3): Quatern
     return Quaternion.RotationAxis(rotationAxis, angle);
 }
 
+export function getDeltaQuaternion(from: Quaternion, to: Quaternion): Quaternion {
+    return to.multiply(from.conjugate());
+}
+
+export function getAngleFromQuaternion(quaternion: Quaternion): number {
+    return 2 * Math.acos(quaternion.w);
+}
+
+export function getAxisFromQuaternion(quaternion: Quaternion): Vector3 {
+    return new Vector3(quaternion.x, quaternion.y, quaternion.z).normalize();
+}
+
 export function flattenVector3Array(vector3Array: Vector3[]): number[] {
     const result: number[] = [];
     for (const vector3 of vector3Array) {

--- a/src/ts/utils/asteroidFields.ts
+++ b/src/ts/utils/asteroidFields.ts
@@ -1,0 +1,40 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { AsteroidField } from "../asteroidFields/asteroidField";
+
+export function distanceToAsteroidField(position: Vector3, asteroidField: AsteroidField) {
+    const celestialBody = asteroidField.parent;
+    const celestialBodyPosition = celestialBody.position;
+
+    const relativePosition = position.subtract(celestialBodyPosition);
+    const distanceAboveRings = Math.abs(Vector3.Dot(relativePosition, celestialBody.up));
+    const planarDistance = relativePosition.subtract(celestialBody.up.scale(distanceAboveRings)).length();
+
+    const ringsMinDistance = asteroidField.minRadius;
+    const ringsMaxDistance = asteroidField.maxRadius;
+
+    const isAboveRings = planarDistance > ringsMinDistance && planarDistance < ringsMaxDistance;
+
+    return isAboveRings
+        ? Math.abs(distanceAboveRings)
+        : Math.sqrt(
+              Math.min((planarDistance - ringsMinDistance) ** 2, (planarDistance - ringsMaxDistance) ** 2) +
+                  distanceAboveRings ** 2
+          );
+}

--- a/src/ts/utils/notification.ts
+++ b/src/ts/utils/notification.ts
@@ -29,8 +29,12 @@ class Notification {
     private isBeingRemoved = false;
 
     constructor(origin: NotificationOrigin, intent: NotificationIntent, text: string, durationSeconds: number) {
-        const container = document.getElementById("notificationContainer");
-        if (container === null) throw new Error("No notification container found");
+        let container = document.getElementById("notificationContainer");
+        if (container === null) {
+            container = document.createElement("div");
+            container.id = "notificationContainer";
+            document.body.appendChild(container);
+        }
 
         this.htmlRoot = document.createElement("div");
         this.htmlRoot.classList.add("notification", origin);


### PR DESCRIPTION
## Related Tickets

Fixes #227 

## Description

The goal of this PR is to make spaceship landing more predictable by leveraging the physics engine in a cleaner way.

This is also an opportunity to extract this logic to a new component called the "Landing Computer".

The landing computer also unifies landing pad and surface landing procedures.

## Unexpected difficulties

Torque is not mentionned in Havok, it is called angular impulse instead.

## How to test

Try to land on any space station and on any planetary surface. Landing should either succeed or time out.

Known issue: when landing on planetary surfaces the spaceship wings can get stuck in the ground. A more durable solution will be needed, possibly by adding landing legs.

## Follow-up

Further auto pilot can be implemented for NPCs in the future. And surface landing can still be improved.
