### PR TITLE
Make neutron stars matter jets volumetric

### DIFF
--- a/src/shaders/matterjet.glsl
+++ b/src/shaders/matterjet.glsl
@@ -26,6 +26,8 @@ uniform float time;
 
 uniform mat4 inverseRotation;
 
+uniform float dipoleTilt;
+
 #include "./utils/camera.glsl";
 
 #include "./utils/object.glsl";
@@ -241,7 +243,7 @@ void main() {
     vec3 rayOriginLocalSpace = mat3(inverseRotation) * (camera_position - object_position) / scaling_factor;
     vec3 rayDirLocalSpace = mat3(inverseRotation) * rayDir;
 
-    float coneTheta = 0.2;
+    float coneTheta = dipoleTilt;
     float coneHeight = 100.0;
 
     vec3 color = screenColor.rgb;

--- a/src/shaders/matterjet.glsl
+++ b/src/shaders/matterjet.glsl
@@ -213,7 +213,7 @@ vec3 rayMarchSpiral(vec3 rayOrigin, vec3 rayDir, float distThrough, int nbSteps,
     for(int i = 0; i < nbSteps; i++) {
         vec3 p = rayOrigin + float(i) * stepSize * rayDir;
 
-        float density = spiralDensity(p, coneTheta * 0.2, coneHeight);
+        float density = spiralDensity(p, coneTheta * 0.7, coneHeight);
     
         vec3 emission = 10.0 * vec3(0.3, 0.6, 1.0) * density;
         float absorption = 0.2 * density;

--- a/src/shaders/matterjet.glsl
+++ b/src/shaders/matterjet.glsl
@@ -66,7 +66,7 @@ float spiralDensity(vec3 p, float coneTheta, float coneHeight) {
 
     float density = 1.0;
 
-    density *= exp(-0.1 * dist * dist);
+    density *= exp(-0.02 * dist * dist);
     
     density *= 1.0 - smoothstep(0.0, 1.0, heightFraction);
     
@@ -215,7 +215,7 @@ vec3 rayMarchSpiral(vec3 rayOrigin, vec3 rayDir, float distThrough, int nbSteps,
 
         float density = spiralDensity(p, coneTheta * 0.7, coneHeight);
     
-        vec3 emission = 10.0 * vec3(0.3, 0.6, 1.0) * density;
+        vec3 emission = 3.0 * vec3(0.3, 0.6, 1.0) * density;
         float absorption = 0.2 * density;
     
         transmittance *= exp(-absorption * stepSize);

--- a/src/shaders/matterjet.glsl
+++ b/src/shaders/matterjet.glsl
@@ -44,7 +44,7 @@ float sdSpiral(vec3 p, float coneTheta, float frequency) {
     // Y-axis is now the spiral direction
     float spiralPos = p.y; // Using Y instead of Z
     float radius = spiralPos * tan(coneTheta);
-    float theta = frequency * spiralPos - sign(spiralPos) * time * 20.0;
+    float theta = frequency * spiralPos;
     
     // Spiral now wraps around Y-axis
     vec3 spiralPoint = vec3(

--- a/src/ts/playground.ts
+++ b/src/ts/playground.ts
@@ -30,6 +30,7 @@ import { createDebugAssetsScene } from "./playgrounds/debugAssets";
 import { createSpaceStationScene } from "./playgrounds/spaceStation";
 import { createXrScene } from "./playgrounds/xr";
 import { createFlightDemoScene } from "./playgrounds/flightDemo";
+import { createNeutronStarScene } from "./playgrounds/neutronStar";
 
 const canvas = document.getElementById("renderer") as HTMLCanvasElement;
 canvas.width = window.innerWidth;
@@ -64,6 +65,9 @@ switch (requestedScene) {
         break;
     case "flightDemo":
         scene = await createFlightDemoScene(engine);
+        break;
+    case "neutronStar":
+        scene = await createNeutronStarScene(engine);
         break;
     default:
         scene = await createAutomaticLandingScene(engine);

--- a/src/ts/playgrounds/neutronStar.ts
+++ b/src/ts/playgrounds/neutronStar.ts
@@ -26,7 +26,7 @@ import { MatterJetPostProcess } from "../postProcesses/matterJetPostProcess";
 import { VolumetricLight } from "../volumetricLight/volumetricLight";
 import { translate } from "../uberCore/transforms/basicTransform";
 import { Textures } from "../assets/textures";
-import { AssetsManager } from "@babylonjs/core";
+import { AssetsManager, Axis } from "@babylonjs/core";
 import { LensFlarePostProcess } from "../postProcesses/lensFlarePostProcess";
 import { getRgbFromTemperature } from "../utils/specrend";
 
@@ -79,6 +79,8 @@ export async function createNeutronStarScene(engine: AbstractEngine): Promise<Sc
     scene.onBeforePhysicsObservable.add(() => {
         const deltaSeconds = engine.getDeltaTime() / 1000;
         const displacement = defaultControls.update(deltaSeconds);
+
+        neutronStar.getTransform().rotate(Axis.Y, (2 * Math.PI * deltaSeconds) / neutronStarModel.siderealDaySeconds);
 
         translate(defaultControls.getTransform(), displacement.negate());
         translate(neutronStar.getTransform(), displacement.negate());

--- a/src/ts/playgrounds/neutronStar.ts
+++ b/src/ts/playgrounds/neutronStar.ts
@@ -57,7 +57,12 @@ export async function createNeutronStarScene(engine: AbstractEngine): Promise<Sc
     const volumetricLight = new VolumetricLight(neutronStar.mesh, neutronStar.volumetricLightUniforms, [], scene);
     camera.attachPostProcess(volumetricLight);
 
-    const matterJets = new MatterJetPostProcess(neutronStar.getTransform(), neutronStar.getRadius(), scene);
+    const matterJets = new MatterJetPostProcess(
+        neutronStar.getTransform(),
+        neutronStar.getRadius(),
+        neutronStar.model.dipoleTilt,
+        scene
+    );
     camera.attachPostProcess(matterJets);
 
     const lensFlare = new LensFlarePostProcess(

--- a/src/ts/playgrounds/neutronStar.ts
+++ b/src/ts/playgrounds/neutronStar.ts
@@ -1,0 +1,72 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { Scene } from "@babylonjs/core/scene";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { enablePhysics } from "./utils";
+import { DefaultControls } from "../defaultControls/defaultControls";
+import { Assets } from "../assets/assets";
+import { NeutronStar } from "../stellarObjects/neutronStar/neutronStar";
+import { newSeededNeutronStarModel } from "../stellarObjects/neutronStar/neutronStarModelGenerator";
+import { MatterJetPostProcess } from "../postProcesses/matterJetPostProcess";
+import { VolumetricLight } from "../volumetricLight/volumetricLight";
+import { translate } from "../uberCore/transforms/basicTransform";
+
+export async function createNeutronStarScene(engine: AbstractEngine): Promise<Scene> {
+    const scene = new Scene(engine);
+    scene.useRightHandedSystem = true;
+
+    await enablePhysics(scene);
+
+    await Assets.Init(scene);
+
+    const defaultControls = new DefaultControls(scene);
+    defaultControls.speed = 2000;
+
+    const camera = defaultControls.getActiveCamera();
+    camera.attachControl();
+
+    scene.activeCamera = camera;
+
+    scene.enableDepthRenderer(camera, false, true);
+
+    const neutronStarModel = newSeededNeutronStarModel(456, "Neutron Star Demo", []);
+    const neutronStar = new NeutronStar(neutronStarModel, scene);
+    neutronStar.getTransform().position = new Vector3(0, 0, 1).scaleInPlace(neutronStar.getRadius() * 10);
+
+    const volumetricLight = new VolumetricLight(neutronStar.mesh, neutronStar.volumetricLightUniforms, [], scene);
+    camera.attachPostProcess(volumetricLight);
+
+    const matterJets = new MatterJetPostProcess(neutronStar.getTransform(), neutronStar.getRadius(), scene);
+    camera.attachPostProcess(matterJets);
+
+    camera.maxZ = neutronStar.getRadius() * 100;
+    defaultControls.getTransform().lookAt(neutronStar.getTransform().position);
+
+    scene.onBeforePhysicsObservable.add(() => {
+        const deltaSeconds = engine.getDeltaTime() / 1000;
+        const displacement = defaultControls.update(deltaSeconds);
+
+        translate(defaultControls.getTransform(), displacement.negate());
+        translate(neutronStar.getTransform(), displacement.negate());
+
+        matterJets.update(deltaSeconds);
+    });
+
+    return scene;
+}

--- a/src/ts/postProcesses/matterJetPostProcess.ts
+++ b/src/ts/postProcesses/matterJetPostProcess.ts
@@ -27,11 +27,11 @@ import { Constants } from "@babylonjs/core/Engines/constants";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { Matrix } from "@babylonjs/core/Maths/math.vector";
 
 export type MatterJetUniforms = {
-    // the rotation period in seconds of the matter jet
-    rotationPeriod: number;
-    time: number;
+    elapsedSeconds: number;
+    inverseRotation: Matrix;
 };
 
 /**
@@ -49,14 +49,13 @@ export class MatterJetPostProcess extends PostProcess implements UpdatablePostPr
         }
 
         const settings: MatterJetUniforms = {
-            rotationPeriod: 1.5,
-            time: 0
+            elapsedSeconds: 0,
+            inverseRotation: Matrix.Identity()
         };
 
         const MatterJetUniformNames = {
             TIME: "time",
-            ROTATION_PERIOD: "rotationPeriod",
-            ROTATION_AXIS: "rotationAxis"
+            INVERSE_ROTATION: "inverseRotation"
         };
 
         const uniforms: string[] = [
@@ -95,18 +94,18 @@ export class MatterJetPostProcess extends PostProcess implements UpdatablePostPr
             setCameraUniforms(effect, this.activeCamera);
             setObjectUniforms(effect, stellarTransform, boundingRadius);
 
-            effect.setFloat(
-                MatterJetUniformNames.TIME,
-                this.matterJetUniforms.time % (this.matterJetUniforms.rotationPeriod * 10000)
-            );
-            effect.setFloat(MatterJetUniformNames.ROTATION_PERIOD, this.matterJetUniforms.rotationPeriod);
-            effect.setVector3(MatterJetUniformNames.ROTATION_AXIS, stellarTransform.up);
+            effect.setFloat(MatterJetUniformNames.TIME, this.matterJetUniforms.elapsedSeconds % 10000);
+
+            stellarTransform.getWorldMatrix().getRotationMatrixToRef(this.matterJetUniforms.inverseRotation);
+            this.matterJetUniforms.inverseRotation.transposeToRef(this.matterJetUniforms.inverseRotation);
+
+            effect.setMatrix(MatterJetUniformNames.INVERSE_ROTATION, this.matterJetUniforms.inverseRotation);
 
             setSamplerUniforms(effect, this.activeCamera, scene);
         });
     }
 
-    public update(deltaTime: number): void {
-        this.matterJetUniforms.time += deltaTime;
+    public update(deltaSeconds: number): void {
+        this.matterJetUniforms.elapsedSeconds += deltaSeconds;
     }
 }

--- a/src/ts/postProcesses/matterJetPostProcess.ts
+++ b/src/ts/postProcesses/matterJetPostProcess.ts
@@ -32,17 +32,18 @@ import { Matrix } from "@babylonjs/core/Maths/math.vector";
 export type MatterJetUniforms = {
     elapsedSeconds: number;
     inverseRotation: Matrix;
+    dipoleTilt: number;
 };
 
 /**
  * Post process for rendering matter jets that are used by neutron stars for example
  */
 export class MatterJetPostProcess extends PostProcess implements UpdatablePostProcess {
-    matterJetUniforms: MatterJetUniforms;
+    readonly matterJetUniforms: MatterJetUniforms;
 
     private activeCamera: Camera | null = null;
 
-    constructor(stellarTransform: TransformNode, boundingRadius: number, scene: Scene) {
+    constructor(stellarTransform: TransformNode, boundingRadius: number, dipoleTilt: number, scene: Scene) {
         const shaderName = "matterjet";
         if (Effect.ShadersStore[`${shaderName}FragmentShader`] === undefined) {
             Effect.ShadersStore[`${shaderName}FragmentShader`] = matterJetFragment;
@@ -50,12 +51,14 @@ export class MatterJetPostProcess extends PostProcess implements UpdatablePostPr
 
         const settings: MatterJetUniforms = {
             elapsedSeconds: 0,
-            inverseRotation: Matrix.Identity()
+            inverseRotation: Matrix.Identity(),
+            dipoleTilt: dipoleTilt
         };
 
         const MatterJetUniformNames = {
             TIME: "time",
-            INVERSE_ROTATION: "inverseRotation"
+            INVERSE_ROTATION: "inverseRotation",
+            DIPOLE_TILT: "dipoleTilt"
         };
 
         const uniforms: string[] = [
@@ -100,6 +103,8 @@ export class MatterJetPostProcess extends PostProcess implements UpdatablePostPr
             this.matterJetUniforms.inverseRotation.transposeToRef(this.matterJetUniforms.inverseRotation);
 
             effect.setMatrix(MatterJetUniformNames.INVERSE_ROTATION, this.matterJetUniforms.inverseRotation);
+
+            effect.setFloat(MatterJetUniformNames.DIPOLE_TILT, this.matterJetUniforms.dipoleTilt);
 
             setSamplerUniforms(effect, this.activeCamera, scene);
         });

--- a/src/ts/postProcesses/postProcessManager.ts
+++ b/src/ts/postProcesses/postProcessManager.ts
@@ -321,6 +321,7 @@ export class PostProcessManager {
         const matterJets = new MatterJetPostProcess(
             neutronStar.getTransform(),
             neutronStar.getBoundingRadius(),
+            neutronStar.model.dipoleTilt,
             this.scene
         );
         this.matterJets.push(matterJets);

--- a/src/ts/stellarObjects/neutronStar/neutronStarModel.ts
+++ b/src/ts/stellarObjects/neutronStar/neutronStarModel.ts
@@ -16,13 +16,19 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { HasSeed } from "../../architecture/hasSeed";
-import { OrbitalObjectModelBase } from "../../architecture/orbitalObjectModelBase";
+import { CelestialBodyModelBase } from "../../architecture/orbitalObjectModelBase";
 import { OrbitalObjectType } from "../../architecture/orbitalObjectType";
 import { RingsModel } from "../../rings/ringsModel";
 
-export type NeutronStarModel = OrbitalObjectModelBase<OrbitalObjectType.NEUTRON_STAR> &
+export type NeutronStarModel = CelestialBodyModelBase<OrbitalObjectType.NEUTRON_STAR> &
     HasSeed & {
         readonly blackBodyTemperature: number;
-        readonly radius: number;
+
+        /**
+         * The angle between the magnetic dipole axis and the rotation axis.
+         * If the magnetic field were perfectly aligned with the rotation axis, this angle would be 0.
+         */
+        readonly dipoleTilt: number;
+
         readonly rings: RingsModel | null;
     };

--- a/src/ts/stellarObjects/neutronStar/neutronStarModelGenerator.ts
+++ b/src/ts/stellarObjects/neutronStar/neutronStarModelGenerator.ts
@@ -40,7 +40,7 @@ export function newSeededNeutronStarModel(
 ): NeutronStarModel {
     const rng = getRngFromSeed(seed);
 
-    const mass = 1000;
+    const mass = 1.9885e30; //TODO: compute mass from physical properties
 
     // https://arxiv.org/pdf/2402.14030 and https://en.wikipedia.org/wiki/Neutron_star#:~:text=Because%20it%20has%20only%20a,1.4%20ms%20to%2030%20s.
     const siderealDaySeconds = clamp(1.4e-3, 30, normalRandom(0.5e-2, 5e-3, rng, GenerationSteps.SIDEREAL_DAY_SECONDS));

--- a/src/ts/stellarObjects/neutronStar/neutronStarModelGenerator.ts
+++ b/src/ts/stellarObjects/neutronStar/neutronStarModelGenerator.ts
@@ -25,6 +25,14 @@ import { OrbitalObjectModel } from "../../architecture/orbitalObjectModel";
 import { NeutronStarModel } from "./neutronStarModel";
 import { OrbitalObjectType } from "../../architecture/orbitalObjectType";
 
+/**
+ * Creates a new pseudo-random neutron star model
+ * @param seed The seed to use for the pseudo-random number generator
+ * @param name The name of the neutron star
+ * @param parentBodies The parent bodies of the neutron star (an empty array if it is the primary body of the system)
+ * @returns A new neutron star model
+ * @see https://arxiv.org/pdf/2402.14030 "On the initial spin period distribution of neutron stars"
+ */
 export function newSeededNeutronStarModel(
     seed: number,
     name: string,
@@ -32,10 +40,12 @@ export function newSeededNeutronStarModel(
 ): NeutronStarModel {
     const rng = getRngFromSeed(seed);
 
-    const temperature = randRangeInt(200_000, 5_000_000_000, rng, GenerationSteps.TEMPERATURE);
     const mass = 1000;
-    const siderealDaySeconds = 24 * 60 * 60;
-    const blackBodyTemperature = temperature;
+
+    // https://arxiv.org/pdf/2402.14030 and https://en.wikipedia.org/wiki/Neutron_star#:~:text=Because%20it%20has%20only%20a,1.4%20ms%20to%2030%20s.
+    const siderealDaySeconds = clamp(1.4e-3, 30, normalRandom(0.5e-2, 5e-3, rng, GenerationSteps.SIDEREAL_DAY_SECONDS));
+
+    const blackBodyTemperature = randRangeInt(200_000, 5_000_000_000, rng, GenerationSteps.TEMPERATURE);
     const axialTilt = 0;
 
     const radius = clamp(normalRandom(10e3, 1e3, rng, GenerationSteps.RADIUS), 2e3, 50e3);

--- a/src/ts/stellarObjects/neutronStar/neutronStarModelGenerator.ts
+++ b/src/ts/stellarObjects/neutronStar/neutronStarModelGenerator.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Orbit } from "../../orbit/orbit";
-import { normalRandom, randRangeInt, uniformRandBool } from "extended-random";
+import { normalRandom, randRange, randRangeInt, uniformRandBool } from "extended-random";
 import { clamp } from "../../utils/math";
 import { newSeededRingsModel } from "../../rings/ringsModel";
 import { GenerationSteps } from "../../utils/generationSteps";
@@ -40,6 +40,8 @@ export function newSeededNeutronStarModel(
 
     const radius = clamp(normalRandom(10e3, 1e3, rng, GenerationSteps.RADIUS), 2e3, 50e3);
 
+    const dipoleTilt = randRange(-Math.PI / 3, Math.PI / 3, rng, GenerationSteps.DIPOLE_TILT);
+
     // Todo: do not hardcode
     const orbitRadius = rng(GenerationSteps.ORBIT) * 5000000e3;
 
@@ -58,15 +60,16 @@ export function newSeededNeutronStarModel(
     const rings = uniformRandBool(ringProportion, rng, GenerationSteps.RINGS) ? newSeededRingsModel(rng) : null;
 
     return {
-        name: name,
-        seed: seed,
         type: OrbitalObjectType.NEUTRON_STAR,
-        blackBodyTemperature: blackBodyTemperature,
+        name,
+        seed,
+        blackBodyTemperature,
+        dipoleTilt,
         mass,
         siderealDaySeconds,
         axialTilt,
-        radius: radius,
-        orbit: orbit,
-        rings: rings
+        radius,
+        orbit,
+        rings
     };
 }

--- a/src/ts/stellarObjects/neutronStar/neutronStarModelGenerator.ts
+++ b/src/ts/stellarObjects/neutronStar/neutronStarModelGenerator.ts
@@ -50,7 +50,7 @@ export function newSeededNeutronStarModel(
 
     const radius = clamp(normalRandom(10e3, 1e3, rng, GenerationSteps.RADIUS), 2e3, 50e3);
 
-    const dipoleTilt = randRange(-Math.PI / 3, Math.PI / 3, rng, GenerationSteps.DIPOLE_TILT);
+    const dipoleTilt = randRange(-Math.PI / 6, Math.PI / 6, rng, GenerationSteps.DIPOLE_TILT);
 
     // Todo: do not hardcode
     const orbitRadius = rng(GenerationSteps.ORBIT) * 5000000e3;

--- a/src/ts/stellarObjects/star/starMaterialLut.ts
+++ b/src/ts/stellarObjects/star/starMaterialLut.ts
@@ -27,7 +27,7 @@ export class StarMaterialLut {
             Effect.ShadersStore["starLutFragmentShader"] = lutFragment;
         }
 
-        this.lut = new ProceduralTexture(`StarMaterialLut`, 4096, "starLut", scene, null, true, false);
+        this.lut = new ProceduralTexture(`StarMaterialLut`, 256, "starLut", scene, null, true, false);
         this.lut.refreshRate = 0;
     }
 

--- a/src/ts/utils/generationSteps.ts
+++ b/src/ts/utils/generationSteps.ts
@@ -33,5 +33,7 @@ export const enum GenerationSteps {
     WATER_AMOUNT = 1700,
     TERRAIN = 1500,
 
-    DIPOLE_TILT = 1300
+    DIPOLE_TILT = 1300,
+
+    SIDEREAL_DAY_SECONDS = 2500
 }

--- a/src/ts/utils/generationSteps.ts
+++ b/src/ts/utils/generationSteps.ts
@@ -31,5 +31,7 @@ export const enum GenerationSteps {
 
     PRESSURE = 1800,
     WATER_AMOUNT = 1700,
-    TERRAIN = 1500
+    TERRAIN = 1500,
+
+    DIPOLE_TILT = 1300
 }

--- a/src/ts/volumetricLight/volumetricLight.ts
+++ b/src/ts/volumetricLight/volumetricLight.ts
@@ -29,7 +29,7 @@ export class VolumetricLight extends VolumetricLightScatteringPostProcess {
         excludedMeshes: AbstractMesh[],
         scene: Scene
     ) {
-        if (scene.activeCameras === null || scene.activeCameras.length === 0) throw new Error("no camera");
+        if (scene.activeCamera === null) throw new Error("no camera");
         super(
             `${starMesh.name}VolumetricLight`,
             1,


### PR DESCRIPTION
## Related Tickets

Fixes #268 

## Description

This makes the neutron star's matter jets volumetric, making them look much better.

## Unexpected difficulties

Scaling raymarching to those absurd scales is always a challenge. Although the code from Deepseek was ok, it breaks down the further away you get.

The solution is to start raymarching close to the matter jet instead of starting at the camera's position.

This can be achieved by computing the intersection between the view ray and the cone that contains the matter jets as demonstrated here: https://www.shadertoy.com/view/MtcXWr

This worked very well, until you tried getting inside the matter jets where it would look horrendous. I had to adapt the ray-cone intersection function to get 2 points, handle the base of the cone, and handle cases where the camera is inside the cone. o3-mini did most of that adptation work, and I optimized it further afterward.

## How to test

In a system with a neutron star, you should see something like that:

![screenshot_25-2-16_15-53](https://github.com/user-attachments/assets/c342ed76-1b52-4da1-a12b-1ffe16e90a9b)

This save is inside a star system with a neutron star: 

[Barth_1739717680643.json](https://github.com/user-attachments/files/18815092/Barth_1739717680643.json)

You can also start the associated playground at http://localhost:8080/playground.html?scene=neutronStar

## Follow-up

Well it can always be more beautiful! 

On the gameplay side, I would like to implement something akin to Elite Dangerous' "neutron star highway" where going inside the matter jet extends the jump range of the ship.
