### PR TITLE
Add first person view

### DIFF
--- a/src/ts/characterControls/characterControls.ts
+++ b/src/ts/characterControls/characterControls.ts
@@ -203,7 +203,7 @@ export class CharacterControls implements Controls {
         }
         this.characterNode = characterNode;
 
-        const headBoneIndex = skeleton.getBoneIndexByName("mixamorig:Head");
+        const headBoneIndex = skeleton.getBoneIndexByName("mixamorig:HeadTop_End");
 
         this.headTransform = new TransformNode("headTransform", scene);
         this.headTransform.scaling.scaleInPlace(20);

--- a/src/ts/characterControls/characterControls.ts
+++ b/src/ts/characterControls/characterControls.ts
@@ -190,6 +190,7 @@ export class CharacterControls implements Controls {
         this.firstPersonCamera = new FreeCamera("characterFirstPersonCamera", Vector3.Zero(), scene);
         this.firstPersonCamera.minZ = 0.2;
         this.firstPersonCamera.parent = this.getTransform();
+        this.firstPersonCamera.rotationQuaternion = Quaternion.Identity();
 
         const skeleton = this.character.getChildMeshes().find((mesh) => mesh.skeleton !== null)?.skeleton;
         if (skeleton === undefined || skeleton === null) throw new Error("Skeleton not found");

--- a/src/ts/characterControls/characterControls.ts
+++ b/src/ts/characterControls/characterControls.ts
@@ -263,6 +263,10 @@ export class CharacterControls implements Controls {
         return this.character;
     }
 
+    public shouldLockPointer(): boolean {
+        return true;
+    }
+
     public update(deltaSeconds: number): Vector3 {
         const inverseTransform = this.getTransform().getWorldMatrix().clone().invert();
         this.firstPersonCamera.position = Vector3.TransformCoordinates(

--- a/src/ts/characterControls/characterControls.ts
+++ b/src/ts/characterControls/characterControls.ts
@@ -25,7 +25,7 @@ import { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
 import { CollisionMask, Settings } from "../settings";
 import { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
 import { PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
-import { Quaternion } from "@babylonjs/core/Maths/math";
+import { Axis, Quaternion, Space } from "@babylonjs/core/Maths/math";
 import "@babylonjs/core/Collisions/collisionCoordinator";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
@@ -188,9 +188,9 @@ export class CharacterControls implements Controls {
         this.targetAnim = this.idleAnim;
 
         this.firstPersonCamera = new FreeCamera("characterFirstPersonCamera", Vector3.Zero(), scene);
+        this.firstPersonCamera.speed = 0;
         this.firstPersonCamera.minZ = 0.2;
         this.firstPersonCamera.parent = this.getTransform();
-        this.firstPersonCamera.rotationQuaternion = Quaternion.Identity();
 
         const skeleton = this.character.getChildMeshes().find((mesh) => mesh.skeleton !== null)?.skeleton;
         if (skeleton === undefined || skeleton === null) throw new Error("Skeleton not found");
@@ -247,6 +247,11 @@ export class CharacterControls implements Controls {
             this.headTransform.getAbsolutePosition(),
             inverseTransform
         );
+
+        this.getTransform().rotate(Axis.Y, this.firstPersonCamera.rotation.y, Space.LOCAL);
+        this.getTransform().computeWorldMatrix(true);
+        this.firstPersonCamera.rotation.y = 0;
+        this.firstPersonCamera.getViewMatrix(true);
 
         const character = this.getTransform();
         const start = character.getAbsolutePosition().add(character.up.scale(50e3));
@@ -426,6 +431,7 @@ export class CharacterControls implements Controls {
 
     dispose() {
         this.character.dispose();
+        this.firstPersonCamera.dispose();
         this.thirdPersonCamera.dispose();
     }
 }

--- a/src/ts/characterControls/characterControls.ts
+++ b/src/ts/characterControls/characterControls.ts
@@ -188,6 +188,8 @@ export class CharacterControls implements Controls {
         this.targetAnim = this.idleAnim;
 
         this.firstPersonCamera = new FreeCamera("characterFirstPersonCamera", Vector3.Zero(), scene);
+        this.firstPersonCamera.minZ = 0.2;
+        this.firstPersonCamera.parent = this.getTransform();
 
         const skeleton = this.character.getChildMeshes().find((mesh) => mesh.skeleton !== null)?.skeleton;
         if (skeleton === undefined || skeleton === null) throw new Error("Skeleton not found");
@@ -205,8 +207,6 @@ export class CharacterControls implements Controls {
         this.headTransform = new TransformNode("headTransform", scene);
         this.headTransform.scaling.scaleInPlace(20);
         this.headTransform.attachToBone(skeleton.bones[headBoneIndex], characterNode);
-
-        this.firstPersonCamera.parent = this.headTransform;
 
         this.thirdPersonCamera = new ArcRotateCamera(
             "characterThirdPersonCamera",
@@ -241,6 +241,12 @@ export class CharacterControls implements Controls {
     }
 
     public update(deltaTime: number): Vector3 {
+        const inverseTransform = this.getTransform().getWorldMatrix().clone().invert();
+        this.firstPersonCamera.position = Vector3.TransformCoordinates(
+            this.headTransform.getAbsolutePosition(),
+            inverseTransform
+        );
+
         const character = this.getTransform();
         const start = character.getAbsolutePosition().add(character.up.scale(50e3));
         const end = character.position.add(character.up.scale(-50e3));

--- a/src/ts/characterControls/characterControls.ts
+++ b/src/ts/characterControls/characterControls.ts
@@ -79,6 +79,7 @@ export class CharacterControls implements Controls {
 
     private readonly firstPersonCamera: FreeCamera;
     private readonly thirdPersonCamera: ArcRotateCamera;
+    private activeCamera: Camera;
 
     private readonly characterWalkSpeed = 1.8;
     private readonly characterWalkSpeedBackwards = 1.2;
@@ -189,7 +190,7 @@ export class CharacterControls implements Controls {
 
         this.firstPersonCamera = new FreeCamera("characterFirstPersonCamera", Vector3.Zero(), scene);
         this.firstPersonCamera.speed = 0;
-        this.firstPersonCamera.minZ = 0.2;
+        this.firstPersonCamera.minZ = 1;
         this.firstPersonCamera.parent = this.getTransform();
 
         const skeleton = this.character.getChildMeshes().find((mesh) => mesh.skeleton !== null)?.skeleton;
@@ -211,9 +212,9 @@ export class CharacterControls implements Controls {
 
         this.thirdPersonCamera = new ArcRotateCamera(
             "characterThirdPersonCamera",
-            1.0,
-            -Math.PI / 4,
-            40,
+            -1.0,
+            Math.PI / 3,
+            10,
             new Vector3(0, 1.5, 0),
             scene
         );
@@ -223,6 +224,27 @@ export class CharacterControls implements Controls {
         this.thirdPersonCamera.maxZ = Settings.EARTH_RADIUS * 5;
         this.thirdPersonCamera.wheelPrecision *= 3;
         this.thirdPersonCamera.parent = this.getTransform();
+
+        this.activeCamera = this.firstPersonCamera;
+        this.setFirstPersonCameraActive();
+
+        CharacterInputs.map.toggleCamera.on("complete", () => {
+            if (this.getActiveCamera() === this.thirdPersonCamera) {
+                this.setFirstPersonCameraActive();
+            } else {
+                this.setThirdPersonCameraActive();
+            }
+        });
+    }
+
+    public setFirstPersonCameraActive() {
+        this.activeCamera = this.firstPersonCamera;
+        this.character.getChildMeshes().forEach((mesh) => mesh.setEnabled(false));
+    }
+
+    public setThirdPersonCameraActive() {
+        this.activeCamera = this.thirdPersonCamera;
+        this.character.getChildMeshes().forEach((mesh) => mesh.setEnabled(true));
     }
 
     public setClosestWalkableObject(object: Transformable | null) {
@@ -230,7 +252,7 @@ export class CharacterControls implements Controls {
     }
 
     public getActiveCamera(): Camera {
-        return this.firstPersonCamera;
+        return this.activeCamera;
     }
 
     public getCameras(): Camera[] {

--- a/src/ts/characterControls/characterControls.ts
+++ b/src/ts/characterControls/characterControls.ts
@@ -412,22 +412,26 @@ export class CharacterControls implements Controls {
         const isMoving = this.currentAnimationState.currentAnimation !== this.currentAnimationState.idleAnimation;
 
         // Rotation
-        if (xMove < 0 && isMoving) {
-            const dtheta = this.characterRotationSpeed * deltaTime;
-            this.character.rotate(Vector3.Up(), dtheta);
-            this.thirdPersonCamera.alpha += dtheta;
+        if (this.activeCamera === this.thirdPersonCamera) {
+            if (xMove < 0 && isMoving) {
+                const dtheta = this.characterRotationSpeed * deltaTime;
+                this.character.rotate(Vector3.Up(), dtheta);
+                this.thirdPersonCamera.alpha += dtheta;
 
-            const cameraPosition = this.thirdPersonCamera.target;
-            cameraPosition.applyRotationQuaternionInPlace(Quaternion.RotationAxis(Vector3.Up(), -dtheta));
-            this.thirdPersonCamera.target = cameraPosition;
-        } else if (xMove > 0 && isMoving) {
-            const dtheta = this.characterRotationSpeed * deltaTime;
-            this.character.rotate(Vector3.Up(), -dtheta);
-            this.thirdPersonCamera.alpha -= dtheta;
+                const cameraPosition = this.thirdPersonCamera.target;
+                cameraPosition.applyRotationQuaternionInPlace(Quaternion.RotationAxis(Vector3.Up(), -dtheta));
+                this.thirdPersonCamera.target = cameraPosition;
+            } else if (xMove > 0 && isMoving) {
+                const dtheta = this.characterRotationSpeed * deltaTime;
+                this.character.rotate(Vector3.Up(), -dtheta);
+                this.thirdPersonCamera.alpha -= dtheta;
 
-            const cameraPosition = this.thirdPersonCamera.target;
-            cameraPosition.applyRotationQuaternionInPlace(Quaternion.RotationAxis(Vector3.Up(), dtheta));
-            this.thirdPersonCamera.target = cameraPosition;
+                const cameraPosition = this.thirdPersonCamera.target;
+                cameraPosition.applyRotationQuaternionInPlace(Quaternion.RotationAxis(Vector3.Up(), dtheta));
+                this.thirdPersonCamera.target = cameraPosition;
+            }
+        } else if (this.activeCamera === this.firstPersonCamera) {
+            displacement.addInPlace(this.character.right.scale(xMove * this.characterWalkSpeed * deltaTime));
         }
 
         let weightSum = 0;

--- a/src/ts/characterControls/characterControlsInputs.ts
+++ b/src/ts/characterControls/characterControlsInputs.ts
@@ -48,16 +48,24 @@ const runAction = new Action({
     bindings: [runKey, runButton]
 });
 
+const toggleCameraInteraction = new PressInteraction(
+    new Action({
+        bindings: [keyboard.getControl("KeyB")]
+    })
+);
+
 export const CharacterInputs = new InputMap<{
     move: Action<[number, number]>;
     jump: PressInteraction;
     samba: Action<number>;
     run: Action<number>;
+    toggleCamera: PressInteraction;
 }>("CharacterInputs", {
     move: moveAction,
     jump: jumpInteraction,
     samba: sambaAction,
-    run: runAction
+    run: runAction,
+    toggleCamera: toggleCameraInteraction
 });
 
 CharacterInputs.setEnabled(false);

--- a/src/ts/defaultControls/defaultControls.ts
+++ b/src/ts/defaultControls/defaultControls.ts
@@ -69,6 +69,10 @@ export class DefaultControls implements Controls {
         return this.transform;
     }
 
+    public shouldLockPointer(): boolean {
+        return true;
+    }
+
     public update(deltaSeconds: number): Vector3 {
         const inertiaHalfLifeSeconds = 0.07;
 

--- a/src/ts/playground.ts
+++ b/src/ts/playground.ts
@@ -31,6 +31,7 @@ import { createSpaceStationScene } from "./playgrounds/spaceStation";
 import { createXrScene } from "./playgrounds/xr";
 import { createFlightDemoScene } from "./playgrounds/flightDemo";
 import { createNeutronStarScene } from "./playgrounds/neutronStar";
+import { createCharacterDemoScene } from "./playgrounds/character";
 
 const canvas = document.getElementById("renderer") as HTMLCanvasElement;
 canvas.width = window.innerWidth;
@@ -68,6 +69,9 @@ switch (requestedScene) {
         break;
     case "neutronStar":
         scene = await createNeutronStarScene(engine);
+        break;
+    case "character":
+        scene = await createCharacterDemoScene(engine);
         break;
     default:
         scene = await createAutomaticLandingScene(engine);

--- a/src/ts/playgrounds/character.ts
+++ b/src/ts/playgrounds/character.ts
@@ -1,0 +1,80 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { Scene } from "@babylonjs/core/scene";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import {
+    AssetsManager,
+    Color3,
+    DirectionalLight,
+    MeshBuilder,
+    PBRMetallicRoughnessMaterial,
+    PhysicsAggregate,
+    PhysicsShapeType,
+    ShadowGenerator
+} from "@babylonjs/core";
+import { enablePhysics } from "./utils";
+import { Objects } from "../assets/objects";
+import { CollisionMask } from "../settings";
+import { CharacterControls } from "../characterControls/characterControls";
+import { CharacterInputs } from "../characterControls/characterControlsInputs";
+
+export async function createCharacterDemoScene(engine: AbstractEngine): Promise<Scene> {
+    const scene = new Scene(engine);
+    scene.useRightHandedSystem = true;
+
+    await enablePhysics(scene);
+
+    const assetsManager = new AssetsManager(scene);
+    Objects.EnqueueTasks(assetsManager, scene);
+    await assetsManager.loadAsync();
+
+    const light = new DirectionalLight("dir01", new Vector3(1, -2, -1), scene);
+    light.position = new Vector3(5, 5, 5).scaleInPlace(10);
+
+    const shadowGenerator = new ShadowGenerator(1024, light);
+    shadowGenerator.useBlurExponentialShadowMap = true;
+
+    const character = new CharacterControls(scene);
+    character.getTransform().position.y = 5;
+
+    CharacterInputs.setEnabled(true);
+
+    shadowGenerator.addShadowCaster(character.character);
+
+    const camera = character.getActiveCamera();
+    camera.attachControl();
+
+    const ground = MeshBuilder.CreateBox("ground", { width: 20, height: 1, depth: 20 }, scene);
+
+    const groundAggregate = new PhysicsAggregate(ground, PhysicsShapeType.BOX, { mass: 0 }, scene);
+    groundAggregate.shape.filterMembershipMask = CollisionMask.ENVIRONMENT;
+    groundAggregate.shape.filterCollideMask = CollisionMask.DYNAMIC_OBJECTS;
+
+    const groundMaterial = new PBRMetallicRoughnessMaterial("groundMaterial", scene);
+    groundMaterial.baseColor = new Color3(0.5, 0.5, 0.5);
+    ground.material = groundMaterial;
+    ground.receiveShadows = true;
+
+    scene.onBeforeRenderObservable.add(() => {
+        const deltaSeconds = engine.getDeltaTime() / 1000;
+        character.update(deltaSeconds);
+    });
+
+    return scene;
+}

--- a/src/ts/playgrounds/character.ts
+++ b/src/ts/playgrounds/character.ts
@@ -26,7 +26,8 @@ import {
     PBRMetallicRoughnessMaterial,
     PhysicsAggregate,
     PhysicsShapeType,
-    ShadowGenerator
+    ShadowGenerator,
+    SkeletonViewer
 } from "@babylonjs/core";
 import { enablePhysics } from "./utils";
 import { Objects } from "../assets/objects";
@@ -53,12 +54,19 @@ export async function createCharacterDemoScene(engine: AbstractEngine): Promise<
     const character = new CharacterControls(scene);
     character.getTransform().position.y = 5;
 
+    // Create a skeleton viewer for the mesh
+    const skeletonViewer = new SkeletonViewer(character.skeleton, character.characterNode, scene);
+    skeletonViewer.isEnabled = true; // Enable it
+    skeletonViewer.color = Color3.Red(); // Change default color from white to red
+
     CharacterInputs.setEnabled(true);
 
     shadowGenerator.addShadowCaster(character.character);
 
     const camera = character.getActiveCamera();
     camera.attachControl();
+
+    scene.activeCamera = camera;
 
     const ground = MeshBuilder.CreateBox("ground", { width: 20, height: 1, depth: 20 }, scene);
 

--- a/src/ts/spaceship/aiSpaceshipControls.ts
+++ b/src/ts/spaceship/aiSpaceshipControls.ts
@@ -46,6 +46,10 @@ export class AiSpaceshipControls implements Controls {
         return [this.thirdPersonCamera];
     }
 
+    shouldLockPointer(): boolean {
+        return false;
+    }
+
     update(deltaSeconds: number): Vector3 {
         return Vector3.Zero();
     }

--- a/src/ts/spaceship/shipControls.ts
+++ b/src/ts/spaceship/shipControls.ts
@@ -251,6 +251,10 @@ export class ShipControls implements Controls {
         return this.getSpaceship().getTransform();
     }
 
+    public shouldLockPointer(): boolean {
+        return false;
+    }
+
     public getActiveCamera(): Camera {
         return this.thirdPersonCamera;
     }

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -449,8 +449,11 @@ export class Spaceship implements Transformable {
 
         this.getTransform().setParent(null);
 
+        translate(this.getTransform(), this.getTransform().up.scale(5));
+
         this.state = ShipState.FLYING;
         this.aggregate.body.setMotionType(PhysicsMotionType.DYNAMIC);
+
         this.aggregate.shape.filterCollideMask = CollisionMask.DYNAMIC_OBJECTS | CollisionMask.ENVIRONMENT;
         this.aggregate.shape.filterMembershipMask = CollisionMask.DYNAMIC_OBJECTS;
 

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -718,6 +718,11 @@ export class StarSystemView implements View {
         if (this.spaceshipControls === null) throw new Error("Spaceship controls is null");
         if (this.characterControls === null) throw new Error("Character controls is null");
 
+        if (this.scene.getActiveControls().getActiveCamera() !== this.scene.activeCamera) {
+            this.scene.activeCamera?.detachControl();
+            this.scene.setActiveCamera(this.scene.getActiveControls().getActiveCamera());
+        }
+
         const nearestOrbitalObject = starSystem.getNearestOrbitalObject(
             this.scene.getActiveControls().getTransform().getAbsolutePosition()
         );

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -272,7 +272,7 @@ export class StarSystemView implements View {
             } else if (this.scene.getActiveControls() === this.getDefaultControls()) {
                 await this.switchToCharacterControls();
             } else if (this.scene.getActiveControls() === this.getCharacterControls()) {
-                this.switchToSpaceshipControls();
+                await this.switchToSpaceshipControls();
             }
         });
 
@@ -382,8 +382,6 @@ export class StarSystemView implements View {
             const keyboardLayoutMap = await getGlobalKeyboardLayoutMap();
 
             if (this.scene.getActiveControls() === shipControls) {
-                console.log("disembark");
-
                 characterControls.getTransform().setEnabled(true);
                 CharacterInputs.setEnabled(true);
                 characterControls.getTransform().setAbsolutePosition(shipControls.getTransform().absolutePosition);
@@ -401,17 +399,15 @@ export class StarSystemView implements View {
                 SpaceShipControlsInputs.setEnabled(false);
                 this.spaceShipLayer.setVisibility(false);
 
-                this.scene.setActiveControls(characterControls);
+                await this.scene.setActiveControls(characterControls);
 
                 spaceship.acceleratingWarpDriveSound.setTargetVolume(0);
                 spaceship.deceleratingWarpDriveSound.setTargetVolume(0);
             } else if (this.scene.getActiveControls() === characterControls) {
-                console.log("embark");
-
                 characterControls.getTransform().setEnabled(false);
                 CharacterInputs.setEnabled(false);
 
-                this.scene.setActiveControls(shipControls);
+                await this.scene.setActiveControls(shipControls);
                 SpaceShipControlsInputs.setEnabled(true);
 
                 if (spaceship.isLanded()) {
@@ -653,7 +649,7 @@ export class StarSystemView implements View {
      * Call this when the player object is changed when loading a save.
      * It will remove the current controls and recreate them based on the player object.
      */
-    public resetPlayer() {
+    public async resetPlayer() {
         this.postProcessManager.reset();
 
         const maxZ = Settings.EARTH_RADIUS * 1e5;
@@ -686,7 +682,7 @@ export class StarSystemView implements View {
             this.characterControls.getCameras().forEach((camera) => (camera.maxZ = maxZ));
         }
 
-        this.scene.setActiveControls(this.spaceshipControls);
+        await this.scene.setActiveControls(this.spaceshipControls);
     }
 
     public isJumpingBetweenSystems() {
@@ -945,9 +941,7 @@ export class StarSystemView implements View {
     /**
      * Switches the active controller to the spaceship controls
      */
-    public switchToSpaceshipControls() {
-        document.exitPointerLock();
-
+    public async switchToSpaceshipControls() {
         const shipControls = this.getSpaceshipControls();
         const characterControls = this.getCharacterControls();
         const defaultControls = this.getDefaultControls();
@@ -956,7 +950,7 @@ export class StarSystemView implements View {
 
         characterControls.getTransform().setEnabled(false);
         CharacterInputs.setEnabled(false);
-        this.scene.setActiveControls(shipControls);
+        await this.scene.setActiveControls(shipControls);
         setRotationQuaternion(
             shipControls.getTransform(),
             getRotationQuaternion(defaultControls.getTransform()).clone()
@@ -970,8 +964,6 @@ export class StarSystemView implements View {
      * Switches the active controller to the character controls
      */
     public async switchToCharacterControls() {
-        await this.scene.getEngine().getRenderingCanvas()?.requestPointerLock();
-
         const shipControls = this.getSpaceshipControls();
         const characterControls = this.getCharacterControls();
         const defaultControls = this.getDefaultControls();
@@ -981,7 +973,7 @@ export class StarSystemView implements View {
         characterControls.getTransform().setEnabled(true);
         CharacterInputs.setEnabled(true);
         characterControls.getTransform().setAbsolutePosition(defaultControls.getTransform().absolutePosition);
-        this.scene.setActiveControls(characterControls);
+        await this.scene.setActiveControls(characterControls);
         setRotationQuaternion(
             characterControls.getTransform(),
             getRotationQuaternion(defaultControls.getTransform()).clone()
@@ -998,8 +990,6 @@ export class StarSystemView implements View {
      * Switches the active controller to the default controls
      */
     public async switchToDefaultControls(showHelpNotification: boolean) {
-        await this.scene.getEngine().getRenderingCanvas()?.requestPointerLock();
-
         const shipControls = this.getSpaceshipControls();
         const characterControls = this.getCharacterControls();
         const defaultControls = this.getDefaultControls();
@@ -1018,7 +1008,7 @@ export class StarSystemView implements View {
 
         this.stopBackgroundSounds();
 
-        this.scene.setActiveControls(defaultControls);
+        await this.scene.setActiveControls(defaultControls);
         setRotationQuaternion(
             defaultControls.getTransform(),
             getRotationQuaternion(shipControls.getTransform()).clone()

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -270,7 +270,7 @@ export class StarSystemView implements View {
             if (this.scene.getActiveControls() === this.getSpaceshipControls()) {
                 await this.switchToDefaultControls(true);
             } else if (this.scene.getActiveControls() === this.getDefaultControls()) {
-                this.switchToCharacterControls();
+                await this.switchToCharacterControls();
             } else if (this.scene.getActiveControls() === this.getCharacterControls()) {
                 this.switchToSpaceshipControls();
             }
@@ -941,6 +941,8 @@ export class StarSystemView implements View {
      * Switches the active controller to the spaceship controls
      */
     public switchToSpaceshipControls() {
+        document.exitPointerLock();
+
         const shipControls = this.getSpaceshipControls();
         const characterControls = this.getCharacterControls();
         const defaultControls = this.getDefaultControls();
@@ -962,7 +964,9 @@ export class StarSystemView implements View {
     /**
      * Switches the active controller to the character controls
      */
-    public switchToCharacterControls() {
+    public async switchToCharacterControls() {
+        await this.scene.getEngine().getRenderingCanvas()?.requestPointerLock();
+
         const shipControls = this.getSpaceshipControls();
         const characterControls = this.getCharacterControls();
         const defaultControls = this.getDefaultControls();
@@ -989,6 +993,8 @@ export class StarSystemView implements View {
      * Switches the active controller to the default controls
      */
     public async switchToDefaultControls(showHelpNotification: boolean) {
+        await this.scene.getEngine().getRenderingCanvas()?.requestPointerLock();
+
         const shipControls = this.getSpaceshipControls();
         const characterControls = this.getCharacterControls();
         const defaultControls = this.getDefaultControls();

--- a/src/ts/starmap/starMapControls.ts
+++ b/src/ts/starmap/starMapControls.ts
@@ -63,6 +63,10 @@ export class StarMapControls implements Controls {
         return this.transform;
     }
 
+    public shouldLockPointer(): boolean {
+        return false;
+    }
+
     public update(deltaSeconds: number): Vector3 {
         const inertiaFactor = 0.15;
         const [xMove, zMove] = StarMapInputs.map.move.value;

--- a/src/ts/uberCore/controls.ts
+++ b/src/ts/uberCore/controls.ts
@@ -27,6 +27,8 @@ export interface Controls extends Transformable {
 
     getCameras(): Camera[];
 
+    shouldLockPointer(): boolean;
+
     /**
      * Makes the controller listen to all its inputs and returns the displacement to apply to the player
      * @param deltaSeconds the time between 2 frames

--- a/src/ts/uberCore/uberScene.ts
+++ b/src/ts/uberCore/uberScene.ts
@@ -62,9 +62,15 @@ export class UberScene extends Scene {
      * Sets the active controls for the scene. This also sets the active camera of the scene using the active camera of the controls.
      * @param controls The active controls.
      */
-    public setActiveControls(controls: Controls) {
+    public async setActiveControls(controls: Controls) {
         this.activeControls = controls;
         this.setActiveCamera(controls.getActiveCamera());
+
+        if (controls.shouldLockPointer()) {
+            await this.getEngine().getRenderingCanvas()?.requestPointerLock();
+        } else {
+            document.exitPointerLock();
+        }
     }
 
     /**


### PR DESCRIPTION
## Related Tickets

Spontaneous

## Description

It is more immersive to have a first person view by default when walking around on planets. 3rd person view is still accessible by pressing "B".

This PR also adds pointer locking to character controls to make it usable. 

## Unexpected difficulties

At first, I wanted to attach the camera to the head bone. But I noticed the rotation of the head where just too much and would ruin the experience.

Instead I only track the position of the head bone without caring about its rotation.

## How to test

Land on any planet and walk around.

[Capture vidéo du 2025-02-22 13-06-23.webm](https://github.com/user-attachments/assets/f53cd09f-3a2b-411e-94a0-c65539099967)

Or use the associated playground: https://localhost:8080/playground.html?scene=character

## Follow-up

I want to expand character controls by adding interactions with the environment and switching to capsule collider for the character instead of using raycasts like now.
