### PR TITLE
Fix main menu error

### DIFF
--- a/src/ts/defaultControls/defaultControls.ts
+++ b/src/ts/defaultControls/defaultControls.ts
@@ -70,7 +70,7 @@ export class DefaultControls implements Controls {
     }
 
     public shouldLockPointer(): boolean {
-        return true;
+        return false;
     }
 
     public update(deltaSeconds: number): Vector3 {


### PR DESCRIPTION
as main menu cannot request pointer lock while using default controls, it is best to just disable pointer lock for default controls entirely

## Related Tickets

Spontaneous

## Description

Fixes a pointer lock error that would create a visual error in the main menu.

## Unexpected difficulties

None

## How to test

Open Cosmos Journeyer, there should not be any error related to pointer locking in the console and everything should look normal.

## Follow-up

Add cypress tests to avoid this kind of mistakes in the future #311 