### PR TITLE
Create a deployment for the latest version of main

### DIFF
--- a/.github/workflows/main-preview.yml
+++ b/.github/workflows/main-preview.yml
@@ -1,0 +1,48 @@
+name: Deploy (Main Preview)
+on:
+    push:
+        branches:
+            - main
+
+permissions:
+    contents: write
+
+concurrency:
+    group: main-preview
+    cancel-in-progress: true
+
+jobs:
+    deploy:
+        timeout-minutes: 10
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup Node.js with pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 9
+
+            - name: Install dependencies
+              run: pnpm i
+
+            - name: Check formatting
+              run: pnpm run format:check
+
+            - name: Lint project
+              run: pnpm run lint:check
+
+            - name: Test project
+              run: pnpm run test
+
+            - name: Build project
+              run: pnpm run build
+
+            - name: Deploy to GitHub Pages (Production)
+              uses: JamesIves/github-pages-deploy-action@v4
+              with:
+                  folder: dist
+                  branch: gh-pages
+                  clean: false
+                  force: false
+                  target-folder: preview


### PR DESCRIPTION
## Related Tickets

Spontaneous

## Description

Now, PRs can be previewed by being deployed to github pages, and I can manually deploy the main branch to production.

The last missing thing is to create a new deployment for newer versions of main that are not yet part of the latest stable release.

This PR adds this by creating a preview folder in the github pages branch. 

## Unexpected difficulties

None

## How to test

Merge this, main should then be deployed to the preview folder in gh-pages

## Follow-up

Hopefully CI is done now
