### PR TITLE
Long term fix for font display

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "html-webpack-plugin": "^5.6.3",
         "http-server": "^14.1.1",
         "i18next": "^24.2.2",
+        "mini-css-extract-plugin": "^2.9.2",
         "prettier": "^3.5.1",
         "raw-loader": "^4.0.2",
         "sass": "^1.85.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       i18next:
         specifier: ^24.2.2
         version: 24.2.2(typescript@5.7.3)
+      mini-css-extract-plugin:
+        specifier: ^2.9.2
+        version: 2.9.2(webpack@5.98.0(webpack-cli@6.0.1))
       prettier:
         specifier: ^3.5.1
         version: 3.5.1
@@ -2663,6 +2666,12 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  mini-css-extract-plugin@2.9.2:
+    resolution: {integrity: sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      webpack: ^5.0.0
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -6417,6 +6426,12 @@ snapshots:
       mime-db: 1.52.0
 
   mime@1.6.0: {}
+
+  mini-css-extract-plugin@2.9.2(webpack@5.98.0(webpack-cli@6.0.1)):
+    dependencies:
+      schema-utils: 4.3.0
+      tapable: 2.2.1
+      webpack: 5.98.0(webpack-cli@6.0.1)
 
   minimalistic-assert@1.0.1: {}
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -23,8 +23,6 @@
 @font-face {
     font-family: "Nasalization";
     src: url("./nasalization/nasalization-rg.otf") format("opentype");
-    font-weight: 600;
-    font-style: normal;
 }
 
 [hidden] {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,24 +32,25 @@ const config = {
     plugins: [
         new webpack.BannerPlugin({
             raw: true,
-            banner: `
-//  This file is part of Cosmos Journeyer
-//
-//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
-//
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-        `,
+            banner: `/*
+ *  This file is part of Cosmos Journeyer
+ *
+ *  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+`,
             stage: webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT
         }),
         new MiniCssExtractPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 // Generated using webpack-cli https://github.com/webpack/webpack-cli
 import path from "path";
 import HtmlWebpackPlugin from "html-webpack-plugin";
+import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import webpack from "webpack";
 
 const isProduction = process.env.NODE_ENV === "production";
@@ -51,6 +52,9 @@ const config = {
         `,
             stage: webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT
         }),
+        new MiniCssExtractPlugin({
+            filename: "[name].[contenthash].css"
+        }),
         new HtmlWebpackPlugin({
             title: "Cosmos Journeyer",
             filename: "index.html",
@@ -97,13 +101,13 @@ const config = {
             },
             {
                 test: /\.css$/i,
-                use: ["style-loader", "css-loader"],
+                use: [MiniCssExtractPlugin.loader, "css-loader"],
                 exclude: ["/node_modules/"]
             },
 
             {
                 test: /\.s[ac]ss$/i,
-                use: ["style-loader", "css-loader", "sass-loader"],
+                use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
                 exclude: ["/node_modules/"]
             },
             {


### PR DESCRIPTION
## Related Tickets

Follows from #320 

## Description

Remove the mini css extract plugin fixed the font loading, but on the other end the style would no longer load immediately so unstyled content would get displayed. Not a good look!

After some investigation, it happened that the webpack banner plugin injected the "//" commented license in the resulting css files and css does not support "//" comments!

So the fix was to change the banner to use "/**/" comments instead.   

## Unexpected difficulties

Yeah I did not expect the banner plugin to break my css code to be honest.

## How to test

Spin up the dev server, see that there is no flash of unstyled content and that the Nasalization font is displayed instead of sans-serif!

## Follow-up

Hopefully this is fixed and I don't need to touch it again!