### PR TITLE
Clamp thruster light intensity to 0 to avoid visual artefact

### DIFF
--- a/src/ts/spaceship/thruster.ts
+++ b/src/ts/spaceship/thruster.ts
@@ -81,7 +81,7 @@ export class Thruster {
         this.plume.setThrottle(this.throttle);
 
         this.light.intensity =
-            this.lightMinIntensity + (this.lightMaxIntensity - this.lightMinIntensity) * this.throttle;
+            this.lightMinIntensity + (this.lightMaxIntensity - this.lightMinIntensity) * Math.max(0, this.throttle);
 
         if (this.throttle > 0) {
             this.helperMesh.scaling = new Vector3(0.8, 0.8, 0.8);


### PR DESCRIPTION
## Related Tickets

Fixes #275 

## Description

When the throttle was negative, so was the light intensity, which darkened surfaces affected. This now clams the intensity to 0.

## Unexpected difficulties

None.

## How to test

Fly your spaceship with a negative throttle and see that there is no more darkening.

## Follow-up

Nothing comes to mind
