### PR TITLE
Feature: add Discovery scanner

### DIFF
--- a/src/ts/spaceship/components/discoveryScanner.ts
+++ b/src/ts/spaceship/components/discoveryScanner.ts
@@ -15,8 +15,30 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { DiscoveryScanner } from "./discoveryScanner";
-import { FuelScoop } from "./fuelScoop";
-import { FuelTank } from "./fuelTank";
+import { getDiscoveryScannerSpec, SerializedDiscoveryScanner } from "../serializedComponents/discoveryScanner";
 
-export type OptionalComponent = FuelTank | FuelScoop | DiscoveryScanner;
+export class DiscoveryScanner {
+    readonly type;
+    readonly range: number;
+
+    readonly size: number;
+    readonly quality: number;
+
+    constructor(serializedDiscoveryScanner: SerializedDiscoveryScanner) {
+        this.type = serializedDiscoveryScanner.type;
+        this.size = serializedDiscoveryScanner.size;
+        this.quality = serializedDiscoveryScanner.quality;
+
+        const spec = getDiscoveryScannerSpec(serializedDiscoveryScanner);
+
+        this.range = spec.range;
+    }
+
+    serialize() {
+        return {
+            type: this.type,
+            size: this.size,
+            quality: this.quality
+        };
+    }
+}

--- a/src/ts/spaceship/components/discoveryScanner.ts
+++ b/src/ts/spaceship/components/discoveryScanner.ts
@@ -19,7 +19,7 @@ import { getDiscoveryScannerSpec, SerializedDiscoveryScanner } from "../serializ
 
 export class DiscoveryScanner {
     readonly type;
-    readonly range: number;
+    readonly relativeRange: number;
 
     readonly size: number;
     readonly quality: number;
@@ -31,7 +31,7 @@ export class DiscoveryScanner {
 
         const spec = getDiscoveryScannerSpec(serializedDiscoveryScanner);
 
-        this.range = spec.range;
+        this.relativeRange = spec.relativeRange;
     }
 
     serialize() {

--- a/src/ts/spaceship/serializedComponents/discoveryScanner.ts
+++ b/src/ts/spaceship/serializedComponents/discoveryScanner.ts
@@ -15,8 +15,18 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { DiscoveryScanner } from "./discoveryScanner";
-import { FuelScoop } from "./fuelScoop";
-import { FuelTank } from "./fuelTank";
+import { z } from "zod";
 
-export type OptionalComponent = FuelTank | FuelScoop | DiscoveryScanner;
+export const SerializedDiscoveryScannerSchema = z.object({
+    type: z.literal("discoveryScanner"),
+    size: z.number(),
+    quality: z.number()
+});
+
+export type SerializedDiscoveryScanner = z.infer<typeof SerializedDiscoveryScannerSchema>;
+
+export function getDiscoveryScannerSpec(serializedDiscoveryScanner: SerializedDiscoveryScanner) {
+    return {
+        range: (serializedDiscoveryScanner.size + serializedDiscoveryScanner.quality / 10) * 1000e3
+    };
+}

--- a/src/ts/spaceship/serializedComponents/discoveryScanner.ts
+++ b/src/ts/spaceship/serializedComponents/discoveryScanner.ts
@@ -27,6 +27,6 @@ export type SerializedDiscoveryScanner = z.infer<typeof SerializedDiscoveryScann
 
 export function getDiscoveryScannerSpec(serializedDiscoveryScanner: SerializedDiscoveryScanner) {
     return {
-        range: (serializedDiscoveryScanner.size + serializedDiscoveryScanner.quality / 10) * 1000e3
+        relativeRange: serializedDiscoveryScanner.size + serializedDiscoveryScanner.quality / 10
     };
 }

--- a/src/ts/spaceship/serializedComponents/optionalComponents.ts
+++ b/src/ts/spaceship/serializedComponents/optionalComponents.ts
@@ -18,10 +18,12 @@
 import { z } from "zod";
 import { SerializedFuelScoopSchema } from "./fuelScoop";
 import { SerializedFuelTankSchema } from "./fuelTank";
+import { SerializedDiscoveryScannerSchema } from "./discoveryScanner";
 
 export const SerializedOptionalComponentSchema = z.discriminatedUnion("type", [
     SerializedFuelScoopSchema,
-    SerializedFuelTankSchema
+    SerializedFuelTankSchema,
+    SerializedDiscoveryScannerSchema
 ]);
 
 export type SerializedOptionalComponent = z.infer<typeof SerializedOptionalComponentSchema>;

--- a/src/ts/spaceship/serializedSpaceship.ts
+++ b/src/ts/spaceship/serializedSpaceship.ts
@@ -88,7 +88,11 @@ export function getDefaultSerializedSpaceship(): SerializedSpaceship {
                     size: 2,
                     quality: 1
                 },
-                null
+                {
+                    type: "discoveryScanner",
+                    size: 2,
+                    quality: 1
+                }
             ]
         }
     } satisfies SerializedSpaceship);

--- a/src/ts/spaceship/spaceship.ts
+++ b/src/ts/spaceship/spaceship.ts
@@ -57,6 +57,7 @@ import { getDefaultSerializedSpaceship, SerializedSpaceship, ShipType } from "./
 import { OptionalComponent } from "./components/optionalComponents";
 import { FuelScoop } from "./components/fuelScoop";
 import { Thrusters } from "./components/thrusters";
+import { DiscoveryScanner } from "./components/discoveryScanner";
 
 const enum ShipState {
     FLYING,
@@ -116,6 +117,8 @@ export class Spaceship implements Transformable {
 
     readonly fuelScoop: FuelScoop | null;
     private isFuelScooping = false;
+
+    readonly discoveryScanner: DiscoveryScanner | null;
 
     readonly enableWarpDriveSound: AudioInstance;
     readonly disableWarpDriveSound: AudioInstance;
@@ -245,6 +248,10 @@ export class Spaceship implements Transformable {
                     break;
                 case "fuelScoop":
                     optionalComponents.push(new FuelScoop(optionalComponent));
+                    break;
+                case "discoveryScanner":
+                    optionalComponents.push(new DiscoveryScanner(optionalComponent));
+                    break;
             }
         }
 
@@ -273,6 +280,9 @@ export class Spaceship implements Transformable {
         this.fuelTanks.push(...this.components.optional.filter((component) => component.type === "fuelTank"));
 
         this.fuelScoop = this.components.optional.find((component) => component.type === "fuelScoop") ?? null;
+
+        this.discoveryScanner =
+            this.components.optional.find((component) => component.type === "discoveryScanner") ?? null;
 
         const { min: boundingMin, max: boundingMax } = this.getTransform().getHierarchyBoundingVectors();
 

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -742,7 +742,11 @@ export class StarSystemView implements View {
             nearestCelestialBody.getTransform().getAbsolutePosition(),
             this.scene.getActiveControls().getTransform().getAbsolutePosition()
         );
-        if (distanceToNearesetCelestialBody2 < (nearestCelestialBody.getBoundingRadius() * 2) ** 2) {
+
+        const spaceship = this.spaceshipControls.getSpaceship();
+        const shipDiscoveryScanner = spaceship.discoveryScanner;
+
+        if (shipDiscoveryScanner !== null && distanceToNearesetCelestialBody2 < shipDiscoveryScanner.range ** 2) {
             const universeId = getUniverseObjectId(nearestCelestialBody.model, starSystem.model);
             const isNewDiscovery = this.player.addVisitedObjectIfNew(universeId);
             if (isNewDiscovery) {
@@ -758,8 +762,6 @@ export class StarSystemView implements View {
                 this.onNewDiscovery.notifyObservers(universeId);
             }
         }
-
-        const spaceship = this.spaceshipControls.getSpaceship();
 
         spaceship.setNearestOrbitalObject(nearestOrbitalObject);
         spaceship.setNearestCelestialBody(nearestCelestialBody);

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -746,7 +746,11 @@ export class StarSystemView implements View {
         const spaceship = this.spaceshipControls.getSpaceship();
         const shipDiscoveryScanner = spaceship.discoveryScanner;
 
-        if (shipDiscoveryScanner !== null && distanceToNearesetCelestialBody2 < shipDiscoveryScanner.range ** 2) {
+        if (
+            shipDiscoveryScanner !== null &&
+            distanceToNearesetCelestialBody2 <
+                (nearestCelestialBody.getBoundingRadius() * shipDiscoveryScanner.relativeRange) ** 2
+        ) {
             const universeId = getUniverseObjectId(nearestCelestialBody.model, starSystem.model);
             const isNewDiscovery = this.player.addVisitedObjectIfNew(universeId);
             if (isNewDiscovery) {


### PR DESCRIPTION
## Related Tickets

Spontaneous

## Description

Now the discovery scanner is a separate component of the spaceship. This means it can be upgraded or removed instead of being hardcoded.

## Unexpected difficulties

None

## How to test

Create a new game, you should be able to discover bodies by flying near them as usual

## Follow-up

Now I need the UI to upgrade the components.