### PR TITLE
Better tutorial controls

### DIFF
--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -5,5 +5,8 @@
     "and": "and",
     "sellFor": "Sell for {{price}}",
     "sellAllFor": "Sell all for {{price}}",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "ok": "OK"
 }

--- a/src/locales/en-US/tutorials/common.json
+++ b/src/locales/en-US/tutorials/common.json
@@ -1,9 +1,10 @@
 {
     "moreWillComeSoon": "More tutorials will come in the future!",
-    "navigationInfo": "<p>To move forward in the tutorial, simply press {{nextKeys}}. You can go back to the previous panel by pressing {{previousKeys}}.</p><p>You can leave the tutorial at any time by pressing {{quitKeys}}.</p>",
+    "navigationInfo": "<p>To move forward in the tutorial, simply press {{nextKeys}}. You can go back to the previous panel by pressing {{previousKeys}}.</p>",
     "quit": "Quit",
     "next": "Next",
     "previous": "Previous",
     "tutorialEnding": "<p>This tutorial and others are available at any time from the main menu and the pause menu.</p><p>Press {{keyQuit}} to leave the tutorial.</p>",
-    "loadTutorialWillLeaveGame": "Loading this tutorial will leave your current game. An autosave has just been made. Continue loading the tutorial?"
+    "loadTutorialWillLeaveGame": "Loading this tutorial will leave your current game. An autosave has just been made. Continue loading the tutorial?",
+    "quitConfirm": "You are about to quit the tutorial. Are you sure?"
 }

--- a/src/locales/fr-FR/common.json
+++ b/src/locales/fr-FR/common.json
@@ -5,5 +5,8 @@
     "and": "et",
     "sellFor": "Vendre pour {{price}}",
     "sellAllFor": "Vendre tout pour {{price}}",
-    "unknown": "Inconnu"
+    "unknown": "Inconnu",
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "ok": "OK"
 }

--- a/src/locales/fr-FR/tutorials/common.json
+++ b/src/locales/fr-FR/tutorials/common.json
@@ -1,9 +1,10 @@
 {
     "moreWillComeSoon": "Plus de tutoriels dans le futur !",
-    "navigationInfo": "<p>Pour avancer dans le tutoriel, appuyez sur {{nextKeys}}. Vous pouvez revenir aux étapes précédentes avec {{previousKeys}}.</p><p>Vous pouvez sortir du tutoriel à tout moment avec {{quitKeys}}.</p>",
+    "navigationInfo": "<p>Pour avancer dans le tutoriel, appuyez sur {{nextKeys}}. Vous pouvez revenir aux étapes précédentes avec {{previousKeys}}.</p>",
     "quit": "Quitter",
     "next": "Suivant",
     "previous": "Précédent",
     "tutorialEnding": "<p>Ce tutoriel et d'autres sont disponibles à tout moment depuis le menu principal et le menu de pause.</p><p>Appuyez sur {{keyQuit}} pour quitter le tutoriel.</p>",
-    "loadTutorialWillLeaveGame": "Charger ce tutorial quittera votre partie actuelle. Une sauvegarde automatique vient d'être effectuée. Continuer de charger le tutoriel ?"
+    "loadTutorialWillLeaveGame": "Charger ce tutoriel quittera votre partie actuelle. Une sauvegarde automatique vient d'être effectuée. Continuer de charger le tutoriel ?",
+    "quitConfirm": "Vous êtes sur le point de quitter le tutoriel. Êtes-vous sûr ?"
 }

--- a/src/styles/tutorialLayer.scss
+++ b/src/styles/tutorialLayer.scss
@@ -88,6 +88,13 @@
                         font-size: calc(var(--text-size) * 0.75);
                     }
                 }
+
+                &.disabled {
+                    background: rgba(255, 255, 255, 0.5);
+                    color: rgba(0, 0, 0, 0.5);
+                    pointer-events: none;
+                    cursor: not-allowed;
+                }
             }
         }
     }

--- a/src/ts/tutorials/flightTutorial.ts
+++ b/src/ts/tutorials/flightTutorial.ts
@@ -67,9 +67,6 @@ export class FlightTutorial implements Tutorial {
                 ),
                 previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keybordLayoutMap).join(
                     ` ${i18n.t("common:or")} `
-                ),
-                quitKeys: pressInteractionToStrings(TutorialControlsInputs.map.quitTutorial, keybordLayoutMap).join(
-                    ` ${i18n.t("common:or")} `
                 )
             })}
         </div>`;
@@ -128,7 +125,7 @@ export class FlightTutorial implements Tutorial {
             <p>${i18n.t("tutorials:flightTutorial:congratulationsText1")}</p>
             
             ${i18n.t("tutorials:common:tutorialEnding", {
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.quitTutorial, keybordLayoutMap).join(
+                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keybordLayoutMap).join(
                     ` ${i18n.t("common:or")} `
                 )
             })}

--- a/src/ts/tutorials/fuelScoopTutorial.ts
+++ b/src/ts/tutorials/fuelScoopTutorial.ts
@@ -63,9 +63,6 @@ export class FuelScoopTutorial implements Tutorial {
                 ),
                 previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keyboardLayoutMap).join(
                     ` ${i18n.t("common:or")} `
-                ),
-                quitKeys: pressInteractionToStrings(TutorialControlsInputs.map.quitTutorial, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `
                 )
             })}
         </div>`;
@@ -85,7 +82,7 @@ export class FuelScoopTutorial implements Tutorial {
             
             <p>${i18n.t("tutorials:common:tutorialEnding", {
                 // This displays a small internationalized text to explain the keys to end the tutorial
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.quitTutorial, keyboardLayoutMap).join(
+                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
                     ` ${i18n.t("common:or")} `
                 )
             })}

--- a/src/ts/tutorials/stationLandingTutorial.ts
+++ b/src/ts/tutorials/stationLandingTutorial.ts
@@ -68,9 +68,6 @@ export class StationLandingTutorial implements Tutorial {
                 ),
                 previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keyboardLayoutMap).join(
                     ` ${i18n.t("common:or")} `
-                ),
-                quitKeys: pressInteractionToStrings(TutorialControlsInputs.map.quitTutorial, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `
                 )
             })}
         </div>`;
@@ -109,7 +106,7 @@ export class StationLandingTutorial implements Tutorial {
             
             <p>${i18n.t("tutorials:common:tutorialEnding", {
                 // This displays a small internationalized text to explain the keys to end the tutorial
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.quitTutorial, keyboardLayoutMap).join(
+                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
                     ` ${i18n.t("common:or")} `
                 )
             })}

--- a/src/ts/tutorials/templateTutorial.ts
+++ b/src/ts/tutorials/templateTutorial.ts
@@ -60,9 +60,6 @@ export class TemplateTutorial implements Tutorial {
                 ),
                 previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keyboardLayoutMap).join(
                     ` ${i18n.t("common:or")} `
-                ),
-                quitKeys: pressInteractionToStrings(TutorialControlsInputs.map.quitTutorial, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `
                 )
             })}
         </div>`;
@@ -71,7 +68,7 @@ export class TemplateTutorial implements Tutorial {
         <div class="tutorialContent">
             ${i18n.t("tutorials:common:tutorialEnding", {
                 // This displays a small internationalized text to explain the keys to end the tutorial
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.quitTutorial, keyboardLayoutMap).join(
+                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
                     ` ${i18n.t("common:or")} `
                 )
             })}

--- a/src/ts/ui/tutorial/tutorialLayerInputs.ts
+++ b/src/ts/ui/tutorial/tutorialLayerInputs.ts
@@ -17,20 +17,12 @@ const prevPanel = new PressInteraction(
     })
 );
 
-const quitTutorial = new PressInteraction(
-    new Action({
-        bindings: [keyboard.getControl("Delete")]
-    })
-);
-
 export const TutorialControlsInputs = new InputMap<{
     nextPanel: PressInteraction;
     prevPanel: PressInteraction;
-    quitTutorial: PressInteraction;
 }>("TutorialControls", {
     nextPanel,
-    prevPanel,
-    quitTutorial
+    prevPanel
 });
 
 TutorialControlsInputs.setEnabled(false);

--- a/src/ts/utils/dialogModal.ts
+++ b/src/ts/utils/dialogModal.ts
@@ -1,4 +1,5 @@
 import { Sounds } from "../assets/sounds";
+import i18n from "../i18n";
 
 export function promptModalString(prompt: string, defaultValue = ""): Promise<string | null> {
     const modal = document.createElement("dialog");
@@ -7,8 +8,8 @@ export function promptModalString(prompt: string, defaultValue = ""): Promise<st
             <p>${prompt}</p>
             <input type="text" value="${defaultValue}">
             <menu>
-                <button type="reset" value="cancel">Cancel</button>
-                <button type="submit" value="ok">OK</button>
+                <button type="reset" value="cancel">${i18n.t("common:cancel")}</button>
+                <button type="submit" value="ok">${i18n.t("common:ok")}</button>
             </menu>
         </form>
     `;
@@ -48,8 +49,8 @@ export function promptModalBoolean(prompt: string): Promise<boolean> {
         <form method="dialog">
             <p>${prompt}</p>
             <menu>
-                <button value="cancel">Cancel</button>
-                <button value="ok">Do it!</button>
+                <button value="cancel">${i18n.t("common:cancel")}</button>
+                <button value="ok">${i18n.t("common:confirm")}</button>
             </menu>
         </form>
     `;
@@ -71,7 +72,7 @@ export function alertModal(message: string): Promise<void> {
         <form method="dialog">
             <p>${message}</p>
             <menu>
-                <button value="ok">OK</button>
+                <button value="ok">${i18n.t("common:ok")}</button>
             </menu>
         </form>
     `;
@@ -126,7 +127,7 @@ export function connectEncyclopaediaGalacticaModal(): Promise<{
     const cancelButton = document.createElement("button");
     cancelButton.type = "reset";
     cancelButton.value = "cancel";
-    cancelButton.textContent = "Cancel";
+    cancelButton.textContent = i18n.t("common:cancel");
     menu.appendChild(cancelButton);
 
     const connectButton = document.createElement("button");


### PR DESCRIPTION
## Related Tickets

Fixes #279 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

- removed quit button in favor of pressing next again
- confirm before quitting
- grey previous button on panel 0

## Unexpected difficulties

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

None

## How to test

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test` or `pnpm run test`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint:check` or `pnpm run lint:check`

Did you document your code?
-->

Start a new game, you will be greeted by the flight tutorial. The quit button should be gone and the previous button should be greyed out on the first panel. Quitting the tutorial should prompt you to confirm.

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

Next up is to make a tuto for the starmap #197 
