### PR TITLE
Use only point lights instead of stellar objects for the light sources of the scene

### DIFF
--- a/src/ts/anomalies/julia/juliaSetPostProcess.ts
+++ b/src/ts/anomalies/julia/juliaSetPostProcess.ts
@@ -18,7 +18,6 @@
 import juliaFragment from "../../../shaders/juliaSet.glsl";
 import { UpdatablePostProcess } from "../../postProcesses/updatablePostProcess";
 import { Effect } from "@babylonjs/core/Materials/effect";
-import { StellarObject } from "../../architecture/orbitalObject";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ObjectUniformNames, setObjectUniforms } from "../../postProcesses/uniforms/objectUniforms";
@@ -34,6 +33,7 @@ import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { DeepReadonly } from "../../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class JuliaSetPostProcess extends PostProcess implements UpdatablePostProcess {
     private elapsedSeconds = 0;
@@ -45,7 +45,7 @@ export class JuliaSetPostProcess extends PostProcess implements UpdatablePostPro
         boundingRadius: number,
         accentColor: DeepReadonly<Color3>,
         scene: Scene,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const shaderName = "julia";
         if (Effect.ShadersStore[`${shaderName}FragmentShader`] === undefined) {

--- a/src/ts/anomalies/mandelbox/mandelboxPostProcess.ts
+++ b/src/ts/anomalies/mandelbox/mandelboxPostProcess.ts
@@ -18,7 +18,6 @@
 import mandelboxFragment from "../../../shaders/mandelbox.glsl";
 import { UpdatablePostProcess } from "../../postProcesses/updatablePostProcess";
 import { Effect } from "@babylonjs/core/Materials/effect";
-import { StellarObject } from "../../architecture/orbitalObject";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ObjectUniformNames, setObjectUniforms } from "../../postProcesses/uniforms/objectUniforms";
@@ -34,6 +33,7 @@ import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { MandelboxModel } from "./mandelboxModel";
 import { DeepReadonly } from "../../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class MandelboxPostProcess extends PostProcess implements UpdatablePostProcess {
     private elapsedSeconds = 0;
@@ -45,7 +45,7 @@ export class MandelboxPostProcess extends PostProcess implements UpdatablePostPr
         boundingRadius: number,
         model: DeepReadonly<MandelboxModel>,
         scene: Scene,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const shaderName = "mandelbox";
         if (Effect.ShadersStore[`${shaderName}FragmentShader`] === undefined) {

--- a/src/ts/anomalies/mandelbulb/mandelbulbPostProcess.ts
+++ b/src/ts/anomalies/mandelbulb/mandelbulbPostProcess.ts
@@ -18,7 +18,6 @@
 import mandelbulbFragment from "../../../shaders/mandelbulb.glsl";
 import { UpdatablePostProcess } from "../../postProcesses/updatablePostProcess";
 import { Effect } from "@babylonjs/core/Materials/effect";
-import { StellarObject } from "../../architecture/orbitalObject";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ObjectUniformNames, setObjectUniforms } from "../../postProcesses/uniforms/objectUniforms";
@@ -34,6 +33,7 @@ import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { MandelbulbModel } from "./mandelbulbModel";
 import { DeepReadonly } from "../../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class MandelbulbPostProcess extends PostProcess implements UpdatablePostProcess {
     private elapsedSeconds = 0;
@@ -45,7 +45,7 @@ export class MandelbulbPostProcess extends PostProcess implements UpdatablePostP
         boundingRadius: number,
         mandelbulbModel: DeepReadonly<MandelbulbModel>,
         scene: Scene,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const shaderName = "mandelbulb";
         if (Effect.ShadersStore[`${shaderName}FragmentShader`] === undefined) {

--- a/src/ts/anomalies/mengerSponge/mengerSpongePostProcess.ts
+++ b/src/ts/anomalies/mengerSponge/mengerSpongePostProcess.ts
@@ -18,7 +18,6 @@
 import mengerSpongeFragment from "../../../shaders/mengerSponge.glsl";
 import { UpdatablePostProcess } from "../../postProcesses/updatablePostProcess";
 import { Effect } from "@babylonjs/core/Materials/effect";
-import { StellarObject } from "../../architecture/orbitalObject";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ObjectUniformNames, setObjectUniforms } from "../../postProcesses/uniforms/objectUniforms";
@@ -34,6 +33,7 @@ import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { MengerSpongeModel } from "./mengerSpongeModel";
 import { DeepReadonly } from "../../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class MengerSpongePostProcess extends PostProcess implements UpdatablePostProcess {
     private elapsedSeconds = 0;
@@ -45,7 +45,7 @@ export class MengerSpongePostProcess extends PostProcess implements UpdatablePos
         boundingRadius: number,
         model: DeepReadonly<MengerSpongeModel>,
         scene: Scene,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const shaderName = "MengerSponge";
         if (Effect.ShadersStore[`${shaderName}FragmentShader`] === undefined) {

--- a/src/ts/anomalies/sierpinskiPyramid/sierpinskiPyramidPostProcess.ts
+++ b/src/ts/anomalies/sierpinskiPyramid/sierpinskiPyramidPostProcess.ts
@@ -18,7 +18,6 @@
 import sierpinskiFragment from "../../../shaders/sierpinski.glsl";
 import { UpdatablePostProcess } from "../../postProcesses/updatablePostProcess";
 import { Effect } from "@babylonjs/core/Materials/effect";
-import { StellarObject } from "../../architecture/orbitalObject";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ObjectUniformNames, setObjectUniforms } from "../../postProcesses/uniforms/objectUniforms";
@@ -34,6 +33,7 @@ import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { SierpinskiPyramidModel } from "./sierpinskiPyramidModel";
 import { DeepReadonly } from "../../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class SierpinskiPyramidPostProcess extends PostProcess implements UpdatablePostProcess {
     private elapsedSeconds = 0;
@@ -45,7 +45,7 @@ export class SierpinskiPyramidPostProcess extends PostProcess implements Updatab
         boundingRadius: number,
         model: DeepReadonly<SierpinskiPyramidModel>,
         scene: Scene,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const shaderName = "SierpinskiPyramid";
         if (Effect.ShadersStore[`${shaderName}FragmentShader`] === undefined) {

--- a/src/ts/architecture/lightEmitter.ts
+++ b/src/ts/architecture/lightEmitter.ts
@@ -16,9 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { PointLight } from "@babylonjs/core/Lights/pointLight";
-import { CelestialBodyBase } from "./celestialBody";
-import { OrbitalObjectType } from "./orbitalObjectType";
 
-export interface PlanetaryMassObjectBase<T extends OrbitalObjectType> extends CelestialBodyBase<T> {
-    updateMaterial(stellarObjects: ReadonlyArray<PointLight>, deltaSeconds: number): void;
+export interface LightEmitter {
+    getLight(): PointLight;
 }

--- a/src/ts/architecture/stellarObject.ts
+++ b/src/ts/architecture/stellarObject.ts
@@ -15,10 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { PointLight } from "@babylonjs/core/Lights/pointLight";
 import { CelestialBodyBase } from "./celestialBody";
 import { OrbitalObjectType } from "./orbitalObjectType";
+import { LightEmitter } from "./lightEmitter";
 
-export interface StellarObjectBase<T extends OrbitalObjectType> extends CelestialBodyBase<T> {
-    getLight(): PointLight;
-}
+export interface StellarObjectBase<T extends OrbitalObjectType> extends CelestialBodyBase<T>, LightEmitter {}

--- a/src/ts/assets/procedural/butterfly/butterflyMaterial.ts
+++ b/src/ts/assets/procedural/butterfly/butterflyMaterial.ts
@@ -20,15 +20,14 @@ import { Effect } from "@babylonjs/core/Materials/effect";
 import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
 import butterflyFragment from "../../../../shaders/butterflyMaterial/butterflyFragment.glsl";
 import butterflyVertex from "../../../../shaders/butterflyMaterial/butterflyVertex.glsl";
-
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { Transformable } from "../../../architecture/transformable";
 import { Textures } from "../../textures";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import {
     setStellarObjectUniforms,
     StellarObjectUniformNames
 } from "../../../postProcesses/uniforms/stellarObjectUniforms";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 const ButterflyMaterialUniformNames = {
     WORLD: "world",
@@ -50,7 +49,7 @@ const ButterflyMaterialSamplerNames = {
 
 export class ButterflyMaterial extends ShaderMaterial {
     private elapsedSeconds = 0;
-    private stars: ReadonlyArray<Transformable> = [];
+    private stars: ReadonlyArray<PointLight> = [];
     private playerPosition: Vector3 = Vector3.Zero();
 
     private planet: TransformNode | null = null;
@@ -104,7 +103,7 @@ export class ButterflyMaterial extends ShaderMaterial {
         this.planet = planet;
     }
 
-    update(stars: ReadonlyArray<Transformable>, playerPosition: Vector3, deltaSeconds: number) {
+    update(stars: ReadonlyArray<PointLight>, playerPosition: Vector3, deltaSeconds: number) {
         this.elapsedSeconds += deltaSeconds;
         this.stars = stars;
         this.playerPosition = playerPosition;

--- a/src/ts/assets/procedural/grass/grassMaterial.ts
+++ b/src/ts/assets/procedural/grass/grassMaterial.ts
@@ -18,10 +18,8 @@
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
 import { Scene } from "@babylonjs/core/scene";
-
 import grassFragment from "../../../../shaders/grassMaterial/grassFragment.glsl";
 import grassVertex from "../../../../shaders/grassMaterial/grassVertex.glsl";
-import { Transformable } from "../../../architecture/transformable";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import {
     setStellarObjectUniforms,
@@ -29,6 +27,7 @@ import {
 } from "../../../postProcesses/uniforms/stellarObjectUniforms";
 import { Textures } from "../../textures";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 const GrassMaterialUniformNames = {
     WORLD: "world",
@@ -50,7 +49,7 @@ const GrassMaterialSamplerNames = {
 
 export class GrassMaterial extends ShaderMaterial {
     private elapsedSeconds = 0;
-    private stars: ReadonlyArray<Transformable> = [];
+    private stars: ReadonlyArray<PointLight> = [];
     private playerPosition: Vector3 = Vector3.Zero();
 
     private scene: Scene;
@@ -104,7 +103,7 @@ export class GrassMaterial extends ShaderMaterial {
         this.planet = planet;
     }
 
-    update(stars: ReadonlyArray<Transformable>, playerPosition: Vector3, deltaSeconds: number) {
+    update(stars: ReadonlyArray<PointLight>, playerPosition: Vector3, deltaSeconds: number) {
         this.elapsedSeconds += deltaSeconds;
         this.stars = stars;
         this.playerPosition = playerPosition;

--- a/src/ts/atmosphere/atmosphericScatteringPostProcess.ts
+++ b/src/ts/atmosphere/atmosphericScatteringPostProcess.ts
@@ -18,7 +18,6 @@
 import atmosphericScatteringFragment from "../../shaders/atmosphericScatteringFragment.glsl";
 
 import { Effect } from "@babylonjs/core/Materials/effect";
-import { Transformable } from "../architecture/transformable";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ObjectUniformNames, setObjectUniforms } from "../postProcesses/uniforms/objectUniforms";
@@ -30,6 +29,7 @@ import { Constants } from "@babylonjs/core/Engines/constants";
 import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { AtmosphereUniforms } from "./atmosphereUniforms";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class AtmosphericScatteringPostProcess extends PostProcess {
     private activeCamera: Camera | null = null;
@@ -38,7 +38,7 @@ export class AtmosphericScatteringPostProcess extends PostProcess {
         planetTransform: TransformNode,
         planetBoundingRadius: number,
         atmosphereUniforms: AtmosphereUniforms,
-        stellarObjects: ReadonlyArray<Transformable>,
+        stellarObjects: ReadonlyArray<PointLight>,
         scene: Scene
     ) {
         const shaderName = "atmosphericScattering";

--- a/src/ts/clouds/flatCloudsPostProcess.ts
+++ b/src/ts/clouds/flatCloudsPostProcess.ts
@@ -19,7 +19,6 @@ import flatCloudsFragment from "../../shaders/flatCloudsFragment.glsl";
 
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { UpdatablePostProcess } from "../postProcesses/updatablePostProcess";
-import { Transformable } from "../architecture/transformable";
 import { CloudsSamplerNames, CloudsUniformNames, CloudsUniforms } from "./cloudsUniforms";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
@@ -31,6 +30,7 @@ import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class FlatCloudsPostProcess extends PostProcess implements UpdatablePostProcess {
     readonly cloudUniforms: CloudsUniforms;
@@ -41,7 +41,7 @@ export class FlatCloudsPostProcess extends PostProcess implements UpdatablePostP
         planetTransform: TransformNode,
         boundingRadius: number,
         cloudUniforms: CloudsUniforms,
-        stellarObjects: ReadonlyArray<Transformable>,
+        stellarObjects: ReadonlyArray<PointLight>,
         scene: Scene
     ) {
         const shaderName = "flatClouds";

--- a/src/ts/clouds/volumetricCloudsPostProcess.ts
+++ b/src/ts/clouds/volumetricCloudsPostProcess.ts
@@ -20,7 +20,6 @@ import volumetricCloudsFragment from "../../shaders/volumetricCloudsFragment.gls
 import { FlatCloudsPostProcess } from "./flatCloudsPostProcess";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { CloudsUniforms } from "./cloudsUniforms";
-import { StellarObject } from "../architecture/orbitalObject";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ObjectUniformNames, setObjectUniforms } from "../postProcesses/uniforms/objectUniforms";
@@ -31,6 +30,7 @@ import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export type CloudsPostProcess = FlatCloudsPostProcess | VolumetricCloudsPostProcess;
 
@@ -45,7 +45,7 @@ export class VolumetricCloudsPostProcess extends PostProcess {
         boundingRadius: number,
         cloudsUniforms: CloudsUniforms,
         scene: Scene,
-        stars: StellarObject[]
+        stars: ReadonlyArray<PointLight>
     ) {
         const shaderName = "volumetricClouds";
         if (Effect.ShadersStore[`${shaderName}FragmentShader`] === undefined) {

--- a/src/ts/ocean/oceanPostProcess.ts
+++ b/src/ts/ocean/oceanPostProcess.ts
@@ -19,7 +19,6 @@ import { Effect } from "@babylonjs/core/Materials/effect";
 
 import oceanFragment from "../../shaders/oceanFragment.glsl";
 import { UpdatablePostProcess } from "../postProcesses/updatablePostProcess";
-import { Transformable } from "../architecture/transformable";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { CameraUniformNames, setCameraUniforms } from "../postProcesses/uniforms/cameraUniforms";
 import { setStellarObjectUniforms, StellarObjectUniformNames } from "../postProcesses/uniforms/stellarObjectUniforms";
@@ -31,6 +30,7 @@ import { Camera } from "@babylonjs/core/Cameras/camera";
 import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { OceanUniforms } from "./oceanUniforms";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class OceanPostProcess extends PostProcess implements UpdatablePostProcess {
     readonly planetTransform: TransformNode;
@@ -43,7 +43,7 @@ export class OceanPostProcess extends PostProcess implements UpdatablePostProces
         planetTransform: TransformNode,
         boundingRadius: number,
         oceanUniforms: OceanUniforms,
-        stellarObjects: ReadonlyArray<Transformable>,
+        stellarObjects: ReadonlyArray<PointLight>,
         scene: Scene
     ) {
         const shaderName = "ocean";

--- a/src/ts/planets/gasPlanet/gasPlanet.ts
+++ b/src/ts/planets/gasPlanet/gasPlanet.ts
@@ -28,7 +28,6 @@ import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import { Cullable } from "../../utils/cullable";
 import { RingsUniforms } from "../../rings/ringsUniform";
-import { Transformable } from "../../architecture/transformable";
 import { Scene } from "@babylonjs/core/scene";
 import { AsteroidField } from "../../asteroidFields/asteroidField";
 import { getOrbitalObjectTypeToI18nString } from "../../utils/strings/orbitalObjectTypeToDisplay";
@@ -38,6 +37,7 @@ import { Settings } from "../../settings";
 import { PlanetaryMassObjectBase } from "../../architecture/planetaryMassObject";
 import { OrbitalObjectType } from "../../architecture/orbitalObjectType";
 import { DeepReadonly } from "../../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class GasPlanet implements PlanetaryMassObjectBase<OrbitalObjectType.GAS_PLANET>, Cullable {
     readonly model: DeepReadonly<GasPlanetModel>;
@@ -115,7 +115,7 @@ export class GasPlanet implements PlanetaryMassObjectBase<OrbitalObjectType.GAS_
         this.targetInfo = defaultTargetInfoCelestialBody(this.getBoundingRadius());
     }
 
-    updateMaterial(stellarObjects: ReadonlyArray<Transformable>, deltaSeconds: number): void {
+    updateMaterial(stellarObjects: ReadonlyArray<PointLight>, deltaSeconds: number): void {
         this.material.update(stellarObjects, deltaSeconds);
     }
 

--- a/src/ts/planets/gasPlanet/gasPlanetMaterial.ts
+++ b/src/ts/planets/gasPlanet/gasPlanetMaterial.ts
@@ -24,14 +24,13 @@ import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { Scene } from "@babylonjs/core/scene";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
-import { Transformable } from "../../architecture/transformable";
 import {
     setStellarObjectUniforms,
     StellarObjectUniformNames
 } from "../../postProcesses/uniforms/stellarObjectUniforms";
-
 import { getRngFromSeed } from "../../utils/getRngFromSeed";
 import { DeepReadonly } from "../../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 const GasPlanetMaterialUniformNames = {
     WORLD: "world",
@@ -104,7 +103,7 @@ export class GasPlanetMaterial extends ShaderMaterial {
         this.setFloat(GasPlanetMaterialUniformNames.COLOR_SHARPNESS, this.colorSettings.colorSharpness);
     }
 
-    public update(stellarObjects: ReadonlyArray<Transformable>, deltaSeconds: number) {
+    public update(stellarObjects: ReadonlyArray<PointLight>, deltaSeconds: number) {
         this.elapsedSeconds += deltaSeconds;
 
         this.onBindObservable.addOnce(() => {

--- a/src/ts/planets/telluricPlanet/telluricPlanet.ts
+++ b/src/ts/planets/telluricPlanet/telluricPlanet.ts
@@ -41,6 +41,8 @@ import { OceanUniforms } from "../../ocean/oceanUniforms";
 import { TelluricPlanetModel } from "./telluricPlanetModel";
 import { TelluricSatelliteModel } from "./telluricSatelliteModel";
 import { DeepReadonly } from "../../utils/types";
+import { LightEmitter } from "../../architecture/lightEmitter";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class TelluricPlanet
     implements
@@ -170,7 +172,7 @@ export class TelluricPlanet
         for (const side of this.sides) side.update(observerPosition, chunkForge);
     }
 
-    public updateMaterial(stellarObjects: ReadonlyArray<Transformable>, deltaSeconds: number): void {
+    public updateMaterial(stellarObjects: ReadonlyArray<PointLight>, deltaSeconds: number): void {
         this.material.update(this.getTransform().getWorldMatrix(), stellarObjects);
     }
 

--- a/src/ts/planets/telluricPlanet/telluricPlanetMaterial.ts
+++ b/src/ts/planets/telluricPlanet/telluricPlanetMaterial.ts
@@ -22,7 +22,6 @@ import { Assets } from "../../assets/assets";
 import { centeredRand } from "extended-random";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
-import { Transformable } from "../../architecture/transformable";
 import { Scene } from "@babylonjs/core/scene";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import {
@@ -36,6 +35,7 @@ import { LutPoolManager } from "../../assets/lutPoolManager";
 import { TelluricPlanetModel } from "./telluricPlanetModel";
 import { TelluricSatelliteModel } from "./telluricSatelliteModel";
 import { DeepReadonly } from "../../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 const TelluricPlanetMaterialUniformNames = {
     WORLD: "world",
@@ -216,7 +216,7 @@ export class TelluricPlanetMaterial extends ShaderMaterial {
         );
     }
 
-    public update(planetWorldMatrix: Matrix, stellarObjects: ReadonlyArray<Transformable>) {
+    public update(planetWorldMatrix: Matrix, stellarObjects: ReadonlyArray<PointLight>) {
         // The add once is important because the material will be bound for every chunk of the planet
         this.onBindObservable.addOnce(() => {
             this.getEffect().setMatrix(TelluricPlanetMaterialUniformNames.PLANET_WORLD_MATRIX, planetWorldMatrix);

--- a/src/ts/postProcesses/postProcessManager.ts
+++ b/src/ts/postProcesses/postProcessManager.ts
@@ -59,6 +59,7 @@ import { SierpinskiPyramidModel } from "../anomalies/sierpinskiPyramid/sierpinsk
 import { MengerSpongeModel } from "../anomalies/mengerSponge/mengerSpongeModel";
 import { CelestialBody, StellarObject } from "../architecture/orbitalObject";
 import { DeepReadonly } from "../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 /**
  * The order in which the post processes are rendered when away from a planet
@@ -366,7 +367,7 @@ export class PostProcessManager {
                 planet.getTransform(),
                 planet.getBoundingRadius(),
                 planet.atmosphereUniforms,
-                stellarObjects,
+                stellarObjects.map((star) => star.getLight()),
                 this.scene
             );
             this.atmospheres.push(atmosphere);
@@ -378,7 +379,7 @@ export class PostProcessManager {
                 planet.getTransform(),
                 planet.getBoundingRadius(),
                 planet.oceanUniforms,
-                stellarObjects,
+                stellarObjects.map((star) => star.getLight()),
                 this.scene
             );
             this.oceans.push(ocean);
@@ -390,7 +391,7 @@ export class PostProcessManager {
                 planet.getTransform(),
                 planet.getBoundingRadius(),
                 planet.cloudsUniforms,
-                stellarObjects,
+                stellarObjects.map((star) => star.getLight()),
                 this.scene
             );
             this.clouds.push(clouds);
@@ -402,7 +403,7 @@ export class PostProcessManager {
                 planet.getTransform(),
                 planet.ringsUniforms,
                 planet.model,
-                stellarObjects,
+                stellarObjects.map((star) => star.getLight()),
                 this.scene
             );
             this.rings.push(rings);
@@ -432,7 +433,7 @@ export class PostProcessManager {
                 planet.getTransform(),
                 planet.getBoundingRadius(),
                 planet.atmosphereUniforms,
-                stellarObjects,
+                stellarObjects.map((star) => star.getLight()),
                 this.scene
             );
             this.atmospheres.push(atmosphere);
@@ -444,7 +445,7 @@ export class PostProcessManager {
                 planet.getTransform(),
                 planet.ringsUniforms,
                 planet.model,
-                stellarObjects,
+                stellarObjects.map((star) => star.getLight()),
                 this.scene
             );
             this.rings.push(rings);
@@ -476,7 +477,7 @@ export class PostProcessManager {
         transform: TransformNode,
         radius: number,
         model: DeepReadonly<MandelbulbModel>,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const mandelbulb = new MandelbulbPostProcess(transform, radius, model, this.scene, stellarObjects);
         this.mandelbulbs.push(mandelbulb);
@@ -495,7 +496,7 @@ export class PostProcessManager {
         transform: TransformNode,
         radius: number,
         model: DeepReadonly<JuliaSetModel>,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const juliaSetPostProcess = new JuliaSetPostProcess(
             transform,
@@ -513,7 +514,7 @@ export class PostProcessManager {
         transform: TransformNode,
         radius: number,
         model: DeepReadonly<MandelboxModel>,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const mandelbox = new MandelboxPostProcess(transform, radius, model, this.scene, stellarObjects);
         this.mandelboxes.push(mandelbox);
@@ -525,7 +526,7 @@ export class PostProcessManager {
         transform: TransformNode,
         radius: number,
         model: DeepReadonly<SierpinskiPyramidModel>,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const sierpinskiPyramid = new SierpinskiPyramidPostProcess(
             transform,
@@ -543,7 +544,7 @@ export class PostProcessManager {
         transform: TransformNode,
         radius: number,
         model: DeepReadonly<MengerSpongeModel>,
-        stellarObjects: ReadonlyArray<StellarObject>
+        stellarObjects: ReadonlyArray<PointLight>
     ) {
         const mengerSponge = new MengerSpongePostProcess(transform, radius, model, this.scene, stellarObjects);
         this.mengerSponges.push(mengerSponge);

--- a/src/ts/postProcesses/shadowPostProcess.ts
+++ b/src/ts/postProcesses/shadowPostProcess.ts
@@ -18,7 +18,6 @@
 import shadowFragment from "../../shaders/shadowFragment.glsl";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { RingsSamplerNames, RingsUniformNames, RingsUniforms } from "../rings/ringsUniform";
-import { StellarObject } from "../architecture/orbitalObject";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 import { ObjectUniformNames, setObjectUniforms } from "./uniforms/objectUniforms";
@@ -30,6 +29,8 @@ import { SamplerUniformNames, setSamplerUniforms } from "./uniforms/samplerUnifo
 import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { CloudsUniforms } from "../clouds/cloudsUniforms";
+import { LightEmitter } from "../architecture/lightEmitter";
+import { HasBoundingSphere } from "../architecture/hasBoundingSphere";
 
 export type ShadowUniforms = {
     hasRings: boolean;
@@ -49,7 +50,7 @@ export class ShadowPostProcess extends PostProcess {
         ringsUniforms: RingsUniforms | null,
         cloudsUniforms: CloudsUniforms | null,
         hasOcean: boolean,
-        stellarObjects: ReadonlyArray<StellarObject>,
+        stellarObjects: ReadonlyArray<HasBoundingSphere & LightEmitter>,
         scene: Scene
     ) {
         const shaderName = "shadow";
@@ -107,7 +108,10 @@ export class ShadowPostProcess extends PostProcess {
             }
 
             setCameraUniforms(effect, this.activeCamera);
-            setStellarObjectUniforms(effect, stellarObjects);
+            setStellarObjectUniforms(
+                effect,
+                stellarObjects.map((star) => star.getLight())
+            );
             setObjectUniforms(effect, transform, boundingRadius);
 
             effect.setFloatArray(

--- a/src/ts/postProcesses/uniforms/stellarObjectUniforms.ts
+++ b/src/ts/postProcesses/uniforms/stellarObjectUniforms.ts
@@ -16,11 +16,8 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Effect } from "@babylonjs/core/Materials/effect";
-import { Transformable } from "../../architecture/transformable";
-import { Star } from "../../stellarObjects/star/star";
-import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { flattenColor3Array, flattenVector3Array } from "../../utils/algebra";
-import { getRgbFromTemperature } from "../../utils/specrend";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export const StellarObjectUniformNames = {
     STAR_POSITIONS: "star_positions",
@@ -28,8 +25,7 @@ export const StellarObjectUniformNames = {
     NB_STARS: "nbStars"
 };
 
-//FIXME: take point lights as input instead of transformables
-export function setStellarObjectUniforms(effect: Effect, stellarObjects: ReadonlyArray<Transformable>): void {
+export function setStellarObjectUniforms(effect: Effect, stellarObjects: ReadonlyArray<PointLight>): void {
     effect.setInt(StellarObjectUniformNames.NB_STARS, stellarObjects.length);
 
     if (stellarObjects.length === 0) {
@@ -40,16 +36,10 @@ export function setStellarObjectUniforms(effect: Effect, stellarObjects: Readonl
 
     effect.setArray3(
         StellarObjectUniformNames.STAR_POSITIONS,
-        flattenVector3Array(stellarObjects.map((stellarObject) => stellarObject.getTransform().getAbsolutePosition()))
+        flattenVector3Array(stellarObjects.map((stellarObject) => stellarObject.getAbsolutePosition()))
     );
     effect.setArray3(
         StellarObjectUniformNames.STAR_COLORS,
-        flattenColor3Array(
-            stellarObjects.map((stellarObject) =>
-                stellarObject instanceof Star
-                    ? getRgbFromTemperature(stellarObject.model.blackBodyTemperature)
-                    : Color3.White()
-            )
-        )
+        flattenColor3Array(stellarObjects.map((stellarObject) => stellarObject.diffuse))
     );
 }

--- a/src/ts/rings/ringsPostProcess.ts
+++ b/src/ts/rings/ringsPostProcess.ts
@@ -27,10 +27,10 @@ import { CameraUniformNames, setCameraUniforms } from "../postProcesses/uniforms
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import { SamplerUniformNames, setSamplerUniforms } from "../postProcesses/uniforms/samplerUniforms";
-import { Transformable } from "../architecture/transformable";
 import { Scene } from "@babylonjs/core/scene";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { DeepReadonly } from "../utils/types";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
 
 export class RingsPostProcess extends PostProcess {
     readonly ringsUniforms: RingsUniforms;
@@ -41,7 +41,7 @@ export class RingsPostProcess extends PostProcess {
         bodyTransform: TransformNode,
         ringsUniforms: RingsUniforms,
         bodyModel: DeepReadonly<CelestialBodyModel>,
-        stellarObjects: ReadonlyArray<Transformable>,
+        stellarObjects: ReadonlyArray<PointLight>,
         scene: Scene
     ) {
         const shaderName = "rings";

--- a/src/ts/starSystem/starSystemController.ts
+++ b/src/ts/starSystem/starSystemController.ts
@@ -301,7 +301,7 @@ export class StarSystemController {
                         object.getTransform(),
                         object.getRadius(),
                         object.model,
-                        stellarObjects
+                        stellarObjects.map((object) => object.getLight())
                     );
                     break;
                 case OrbitalObjectType.JULIA_SET:
@@ -309,7 +309,7 @@ export class StarSystemController {
                         object.getTransform(),
                         object.getRadius(),
                         object.model,
-                        stellarObjects
+                        stellarObjects.map((object) => object.getLight())
                     );
                     break;
                 case OrbitalObjectType.MANDELBOX:
@@ -317,7 +317,7 @@ export class StarSystemController {
                         object.getTransform(),
                         object.getRadius(),
                         object.model,
-                        stellarObjects
+                        stellarObjects.map((object) => object.getLight())
                     );
                     break;
                 case OrbitalObjectType.SIERPINSKI_PYRAMID:
@@ -325,7 +325,7 @@ export class StarSystemController {
                         object.getTransform(),
                         object.getRadius(),
                         object.model,
-                        stellarObjects
+                        stellarObjects.map((object) => object.getLight())
                     );
                     break;
                 case OrbitalObjectType.MENGER_SPONGE:
@@ -333,7 +333,7 @@ export class StarSystemController {
                         object.getTransform(),
                         object.getRadius(),
                         object.model,
-                        stellarObjects
+                        stellarObjects.map((object) => object.getLight())
                     );
                     break;
             }
@@ -525,7 +525,10 @@ export class StarSystemController {
         const planetaryMassObjects = this.getPlanetaryMassObjects();
 
         for (const planet of planetaryMassObjects) {
-            planet.updateMaterial(stellarObjects, deltaSeconds);
+            planet.updateMaterial(
+                stellarObjects.map((object) => object.getLight()),
+                deltaSeconds
+            );
         }
 
         for (const stellarObject of stellarObjects) {

--- a/src/ts/starSystem/starSystemView.ts
+++ b/src/ts/starSystem/starSystemView.ts
@@ -811,7 +811,7 @@ export class StarSystemView implements View {
         this.player.completedMissions.push(...newlyCompletedMissions);
         this.player.currentMissions = this.player.currentMissions.filter((mission) => !mission.isCompleted());
 
-        const stellarObjects = starSystem.getStellarObjects();
+        const stellarObjects = starSystem.getStellarObjects().map((object) => object.getLight());
 
         // update dynamic materials
         Materials.BUTTERFLY_MATERIAL.update(


### PR DESCRIPTION

## Related Tickets

Fixes #89 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

Having materials and effects depend on stellar objects was not justified when only having a point light was sufficient to get the necessary shading info.

## Unexpected difficulties

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

None.

## How to test

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test` or `pnpm run test`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint:check` or `pnpm run lint:check`

Did you document your code?
-->

Shading should look the same as before.

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

None
