### PR TITLE
Fix regressions

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
     testDir: "tests/e2e",
-    retries: process.env["CI"] !== undefined ? 2 : 0,
     use: {
         baseURL: "http://localhost:8080",
         browserName: "chromium",

--- a/src/ts/asteroidFields/asteroidPatch.ts
+++ b/src/ts/asteroidFields/asteroidPatch.ts
@@ -94,7 +94,10 @@ export class AsteroidPatch {
                 throw new Error(`Asteroid physics shape for type index ${typeIndex} is undefined.`);
             }
 
-            if (distanceToCamera < this.physicsRadius && instance.physicsBody === null) {
+            if (
+                distanceToCamera < this.physicsRadius &&
+                (instance.physicsBody === null || instance.physicsBody === undefined)
+            ) {
                 const instancePhysicsBody = new PhysicsBody(
                     instance,
                     PhysicsMotionType.DYNAMIC,
@@ -107,13 +110,15 @@ export class AsteroidPatch {
                 instancePhysicsBody.disablePreStep = false;
                 instancePhysicsBody.shape = shape;
                 this.instancePhysicsBodies.push(instancePhysicsBody);
-            } else if (distanceToCamera > this.physicsRadius + 1000 && instance.physicsBody !== null) {
+            } else if (
+                distanceToCamera > this.physicsRadius + 1000 &&
+                instance.physicsBody !== null &&
+                instance.physicsBody !== undefined
+            ) {
                 const body = this.instancePhysicsBodies.find((body) => body === instance.physicsBody);
-                if (body) {
+                if (body !== undefined) {
                     body.dispose();
                     this.instancePhysicsBodies.splice(this.instancePhysicsBodies.indexOf(body), 1);
-                } else {
-                    throw new Error("Physics body not found in instance physics bodies.");
                 }
             }
 

--- a/src/ts/asteroidFields/asteroidPatch.ts
+++ b/src/ts/asteroidFields/asteroidPatch.ts
@@ -41,7 +41,7 @@ export class AsteroidPatch {
 
     private readonly physicsRadius = 15e3;
 
-    private readonly batchSize = 10;
+    public static BATCH_SIZE = 10;
 
     constructor(
         positions: Vector3[],
@@ -127,7 +127,7 @@ export class AsteroidPatch {
             }
         });
 
-        for (let i = 0; i < this.batchSize; i++) {
+        for (let i = 0; i < AsteroidPatch.BATCH_SIZE; i++) {
             if (this.nbInstances === this.positions.length) break;
 
             const typeIndex = this.typeIndices[this.nbInstances];

--- a/src/ts/planets/telluricPlanet/terrain/chunks/chunkForgeWorkers.ts
+++ b/src/ts/planets/telluricPlanet/terrain/chunks/chunkForgeWorkers.ts
@@ -135,14 +135,17 @@ export class ChunkForgeWorkers implements ChunkForge {
      * Updates the state of the forge : dispatch tasks to workers, remove useless chunks, apply vertexData to new chunks
      */
     public update(assets: RenderingAssets) {
-        for (const worker of this.workerPool.availableWorkers) {
+        this.workerPool.availableWorkers.push(...this.workerPool.finishedWorkers);
+        this.workerPool.finishedWorkers = [];
+
+        while (this.workerPool.availableWorkers.length > 0) {
+            const worker = this.workerPool.availableWorkers.shift();
+            if (worker === undefined) {
+                break;
+            }
+
             this.executeNextTask(worker);
         }
-        this.workerPool.availableWorkers = this.workerPool.availableWorkers.filter(
-            (w) => !this.workerPool.busyWorkers.includes(w)
-        );
-        this.workerPool.availableWorkers = this.workerPool.availableWorkers.concat(this.workerPool.finishedWorkers);
-        this.workerPool.finishedWorkers = [];
 
         this.executeNextApplyTask(assets);
     }

--- a/src/ts/playground.ts
+++ b/src/ts/playground.ts
@@ -60,7 +60,7 @@ if (urlParams.get("physicsViewer") !== null) {
     scene.onBeforeRenderObservable.add(() => {
         for (const mesh of scene.meshes) {
             const physicsBody = mesh.physicsBody;
-            if (physicsBody === null) {
+            if (!physicsBody) {
                 continue;
             }
 

--- a/src/ts/playground.ts
+++ b/src/ts/playground.ts
@@ -70,11 +70,12 @@ if (urlParams.get("physicsViewer") !== null) {
 }
 
 const maxFrameCounter = urlParams.get("freeze");
-if (maxFrameCounter !== null) {
+const maxFrameCounterValue = Number(maxFrameCounter);
+if (maxFrameCounter !== null && !isNaN(maxFrameCounterValue)) {
     let frameCounter = 0;
     scene.onAfterRenderObservable.add(() => {
         frameCounter++;
-        if (frameCounter === Number(maxFrameCounter)) {
+        if (frameCounter >= maxFrameCounterValue) {
             engine.stopRenderLoop();
             canvas.dataset["frozen"] = "1";
             return;

--- a/src/ts/playground.ts
+++ b/src/ts/playground.ts
@@ -69,9 +69,16 @@ if (urlParams.get("physicsViewer") !== null) {
     });
 }
 
-if (urlParams.get("freeze") !== null) {
-    scene.onAfterRenderObservable.addOnce(() => {
-        engine.stopRenderLoop();
+const maxFrameCounter = urlParams.get("freeze");
+if (maxFrameCounter !== null) {
+    let frameCounter = 0;
+    scene.onAfterRenderObservable.add(() => {
+        frameCounter++;
+        if (frameCounter === Number(maxFrameCounter)) {
+            engine.stopRenderLoop();
+            canvas.dataset["frozen"] = "1";
+            return;
+        }
     });
 }
 

--- a/src/ts/playgrounds/asteroidField.ts
+++ b/src/ts/playgrounds/asteroidField.ts
@@ -29,6 +29,7 @@ import { enablePhysics } from "./utils";
 import { DefaultControls } from "../defaultControls/defaultControls";
 import { AsteroidField } from "../asteroidFields/asteroidField";
 import { loadRenderingAssets } from "../assets/renderingAssets";
+import { AsteroidPatch } from "@/asteroidFields/asteroidPatch";
 
 export async function createAsteroidFieldScene(
     engine: AbstractEngine,
@@ -58,8 +59,8 @@ export async function createAsteroidFieldScene(
 
     const scalingFactor = 500;
 
-    defaultControls.getTransform().position.z = -200 * scalingFactor;
-    defaultControls.getTransform().position.y = 20 * scalingFactor;
+    defaultControls.getTransform().position.z = -120 * scalingFactor;
+    defaultControls.getTransform().position.y = 5 * scalingFactor;
     defaultControls.speed *= scalingFactor;
     camera.maxZ *= scalingFactor;
 
@@ -69,6 +70,8 @@ export async function createAsteroidFieldScene(
 
     const beltRadius = 100 * scalingFactor;
     const beltSpread = 20 * scalingFactor;
+
+    AsteroidPatch.BATCH_SIZE = 10_000;
 
     const belt = new AsteroidField(42, sphere, beltRadius, beltSpread, scene);
 

--- a/tests/e2e/anomalies/darkKnight.spec.ts
+++ b/tests/e2e/anomalies/darkKnight.spec.ts
@@ -4,6 +4,7 @@ import { renderAndSnap } from "../utils/renderSnap";
 test("The Dark knight playground renders correctly", async ({ page }) => {
     await renderAndSnap(page, {
         scene: "darkKnight",
-        shotName: "baseline"
+        shotName: "baseline",
+        flagToWait: "ready"
     });
 });

--- a/tests/e2e/anomalies/juliaSet.spec.ts
+++ b/tests/e2e/anomalies/juliaSet.spec.ts
@@ -5,7 +5,9 @@ test("The Julia Set playground renders correctly", async ({ page }) => {
     await renderAndSnap(page, {
         scene: "juliaSet",
         shotName: "baseline",
-        additionalUrlParams: {
+        flagToWait: "frozen",
+        urlParams: {
+            freeze: 1,
             seed: "0"
         }
     });

--- a/tests/e2e/anomalies/mandelbox.spec.ts
+++ b/tests/e2e/anomalies/mandelbox.spec.ts
@@ -5,7 +5,9 @@ test("The Mandelbox playground renders correctly", async ({ page }) => {
     await renderAndSnap(page, {
         scene: "mandelbox",
         shotName: "baseline",
-        additionalUrlParams: {
+        flagToWait: "frozen",
+        urlParams: {
+            freeze: 1,
             seed: "0"
         }
     });

--- a/tests/e2e/anomalies/mandelbulb.spec.ts
+++ b/tests/e2e/anomalies/mandelbulb.spec.ts
@@ -5,7 +5,9 @@ test("The Mandelbulb playground renders correctly", async ({ page }) => {
     await renderAndSnap(page, {
         scene: "mandelbulb",
         shotName: "baseline",
-        additionalUrlParams: {
+        flagToWait: "frozen",
+        urlParams: {
+            freeze: 1,
             seed: "0"
         }
     });

--- a/tests/e2e/anomalies/mengerSponge.spec.ts
+++ b/tests/e2e/anomalies/mengerSponge.spec.ts
@@ -5,7 +5,9 @@ test("The Menger Sponge playground renders correctly", async ({ page }) => {
     await renderAndSnap(page, {
         scene: "mengerSponge",
         shotName: "baseline",
-        additionalUrlParams: {
+        flagToWait: "frozen",
+        urlParams: {
+            freeze: 1,
             seed: "0"
         }
     });

--- a/tests/e2e/anomalies/sierpinski.spec.ts
+++ b/tests/e2e/anomalies/sierpinski.spec.ts
@@ -5,7 +5,9 @@ test("The Sierpinski Pyramid playground renders correctly", async ({ page }) => 
     await renderAndSnap(page, {
         scene: "sierpinski",
         shotName: "baseline",
-        additionalUrlParams: {
+        flagToWait: "frozen",
+        urlParams: {
+            freeze: 1,
             seed: "0"
         }
     });

--- a/tests/e2e/asteroidField.spec.ts
+++ b/tests/e2e/asteroidField.spec.ts
@@ -2,5 +2,19 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The asteroid field playground renders correctly", async ({ page }) => {
-    await renderAndSnap(page, { scene: "asteroidField", shotName: "baseline" });
+    await renderAndSnap(page, {
+        scene: "asteroidField",
+        shotName: "baseline",
+        flagToWait: "frozen",
+        urlParams: { freeze: 3 }
+    });
+});
+
+test("The asteroid field playground has correct physics", async ({ page }) => {
+    await renderAndSnap(page, {
+        scene: "asteroidField",
+        shotName: "baseline-physics",
+        flagToWait: "frozen",
+        urlParams: { physicsViewer: "", freeze: 3 }
+    });
 });

--- a/tests/e2e/asteroidField.spec.ts-snapshots/baseline-linux.png
+++ b/tests/e2e/asteroidField.spec.ts-snapshots/baseline-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14dc7baed79ac7d79348e8828dfb4c9f1a067dffe53779d7b932a32a3b302756
-size 12756
+oid sha256:87c6a4c40695e39ad1c9156e2247d49fb312d6c2a1591db237ab5fbbb1c7f0db
+size 95595

--- a/tests/e2e/asteroidField.spec.ts-snapshots/baseline-physics-linux.png
+++ b/tests/e2e/asteroidField.spec.ts-snapshots/baseline-physics-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d6744b4fca326bc12170838e3f3403c7327eccebbccfd929684a6cbf20784c5
+size 81098

--- a/tests/e2e/atmosphereScattering.spec.ts
+++ b/tests/e2e/atmosphereScattering.spec.ts
@@ -2,5 +2,10 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The atmosphere playground renders correctly", async ({ page }) => {
-    await renderAndSnap(page, { scene: "atmosphericScattering", shotName: "baseline" });
+    await renderAndSnap(page, {
+        scene: "atmosphericScattering",
+        shotName: "baseline",
+        flagToWait: "frozen",
+        urlParams: { freeze: 1 }
+    });
 });

--- a/tests/e2e/debugAssets.spec.ts
+++ b/tests/e2e/debugAssets.spec.ts
@@ -2,5 +2,10 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The debug assets playground renders correctly", async ({ page }) => {
-    await renderAndSnap(page, { scene: "debugAssets", shotName: "baseline" });
+    await renderAndSnap(page, {
+        scene: "debugAssets",
+        shotName: "baseline",
+        flagToWait: "frozen",
+        urlParams: { freeze: 1 }
+    });
 });

--- a/tests/e2e/default.spec.ts
+++ b/tests/e2e/default.spec.ts
@@ -2,5 +2,5 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The default playground renders correctly", async ({ page }) => {
-    await renderAndSnap(page, { shotName: "default" });
+    await renderAndSnap(page, { shotName: "default", flagToWait: "ready" });
 });

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -3,5 +3,10 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The i18n should be correctly initialized", async ({ page }) => {
-    await renderAndSnap(page, { scene: "tutorial", shotName: "baseline", additionalUrlParams: { lang: "en-US" } });
+    await renderAndSnap(page, {
+        scene: "tutorial",
+        shotName: "baseline",
+        flagToWait: "ready",
+        urlParams: { lang: "en-US" }
+    });
 });

--- a/tests/e2e/neutronStar.spec.ts
+++ b/tests/e2e/neutronStar.spec.ts
@@ -2,5 +2,10 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The neutron star playground renders correctly", async ({ page }) => {
-    await renderAndSnap(page, { scene: "neutronStar", shotName: "baseline" });
+    await renderAndSnap(page, {
+        scene: "neutronStar",
+        shotName: "baseline",
+        flagToWait: "frozen",
+        urlParams: { freeze: 1 }
+    });
 });

--- a/tests/e2e/orbitalDemo.spec.ts
+++ b/tests/e2e/orbitalDemo.spec.ts
@@ -2,5 +2,10 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The orbital demo playground renders correctly", async ({ page }) => {
-    await renderAndSnap(page, { scene: "orbitalDemo", shotName: "baseline" });
+    await renderAndSnap(page, {
+        scene: "orbitalDemo",
+        shotName: "baseline",
+        flagToWait: "frozen",
+        urlParams: { freeze: 1 }
+    });
 });

--- a/tests/e2e/rings.spec.ts
+++ b/tests/e2e/rings.spec.ts
@@ -2,5 +2,5 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The rings playground renders correctly", async ({ page }) => {
-    await renderAndSnap(page, { scene: "rings", shotName: "baseline" });
+    await renderAndSnap(page, { scene: "rings", shotName: "baseline", flagToWait: "ready" });
 });

--- a/tests/e2e/tunnel.spec.ts
+++ b/tests/e2e/tunnel.spec.ts
@@ -2,5 +2,10 @@ import { test } from "@playwright/test";
 import { renderAndSnap } from "./utils/renderSnap";
 
 test("The tunnel playground renders correctly", async ({ page }) => {
-    await renderAndSnap(page, { scene: "tunnel", shotName: "baseline" });
+    await renderAndSnap(page, {
+        scene: "tunnel",
+        shotName: "baseline",
+        flagToWait: "frozen",
+        urlParams: { freeze: 1 }
+    });
 });

--- a/tests/e2e/utils/renderSnap.ts
+++ b/tests/e2e/utils/renderSnap.ts
@@ -2,20 +2,27 @@ import { Page, expect } from "@playwright/test";
 
 export async function renderAndSnap(
     page: Page,
-    opts: { scene?: string; shotName: string; additionalUrlParams?: Record<string, string> }
+    opts: {
+        scene?: string;
+        shotName: string;
+        urlParams?: {
+            freeze?: number;
+            [key: string]: string | number;
+        };
+        flagToWait: string;
+    }
 ) {
     const urlParams = new URLSearchParams();
     if (opts.scene !== undefined) urlParams.set("scene", opts.scene);
-    urlParams.set("freeze", "");
-
-    for (const [key, value] of Object.entries(opts.additionalUrlParams || {})) {
-        urlParams.set(key, value);
+    for (const [key, value] of Object.entries(opts.urlParams ?? {})) {
+        urlParams.set(key, String(value));
     }
 
     await page.goto(`/playground.html?${urlParams.toString()}`);
 
     await page.waitForSelector("#renderer", { state: "visible" });
-    await page.locator('#renderer[data-ready="1"]').waitFor({ timeout: 30_000 });
+
+    await page.locator(`#renderer[data-${opts.flagToWait}="1"]`).waitFor({ timeout: 30_000 });
 
     await expect(page.locator("#renderer")).toHaveScreenshot(`${opts.shotName}.png`, { timeout: 15_000 });
 }


### PR DESCRIPTION
## Related Tickets

Fixes  some regressions from #395

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

#395 introduced some regressions : a range error for worker dispatch, and asteroid physics not being initialized.

The physics issue has now an E2E test to prevent any regression in the future. This required improving the E2E testing logic.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

The asteroid need a few frames to be initialized with the physics viewer. This means waiting for nth frame, not just the first. 

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

`pnpm test:e2e:docker` and also try to bump in an asteroid.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

More end-to-end tests to prevent regressions
