### PR TITLE
Fix grass shading model

### DIFF
--- a/src/shaders/grassMaterial/grassFragment.glsl
+++ b/src/shaders/grassMaterial/grassFragment.glsl
@@ -46,11 +46,11 @@ void main() {
     vec3 baseColor = vec3(0.4, 0.8, 0.08);
     vec3 tipColor = vec3(0.5, 0.5, 0.1);
 
-    vec3 albedo = mix(baseColor, tipColor, pow(vPosition.y, 4.0));
+    vec3 albedo = 2.0 * mix(baseColor, tipColor, pow(vPosition.y, 4.0));
 
     vec3 normalW = vNormalW;
 
-    float ao = 0.5 + 0.5 * (vPosition.y * vPosition.y);
+    float ao = 0.7 + 0.3 * (vPosition.y * vPosition.y);
 
     vec3 Lo = vec3(0.0);
 
@@ -63,12 +63,8 @@ void main() {
         if (ndl < 0.0) {
             normalW = -normalW;
         }
-        Lo += calculateLight(albedo, normalW, 0.2, 0.0, lightDirectionW, viewDirectionW, star_colors[i]);
+        Lo += calculateLight(albedo, normalW, 0.4, 0.0, lightDirectionW, viewDirectionW, star_colors[i]);
     }
-
-    Lo *= vPlanetNdl;
-
-    Lo += albedo * 0.2;
 
     gl_FragColor = vec4(Lo * ao, 1.0);// apply color and lighting
     #endif

--- a/src/shaders/grassMaterial/grassVertex.glsl
+++ b/src/shaders/grassMaterial/grassVertex.glsl
@@ -99,7 +99,9 @@ void main() {
     scaling *= 1.0 - smoothstep(70.0, 90.0, objectCameraDistance); // fade grass in the distance using scaling
 
     vec3 terrainNormal = normalize(vec3(worldMatrix * vec4(0.0, 1.0, 0.0, 0.0)));
-    vec3 sphereNormal = normalize(objectWorld - planetPosition);
+    vec3 sphereNormal = length(objectWorld - planetPosition) < 0.01 ? normalize(objectWorld - planetPosition) : vec3(0.0, 1.0, 0.0);
+    
+    // calculate the flatness of the terrain
     float flatness = max(dot(terrainNormal, sphereNormal), 0.0);
 
     scaling *= smoothstep(0.78, 0.8, flatness);

--- a/src/ts/frontend/universe/planets/telluricPlanet/terrain/instancePatch/matrixBuffer.ts
+++ b/src/ts/frontend/universe/planets/telluricPlanet/terrain/instancePatch/matrixBuffer.ts
@@ -39,21 +39,21 @@ export function randomDownSample(matrixBuffer: Float32Array, stride: number): Fl
     return downSampledBuffer;
 }
 
-export function createSquareMatrixBuffer(position: Vector3, size: number, resolution: number) {
+export function createSquareMatrixBuffer(position: Vector3, size: number, resolution: number, rng: () => number) {
     const matrixBuffer = new Float32Array(resolution * resolution * 16);
     const cellSize = size / resolution;
     let index = 0;
     for (let x = 0; x < resolution; x++) {
         for (let z = 0; z < resolution; z++) {
-            const randomCellPositionX = Math.random() * cellSize;
-            const randomCellPositionZ = Math.random() * cellSize;
+            const randomCellPositionX = rng() * cellSize;
+            const randomCellPositionZ = rng() * cellSize;
             const positionX = position.x + x * cellSize - size / 2 + randomCellPositionX;
             const positionZ = position.z + z * cellSize - size / 2 + randomCellPositionZ;
-            const scaling = 0.7 + Math.random() * 0.6;
+            const scaling = 0.7 + rng() * 0.6;
 
             const matrix = Matrix.Compose(
                 new Vector3(scaling, scaling, scaling),
-                Quaternion.RotationAxis(Vector3.Up(), Math.random() * 2 * Math.PI),
+                Quaternion.RotationAxis(Vector3.Up(), rng() * 2 * Math.PI),
                 new Vector3(positionX, 0, positionZ),
             );
             matrix.copyToArray(matrixBuffer, 16 * index);

--- a/src/ts/playgrounds/grass.ts
+++ b/src/ts/playgrounds/grass.ts
@@ -15,9 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { FreeCamera, MeshBuilder, PointLight, TransformNode, Vector3 } from "@babylonjs/core";
+import { FreeCamera, MeshBuilder, PointLight, Vector3 } from "@babylonjs/core";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
+import { seededSquirrelNoise } from "squirrel-noise";
 
 import { createGrassBlade } from "@/frontend/assets/procedural/grass/grassBlade";
 import { GrassMaterial } from "@/frontend/assets/procedural/grass/grassMaterial";
@@ -74,7 +75,13 @@ export async function createGrassScene(
     grassMaterial.setPlanet(ground);
     grassBladeMesh.material = grassMaterial;
 
-    const grassPatch = new ThinInstancePatch(createSquareMatrixBuffer(Vector3.Zero(), 32, 256));
+    const rng = seededSquirrelNoise(0);
+    let rngState = 0;
+    const wrappedRng = () => {
+        return rng(rngState++);
+    };
+
+    const grassPatch = new ThinInstancePatch(createSquareMatrixBuffer(Vector3.Zero(), 32, 256, wrappedRng));
     grassPatch.createInstances([{ mesh: grassBladeMesh, distance: 0 }]);
 
     scene.onBeforeRenderObservable.add(() => {

--- a/src/ts/playgrounds/grass.ts
+++ b/src/ts/playgrounds/grass.ts
@@ -1,0 +1,86 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { FreeCamera, MeshBuilder, PointLight, TransformNode, Vector3 } from "@babylonjs/core";
+import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { Scene } from "@babylonjs/core/scene";
+
+import { createGrassBlade } from "@/frontend/assets/procedural/grass/grassBlade";
+import { GrassMaterial } from "@/frontend/assets/procedural/grass/grassMaterial";
+import { loadTextures } from "@/frontend/assets/textures";
+import { createSquareMatrixBuffer } from "@/frontend/universe/planets/telluricPlanet/terrain/instancePatch/matrixBuffer";
+import { ThinInstancePatch } from "@/frontend/universe/planets/telluricPlanet/terrain/instancePatch/thinInstancePatch";
+
+export async function createGrassScene(
+    engine: AbstractEngine,
+    progressCallback: (progress: number, text: string) => void,
+): Promise<Scene> {
+    const scene = new Scene(engine);
+
+    const textures = await loadTextures((loadedCount, totalCount, lastItemName: string) => {
+        progressCallback(loadedCount / totalCount, `Loading ${lastItemName}`);
+    }, scene);
+
+    // This creates and positions a free camera (non-mesh)
+    const camera = new FreeCamera("camera1", new Vector3(0, 5, -10), scene);
+
+    // This targets the camera to scene origin
+    camera.setTarget(Vector3.Zero());
+
+    // This attaches the camera to the canvas
+    camera.attachControl();
+
+    // This creates a light, aiming 0,1,0 - to the sky (non-mesh)
+    const light = new PointLight("light1", new Vector3(200, 800, 100), scene);
+    const lightSphere = MeshBuilder.CreateSphere(
+        "lightSphere",
+        {
+            diameter: 0.1,
+            segments: 8,
+        },
+        scene,
+    );
+    lightSphere.position = light.position;
+
+    const ground = MeshBuilder.CreateGround(
+        "ground",
+        {
+            width: 32,
+            height: 32,
+            subdivisions: 4,
+        },
+        scene,
+    );
+    ground.setEnabled(false);
+
+    const grassBladeMesh = createGrassBlade(scene, 5);
+    grassBladeMesh.isVisible = false;
+
+    const grassMaterial = new GrassMaterial(scene, textures.noises, false);
+    grassMaterial.setPlanet(ground);
+    grassBladeMesh.material = grassMaterial;
+
+    const grassPatch = new ThinInstancePatch(createSquareMatrixBuffer(Vector3.Zero(), 32, 256));
+    grassPatch.createInstances([{ mesh: grassBladeMesh, distance: 0 }]);
+
+    scene.onBeforeRenderObservable.add(() => {
+        const deltaSeconds = engine.getDeltaTime() / 1000;
+        grassMaterial.update([light], new Vector3(0, 10, 0), deltaSeconds);
+    });
+
+    return scene;
+}

--- a/src/ts/playgrounds/playgroundRegistry.ts
+++ b/src/ts/playgrounds/playgroundRegistry.ts
@@ -31,6 +31,7 @@ import { createDebugAssetsScene } from "./debugAssets";
 import { createDefaultScene } from "./default";
 import { createFlightDemoScene } from "./flightDemo";
 import { createGasPlanetScene } from "./gasPlanet";
+import { createGrassScene } from "./grass";
 import { createHyperspaceTunnelDemo } from "./hyperspaceTunnel";
 import { createOrbitalDemoScene } from "./orbitalDemo";
 import { createRingsScene } from "./rings";
@@ -78,6 +79,7 @@ export class PlaygroundRegistry {
         ["jupiter", createJupiterScene],
         ["saturn", createSaturnScene],
         ["sol", createSolScene],
+        ["grass", createGrassScene],
     ]);
 
     register(

--- a/tests/e2e/grass.spec.ts
+++ b/tests/e2e/grass.spec.ts
@@ -1,0 +1,7 @@
+import { test } from "@playwright/test";
+
+import { renderAndSnap } from "./utils/renderSnap";
+
+test("The grass playground renders correctly", async ({ page }) => {
+    await renderAndSnap(page, { scene: "grass", shotName: "baseline", flagToWait: "frozen", urlParams: { freeze: 1 } });
+});

--- a/tests/e2e/grass.spec.ts-snapshots/baseline-linux.png
+++ b/tests/e2e/grass.spec.ts-snapshots/baseline-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3a32bd07a0663654869aa9dc095e9f15bf92400a4774e92fc5f6fc9e0ed3a4b
+size 1301815


### PR DESCRIPTION
## Related Tickets

Fixes #413 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

The shading system only really used the ambient light, so it looked weird when the light source was not white. Now it's better.

![baseline-linux](https://github.com/user-attachments/assets/475e9715-d9bc-4534-9c76-1295e8f46839)

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

Rendering the grass in the PG was not easy because of the stupid coupling to the planets I introduced back then. Cleaning this mess will definitely be part of 2.0

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

`pnpm test:e2e:docker`  and also a playground at `/playground.html?scene=grass`

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

Fix more bugs, and rework asset scattering system