### PR TITLE
Fix calling undefined on navigator when getLayoutMap is undefined

### DIFF
--- a/src/ts/frontend/cosmosJourneyer.ts
+++ b/src/ts/frontend/cosmosJourneyer.ts
@@ -73,6 +73,7 @@ import {
     UniverseCoordinates,
 } from "@/utils/coordinates/universeCoordinates";
 import { hashArray } from "@/utils/hash";
+import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
 import { positionNearObject } from "@/utils/positionNearObject";
 import { View } from "@/utils/view";
 
@@ -506,7 +507,9 @@ export class CosmosJourneyer {
 
         await starSystemView.resetPlayer();
 
-        if (!navigator.keyboard) {
+        const keyboardLayoutMap = await getGlobalKeyboardLayoutMap();
+
+        if (keyboardLayoutMap === null) {
             await alertModal(
                 "Your keyboard layout could not be detected. The QWERTY layout will be assumed by default.",
                 soundPlayer,

--- a/src/ts/frontend/starSystemView.ts
+++ b/src/ts/frontend/starSystemView.ts
@@ -259,7 +259,7 @@ export class StarSystemView implements View {
         this.assets = assets;
 
         void getGlobalKeyboardLayoutMap().then((keyboardLayoutMap) => {
-            this.keyboardLayoutMap = keyboardLayoutMap;
+            this.keyboardLayoutMap = keyboardLayoutMap ?? new Map<string, string>();
         });
 
         StarSystemInputs.map.toggleUi.on("complete", () => {

--- a/src/ts/utils/keyboardAPI.spec.ts
+++ b/src/ts/utils/keyboardAPI.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getGlobalKeyboardLayoutMap } from "./keyboardAPI";
+
+describe("getGlobalKeyboardLayoutMap", () => {
+    const originalNavigator = global.navigator;
+    const mockMap = new Map([
+        ["KeyA", "a"],
+        ["KeyB", "b"],
+    ]);
+    const mockGetLayoutMap = vi.fn().mockResolvedValue(mockMap);
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        // Restore the original navigator
+        Object.defineProperty(global, "navigator", {
+            value: originalNavigator,
+            writable: true,
+        });
+    });
+
+    it("should return keyboard layout map when navigator.keyboard and getLayoutMap are available", async () => {
+        // Mock navigator.keyboard with getLayoutMap function
+        Object.defineProperty(global, "navigator", {
+            value: {
+                keyboard: {
+                    getLayoutMap: mockGetLayoutMap,
+                },
+            },
+            writable: true,
+        });
+
+        const result = await getGlobalKeyboardLayoutMap();
+
+        expect(mockGetLayoutMap).toHaveBeenCalledTimes(1);
+        expect(result).toBe(mockMap);
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("should return empty map when navigator.keyboard exists but getLayoutMap is undefined", async () => {
+        // Mock navigator.keyboard without getLayoutMap
+        Object.defineProperty(global, "navigator", {
+            value: {
+                keyboard: {
+                    getLayoutMap: undefined,
+                },
+            },
+            writable: true,
+        });
+
+        const result = await getGlobalKeyboardLayoutMap();
+
+        expect(result).toBeInstanceOf(Map);
+        expect(result.size).toBe(0);
+        expect(consoleWarnSpy).toHaveBeenCalledWith("navigator.keyboard is not available, returning an empty map");
+    });
+
+    it("should return empty map when navigator.keyboard is undefined", async () => {
+        // Mock navigator without keyboard
+        Object.defineProperty(global, "navigator", {
+            value: {
+                keyboard: undefined,
+            },
+            writable: true,
+        });
+
+        const result = await getGlobalKeyboardLayoutMap();
+
+        expect(result).toBeInstanceOf(Map);
+        expect(result.size).toBe(0);
+        expect(consoleWarnSpy).toHaveBeenCalledWith("navigator.keyboard is not available, returning an empty map");
+    });
+});

--- a/src/ts/utils/keyboardAPI.spec.ts
+++ b/src/ts/utils/keyboardAPI.spec.ts
@@ -36,7 +36,7 @@ describe("getGlobalKeyboardLayoutMap", () => {
         expect(result).toBe(mockMap);
     });
 
-    it("should return empty map when navigator.keyboard exists but getLayoutMap is undefined", async () => {
+    it("should return null when navigator.keyboard exists but getLayoutMap is undefined", async () => {
         // Mock navigator.keyboard without getLayoutMap
         Object.defineProperty(global, "navigator", {
             value: {
@@ -52,7 +52,7 @@ describe("getGlobalKeyboardLayoutMap", () => {
         expect(result).toBe(null);
     });
 
-    it("should return empty map when navigator.keyboard is undefined", async () => {
+    it("should return null when navigator.keyboard is undefined", async () => {
         // Mock navigator without keyboard
         Object.defineProperty(global, "navigator", {
             value: {

--- a/src/ts/utils/keyboardAPI.spec.ts
+++ b/src/ts/utils/keyboardAPI.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getGlobalKeyboardLayoutMap } from "./keyboardAPI";
 
@@ -9,11 +9,6 @@ describe("getGlobalKeyboardLayoutMap", () => {
         ["KeyB", "b"],
     ]);
     const mockGetLayoutMap = vi.fn().mockResolvedValue(mockMap);
-    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
-
-    beforeEach(() => {
-        consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    });
 
     afterEach(() => {
         vi.restoreAllMocks();
@@ -39,7 +34,6 @@ describe("getGlobalKeyboardLayoutMap", () => {
 
         expect(mockGetLayoutMap).toHaveBeenCalledTimes(1);
         expect(result).toBe(mockMap);
-        expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it("should return empty map when navigator.keyboard exists but getLayoutMap is undefined", async () => {
@@ -55,9 +49,7 @@ describe("getGlobalKeyboardLayoutMap", () => {
 
         const result = await getGlobalKeyboardLayoutMap();
 
-        expect(result).toBeInstanceOf(Map);
-        expect(result.size).toBe(0);
-        expect(consoleWarnSpy).toHaveBeenCalledWith("navigator.keyboard is not available, returning an empty map");
+        expect(result).toBe(null);
     });
 
     it("should return empty map when navigator.keyboard is undefined", async () => {
@@ -71,8 +63,6 @@ describe("getGlobalKeyboardLayoutMap", () => {
 
         const result = await getGlobalKeyboardLayoutMap();
 
-        expect(result).toBeInstanceOf(Map);
-        expect(result.size).toBe(0);
-        expect(consoleWarnSpy).toHaveBeenCalledWith("navigator.keyboard is not available, returning an empty map");
+        expect(result).toBe(null);
     });
 });

--- a/src/ts/utils/keyboardAPI.ts
+++ b/src/ts/utils/keyboardAPI.ts
@@ -2,14 +2,14 @@ declare global {
     interface Navigator {
         keyboard:
             | {
-                  getLayoutMap: () => Promise<Map<string, string>>;
+                  getLayoutMap: (() => Promise<Map<string, string>>) | undefined;
               }
             | undefined;
     }
 }
 
 export function getGlobalKeyboardLayoutMap(): Promise<Map<string, string>> {
-    if (navigator.keyboard !== undefined) {
+    if (navigator.keyboard !== undefined && navigator.keyboard.getLayoutMap !== undefined) {
         return navigator.keyboard.getLayoutMap();
     }
     console.warn("navigator.keyboard is not available, returning an empty map");

--- a/src/ts/utils/keyboardAPI.ts
+++ b/src/ts/utils/keyboardAPI.ts
@@ -8,6 +8,9 @@ declare global {
     }
 }
 
+/**
+ * @returns A promise that resolves to a Map of keyboard layout keys and their corresponding characters, or null if the API is not available.
+ */
 export async function getGlobalKeyboardLayoutMap(): Promise<Map<string, string> | null> {
     return (await navigator.keyboard?.getLayoutMap?.()) ?? null;
 }

--- a/src/ts/utils/keyboardAPI.ts
+++ b/src/ts/utils/keyboardAPI.ts
@@ -8,10 +8,6 @@ declare global {
     }
 }
 
-export function getGlobalKeyboardLayoutMap(): Promise<Map<string, string>> {
-    if (navigator.keyboard !== undefined && navigator.keyboard.getLayoutMap !== undefined) {
-        return navigator.keyboard.getLayoutMap();
-    }
-    console.warn("navigator.keyboard is not available, returning an empty map");
-    return Promise.resolve(new Map<string, string>());
+export async function getGlobalKeyboardLayoutMap(): Promise<Map<string, string> | null> {
+    return (await navigator.keyboard?.getLayoutMap?.()) ?? null;
 }


### PR DESCRIPTION
Add unit tests to ensure this never happens again

## Related Tickets

Fixes #421 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

The game could crash on systems implementing a partial keyboard API support.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Run unit tests `pnpm test:unit`

Start the game, it should not display a black screen.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

None