### PR TITLE
Fix warp tunnel stuttering at low speed

### DIFF
--- a/src/ts/frontend/assets/procedural/warpTunnel.ts
+++ b/src/ts/frontend/assets/procedural/warpTunnel.ts
@@ -65,6 +65,8 @@ export class WarpTunnel implements Transformable {
     private emitPeriod = 1;
     private emitCounter = 0;
 
+    private currentForce = Vector3.Zero();
+
     private lastDeltaSeconds = 0;
 
     constructor(scene: Scene) {
@@ -97,7 +99,6 @@ export class WarpTunnel implements Transformable {
                 } else {
                     this.nbParticlesAlive++;
                 }
-                particle.position.z = 0;
             }
         };
 
@@ -113,10 +114,7 @@ export class WarpTunnel implements Transformable {
         SPS.updateParticle = (particle) => {
             if (!particle.isVisible) return particle;
 
-            const particleDirection = this.particleToDirection.get(particle) ?? this.particleDirection;
-            this.particleToDirection.set(particle, particleDirection);
-
-            particle.velocity.copyFrom(particleDirection.scale(this.particleSpeed));
+            particle.velocity.addInPlace(this.currentForce.scale(this.lastDeltaSeconds));
 
             particle.position.addInPlace(particle.velocity.scale(this.lastDeltaSeconds));
 
@@ -161,6 +159,11 @@ export class WarpTunnel implements Transformable {
         particle.rotationQuaternion = this.particleRotationQuaternion;
 
         particle.scaling = this.particleScaling;
+
+        const particleDirection = this.particleToDirection.get(particle) ?? this.particleDirection;
+        this.particleToDirection.set(particle, particleDirection);
+
+        particle.velocity.copyFrom(particleDirection.scale(this.particleSpeed));
     }
 
     private updateGlobals() {
@@ -182,6 +185,10 @@ export class WarpTunnel implements Transformable {
         }
         particle.isVisible = true;
         this.initParticle(particle);
+    }
+
+    public applyForce(force: Vector3) {
+        this.currentForce.addInPlace(force);
     }
 
     update(deltaSeconds: number) {

--- a/src/ts/frontend/assets/procedural/warpTunnel.ts
+++ b/src/ts/frontend/assets/procedural/warpTunnel.ts
@@ -18,7 +18,7 @@
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
-import { RandomRange, RangeToPercent } from "@babylonjs/core/Maths/math.scalar.functions";
+import { RangeToPercent } from "@babylonjs/core/Maths/math.scalar.functions";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
@@ -26,7 +26,7 @@ import { SolidParticle } from "@babylonjs/core/Particles/solidParticle";
 import { SolidParticleSystem } from "@babylonjs/core/Particles/solidParticleSystem";
 import { Scene } from "@babylonjs/core/scene";
 
-import { getForwardDirection } from "@/frontend/uberCore/transforms/basicTransform";
+//import { getForwardDirection } from "@/frontend/uberCore/transforms/basicTransform";
 
 import { Transformable } from "../../universe/architecture/transformable";
 
@@ -36,9 +36,6 @@ import { Transformable } from "../../universe/architecture/transformable";
  * @see https://playground.babylonjs.com/#W9LE0U#28
  */
 export class WarpTunnel implements Transformable {
-    readonly anchor: TransformNode;
-    readonly parent: TransformNode;
-
     readonly solidParticleSystem: SolidParticleSystem;
 
     private throttle = 0;
@@ -51,12 +48,6 @@ export class WarpTunnel implements Transformable {
     private targetNbParticles = 0;
 
     private recycledParticles: SolidParticle[] = [];
-
-    private readonly spaceshipDisplacement = Vector3.Zero();
-
-    private readonly oldShipPosition = Vector3.Zero();
-
-    private readonly spaceshipForward = Vector3.Zero();
 
     private readonly particleScaling = new Vector3(0.1, 0.1, 4);
 
@@ -76,15 +67,7 @@ export class WarpTunnel implements Transformable {
 
     private lastDeltaSeconds = 0;
 
-    constructor(parent: TransformNode, scene: Scene) {
-        this.anchor = new TransformNode("anchor", scene);
-        this.anchor.position = new Vector3(0, 0, WarpTunnel.TUNNEL_LENGTH / 2);
-        this.anchor.rotationQuaternion = Quaternion.Identity();
-        this.anchor.computeWorldMatrix(true);
-
-        this.anchor.parent = parent;
-        this.parent = parent;
-
+    constructor(scene: Scene) {
         const SPS = new SolidParticleSystem("SPS", scene);
         const poly = MeshBuilder.CreatePolyhedron("p", { type: 1 });
         SPS.addShape(poly, WarpTunnel.MAX_NB_PARTICLES);
@@ -114,7 +97,7 @@ export class WarpTunnel implements Transformable {
                 } else {
                     this.nbParticlesAlive++;
                 }
-                particle.position.z = RandomRange(-WarpTunnel.TUNNEL_LENGTH / 2, WarpTunnel.TUNNEL_LENGTH / 2);
+                particle.position.z = 0;
             }
         };
 
@@ -136,12 +119,11 @@ export class WarpTunnel implements Transformable {
             particle.velocity.copyFrom(particleDirection.scale(this.particleSpeed));
 
             particle.position.addInPlace(particle.velocity.scale(this.lastDeltaSeconds));
-            particle.position.addInPlace(this.spaceshipDisplacement);
 
-            const relativePosition = particle.position.subtract(this.parent.position);
-            const localZ = relativePosition.dot(this.spaceshipForward);
+            const relativePosition = particle.position; //.subtract(this.parent.position);
+            const localZ = relativePosition.z; //.dot(this.spaceshipForward);
 
-            if (localZ < -WarpTunnel.TUNNEL_LENGTH / 2 || relativePosition.length() > WarpTunnel.TUNNEL_LENGTH / 2) {
+            if (localZ < -WarpTunnel.TUNNEL_LENGTH / 2) {
                 SPS.recycleParticle(particle);
                 this.nbParticlesAlive--;
                 return particle;
@@ -172,7 +154,7 @@ export class WarpTunnel implements Transformable {
         particle.position.addInPlace(this.tunnelAxis1.scale(r * Math.cos(theta)));
         particle.position.addInPlace(this.tunnelAxis2.scale(r * Math.sin(theta)));
         particle.position.addInPlace(this.particleDirection.scale(Math.random() * 10));
-        particle.position.addInPlace(this.anchor.getAbsolutePosition());
+        particle.position.z += WarpTunnel.TUNNEL_LENGTH / 2;
 
         this.particleToDirection.set(particle, this.particleDirection.clone());
 
@@ -182,10 +164,8 @@ export class WarpTunnel implements Transformable {
     }
 
     private updateGlobals() {
-        this.particleRotationQuaternion.copyFrom(this.anchor.absoluteRotationQuaternion);
-        this.particleDirection.copyFrom(
-            this.parent.getAbsolutePosition().subtract(this.anchor.getAbsolutePosition()).normalize(),
-        );
+        this.particleRotationQuaternion.copyFrom(Quaternion.Identity());
+        this.particleDirection.copyFromFloats(0, 0, -1);
 
         this.tunnelAxis1.copyFrom(this.particleDirection.add(new Vector3(Math.random(), Math.random(), Math.random())));
         this.tunnelAxis1.subtractInPlace(this.particleDirection.scale(this.tunnelAxis1.dot(this.particleDirection)));
@@ -208,14 +188,6 @@ export class WarpTunnel implements Transformable {
         this.lastDeltaSeconds = deltaSeconds;
 
         this.particleSpeed = 200 * (1 + this.throttle);
-
-        const newShipPosition = this.parent.getAbsolutePosition().clone();
-
-        this.spaceshipDisplacement.copyFrom(newShipPosition.subtract(this.oldShipPosition));
-
-        this.oldShipPosition.copyFrom(newShipPosition);
-
-        this.spaceshipForward.copyFrom(getForwardDirection(this.parent));
 
         this.updateGlobals();
 
@@ -254,12 +226,11 @@ export class WarpTunnel implements Transformable {
     }
 
     getTransform(): TransformNode {
-        return this.anchor;
+        return this.solidParticleSystem.mesh;
     }
 
     dispose() {
         this.solidParticleSystem.dispose();
-        this.anchor.dispose();
         this.particleToDirection.clear();
     }
 }

--- a/src/ts/frontend/spaceship/shipControls.ts
+++ b/src/ts/frontend/spaceship/shipControls.ts
@@ -373,6 +373,10 @@ export class ShipControls implements Controls {
             roll(this.getTransform(), this.spaceship.maxRollSpeed * this.rotationInertia.x * deltaSeconds);
             yaw(this.getTransform(), -this.spaceship.maxYawSpeed * this.rotationInertia.x * deltaSeconds);
             pitch(this.getTransform(), this.spaceship.maxPitchSpeed * this.rotationInertia.y * deltaSeconds);
+
+            this.spaceship.warpTunnel.applyForce(
+                new Vector3(this.rotationInertia.x, this.rotationInertia.y, 0).scale(-1),
+            );
         }
 
         this.thirdPersonCameraTransform.position =

--- a/src/ts/frontend/spaceship/spaceship.ts
+++ b/src/ts/frontend/spaceship/spaceship.ts
@@ -186,7 +186,9 @@ export class Spaceship implements Transformable {
 
         this.landingComputer = new LandingComputer(this.aggregate, scene.getPhysicsEngine() as PhysicsEngineV2);
 
-        this.warpTunnel = new WarpTunnel(this.getTransform(), scene);
+        this.warpTunnel = new WarpTunnel(scene);
+        this.warpTunnel.getTransform().parent = this.getTransform();
+
         this.hyperSpaceTunnel = new HyperSpaceTunnel(
             this.getTransform().getDirection(Axis.Z),
             scene,

--- a/src/ts/playgrounds/playgroundRegistry.ts
+++ b/src/ts/playgrounds/playgroundRegistry.ts
@@ -45,6 +45,7 @@ import { createStarSystemViewScene } from "./starSystemView";
 import { createBlackHoleScene } from "./stellarObjects/blackHole";
 import { createNeutronStarScene } from "./stellarObjects/neutronStar";
 import { createTutorialScene } from "./tutorial";
+import { createWarpTunnelScene } from "./warpTunnel";
 import { createXrScene } from "./xr";
 
 export class PlaygroundRegistry {
@@ -80,6 +81,7 @@ export class PlaygroundRegistry {
         ["saturn", createSaturnScene],
         ["sol", createSolScene],
         ["grass", createGrassScene],
+        ["warpTunnel", createWarpTunnelScene],
     ]);
 
     register(

--- a/src/ts/playgrounds/warpTunnel.ts
+++ b/src/ts/playgrounds/warpTunnel.ts
@@ -1,0 +1,52 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { FreeCamera, MeshBuilder, Vector3 } from "@babylonjs/core";
+import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { Scene } from "@babylonjs/core/scene";
+
+import { WarpTunnel } from "@/frontend/assets/procedural/warpTunnel";
+
+import { enablePhysics } from "./utils";
+
+export async function createWarpTunnelScene(
+    engine: AbstractEngine,
+    progressCallback: (progress: number, text: string) => void,
+): Promise<Scene> {
+    const scene = new Scene(engine);
+    scene.useRightHandedSystem = true;
+
+    const freeCamera = new FreeCamera("FreeCamera", new Vector3(0, 0, 0), scene);
+    freeCamera.attachControl();
+
+    await enablePhysics(scene);
+
+    const anchor = MeshBuilder.CreateBox("Anchor", { size: 10 }, scene);
+    anchor.position.z = 200;
+
+    const warpTunnel = new WarpTunnel(anchor, scene);
+    warpTunnel.setThrottle(1);
+
+    scene.onBeforeRenderObservable.add(() => {
+        const deltaSeconds = engine.getDeltaTime() / 1000;
+        warpTunnel.update(deltaSeconds);
+    });
+
+    progressCallback(1, "Warp tunnel scene loaded");
+
+    return scene;
+}


### PR DESCRIPTION
## Related Tickets

Fixes #412 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

There was a synchronization issue between the ship and the particle system at low speed (30km/s) that made the particle stutter.

This is now fixed, and the direction lag has been reimplemented using forces.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None.

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

- `pnpm serve`
- go to http://localhost:8080/playground.html?scene=starSystemView
- press H to engage the warp drive
- the particles should not stutter

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

None