### PR TITLE
Fix GLSL preprocessor error in Windows desktop app

### DIFF
--- a/src/shaders/lensflare.glsl
+++ b/src/shaders/lensflare.glsl
@@ -25,8 +25,6 @@ float getSun(vec2 uv){
     return length(uv) < 0.009 ? 1.0 : 0.0;
 }
 
-#define CHEAP_FLARE
-
 //from: https://www.shadertoy.com/view/XdfXRX
 vec3 lensflares(vec2 uv, vec2 pos, float fadeOut)
 {
@@ -71,11 +69,10 @@ vec3 lensflares(vec2 uv, vec2 pos, float fadeOut)
 
     return sunflare+lensflare;
 }
-//
 
 
 // based on https://www.shadertoy.com/view/XsGfWV
-vec3 anflares(vec2 uv, float threshold, float intensity, float stretch, float brightness, float fadeOut)
+/*vec3 anflares(vec2 uv, float threshold, float intensity, float stretch, float brightness, float fadeOut)
 {
     threshold = 1.0 - threshold;
 
@@ -93,10 +90,7 @@ vec3 anflares(vec2 uv, float threshold, float intensity, float stretch, float br
     }
 
     return hdr*brightness;
-}
-
-
-
+}*/
 
 
 vec3 anflares(vec2 uv, float intensity, float stretch, float brightness)
@@ -137,14 +131,11 @@ void main() {
 
     vec3 flare = lensflares(uv*1.5, mouse*1.5, fadeOut);
 
-    #ifdef CHEAP_FLARE
     vec3 anflare = pow(anflares(uv-mouse, 400.0, 0.5, 0.6) * fadeOut, vec3(4.0));
     anflare += smoothstep(0.0025, 1.0, anflare)*10.0;
     anflare *= smoothstep(0.0, 1.0, anflare);
-    #else
-    vec3 anflare = pow(anflares(uv-mouse, 0.5, 400.0, 0.9, 0.1), vec3(4.0));
-    #endif
 
+    //vec3 anflare = pow(anflares(uv-mouse, 0.5, 400.0, 0.9, 0.1), vec3(4.0));
 
     vec3 sun = getSun(uv-mouse) * fadeOut + (flare + anflare)*flareColor*2.0;
 


### PR DESCRIPTION
## Related Tickets

Fixes #431 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

In the Windows desktop app, the GLSL preprocessor had an issue that removed some variable declarations, which were then accessed. This prevented shader compilation for the lens flare shader. By removing the preprocessor directives, the bug is no more.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

On windows, run `pnpm tauri dev`. The game should be displayed after the loading screen.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

It would be nice to have an E2E test that simulate the windows webview
