### PR TITLE
Fix doc gen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,20 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Format check
-              run: pnpm run format:check
+              run: pnpm format:check
 
             - name: Lint
-              run: pnpm run lint
+              run: pnpm lint
 
             - name: Test
               run: pnpm test:unit
 
+            - name: Build documentation
+              run: pnpm doc
+
             # ─────────── Build & E2E Tests ───────────
             - name: Build
-              run: pnpm run build
+              run: pnpm build
 
               # ─────────── build test image (local load, no push)
             - name: Build Docker image

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,7 +3,11 @@
     "out": "doc",
     "theme": "typedoc-github-theme",
     "exclude": ["**/node_modules/**/*.*", "**/test/**/*.*"],
-    "entryPoints": ["src/ts/cosmosJourneyer.ts", "src/ts/starmap/starMap.ts", "src/ts/starSystem/starSystemView.ts"],
+    "entryPoints": [
+        "src/ts/frontend/cosmosJourneyer.ts",
+        "src/ts/frontend/starmap/starMap.ts",
+        "src/ts/frontend/starSystemView.ts"
+    ],
     "visibilityFilters": {
         "protected": false,
         "private": false,


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Doc gen was broken, preventing deployment. To avoid this issue in the future, doc gen has been added to main CI: it will fail before merging now. 

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

`pnpm doc` should not fail

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

None

<!--
What should we do next to take advantage of this work?
-->
