### PR TITLE
Fix jsonSafeParse and add tests

### DIFF
--- a/src/ts/utils/json.spec.ts
+++ b/src/ts/utils/json.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "vitest";
+
+import { jsonSafeParse } from "@/utils/json";
+
+test("jsonSafeParse returns object for valid JSON", () => {
+    const result = jsonSafeParse('{"a":1,"b":"test"}');
+    expect(result).toEqual({ a: 1, b: "test" });
+});
+
+test("jsonSafeParse returns null on invalid JSON", () => {
+    expect(jsonSafeParse('invalid')).toBeNull();
+});
+
+test("jsonSafeParse returns null for non-object JSON", () => {
+    expect(jsonSafeParse('123')).toBeNull();
+    expect(jsonSafeParse('[1,2,3]')).toBeNull();
+});

--- a/src/ts/utils/json.ts
+++ b/src/ts/utils/json.ts
@@ -17,11 +17,12 @@
 
 import { z } from "zod";
 
-const JsonSchema = z.object({});
+const JsonSchema = z.record(z.unknown());
 
 export function jsonSafeParse(jsonString: string): Record<string, unknown> | null {
     try {
-        return JsonSchema.parse(JSON.parse(jsonString));
+        const parsed = JSON.parse(jsonString);
+        return JsonSchema.parse(parsed);
     } catch {
         return null;
     }


### PR DESCRIPTION
## Summary
- improve `jsonSafeParse` to handle any JSON object and return `null` on invalid values
- add unit tests for `jsonSafeParse`
- move unit tests to `src/ts/utils/json.spec.ts`

## Testing
- `pnpm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_683ff059d8108328ac386c743ac85b8b