### PR TITLE
Fix number formatting in slot component UI

### DIFF
--- a/src/ts/frontend/ui/spaceStation/componentSpecUI.ts
+++ b/src/ts/frontend/ui/spaceStation/componentSpecUI.ts
@@ -104,7 +104,7 @@ export class ComponentSpecUI {
         const container = document.createElement("div");
 
         const scoopRate = document.createElement("p");
-        scoopRate.innerText = `${i18n.t("spaceStation:scoopRate")}: ${spec.fuelPerSecond} L/s`;
+        scoopRate.innerText = `${i18n.t("spaceStation:scoopRate")}: ${spec.fuelPerSecond.toLocaleString(undefined, { maximumSignificantDigits: 3 })} L/s`;
         container.appendChild(scoopRate);
 
         return container;
@@ -115,7 +115,7 @@ export class ComponentSpecUI {
         const container = document.createElement("div");
 
         const capacity = document.createElement("p");
-        capacity.innerText = `${i18n.t("spaceStation:capacity")}: ${spec.maxFuel} L`;
+        capacity.innerText = `${i18n.t("spaceStation:capacity")}: ${spec.maxFuel.toLocaleString(undefined, { maximumSignificantDigits: 3 })} L`;
         container.appendChild(capacity);
 
         return container;
@@ -126,7 +126,7 @@ export class ComponentSpecUI {
         const container = document.createElement("div");
 
         const relativeRange = document.createElement("p");
-        relativeRange.innerText = `${i18n.t("spaceStation:relativeRange")}: ${spec.relativeRange}`;
+        relativeRange.innerText = `${i18n.t("spaceStation:relativeRange")}: ${spec.relativeRange.toLocaleString(undefined, { maximumSignificantDigits: 3 })}`;
         container.appendChild(relativeRange);
 
         return container;


### PR DESCRIPTION
## Summary
- avoid showing long decimals in slot component info
- format values for scoop rate, fuel tank capacity and scanner range

## Testing
- `pnpm lint`
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6842b54243d08328b90e0a0f03a3a0f1