### PR TITLE
Feature: make rayleigh scattering related to atmosphere composition

### DIFF
--- a/src/ts/backend/universe/customSystems/alphaTestis.ts
+++ b/src/ts/backend/universe/customSystems/alphaTestis.ts
@@ -59,7 +59,7 @@ export function getAlphaTestisSystemModel(): StarSystemModel {
 
     const ares = newSeededTelluricPlanetModel("ares", 0.3725, "Ares", [weierstrass]);
     if (ares.clouds !== null) ares.clouds.coverage = 1;
-    if (ares.atmosphere !== null) ares.atmosphere.pressure = Settings.EARTH_SEA_LEVEL_PRESSURE * 0.5;
+    if (ares.atmosphere !== null) ares.atmosphere.seaLevelPressure = Settings.EARTH_SEA_LEVEL_PRESSURE * 0.5;
 
     ares.orbit.semiMajorAxis = 25100 * hecate.radius;
 

--- a/src/ts/backend/universe/customSystems/sol/jupiter.ts
+++ b/src/ts/backend/universe/customSystems/sol/jupiter.ts
@@ -45,6 +45,10 @@ export function getJupiterModel(parentIds: ReadonlyArray<OrbitalObjectId>): GasP
         atmosphere: {
             pressure: Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.7,
+            gasMix: [
+                ["H2", 0.9],
+                ["He", 0.1],
+            ],
         },
         colorPalette: {
             type: "textured",

--- a/src/ts/backend/universe/customSystems/sol/jupiter.ts
+++ b/src/ts/backend/universe/customSystems/sol/jupiter.ts
@@ -43,7 +43,7 @@ export function getJupiterModel(parentIds: ReadonlyArray<OrbitalObjectId>): GasP
             p: 2,
         },
         atmosphere: {
-            pressure: Settings.BAR_TO_PASCAL,
+            seaLevelPressure: Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.7,
             gasMix: [
                 ["H2", 0.9],

--- a/src/ts/backend/universe/customSystems/sol/saturn.ts
+++ b/src/ts/backend/universe/customSystems/sol/saturn.ts
@@ -45,6 +45,10 @@ export function getSaturnModel(parentIds: ReadonlyArray<OrbitalObjectId>): GasPl
         atmosphere: {
             pressure: Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.5,
+            gasMix: [
+                ["H2", 0.9],
+                ["He", 0.1],
+            ],
         },
         colorPalette: {
             type: "textured",

--- a/src/ts/backend/universe/customSystems/sol/saturn.ts
+++ b/src/ts/backend/universe/customSystems/sol/saturn.ts
@@ -43,7 +43,7 @@ export function getSaturnModel(parentIds: ReadonlyArray<OrbitalObjectId>): GasPl
             p: 2,
         },
         atmosphere: {
-            pressure: Settings.BAR_TO_PASCAL,
+            seaLevelPressure: Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.5,
             gasMix: [
                 ["H2", 0.9],

--- a/src/ts/backend/universe/customSystems/sol/sol.ts
+++ b/src/ts/backend/universe/customSystems/sol/sol.ts
@@ -319,7 +319,7 @@ export function getSolSystemModel(): StarSystemModel {
             textureId: "uranus",
         },
         atmosphere: {
-            seaLevelPressure: 1.0 * Settings.BAR_TO_PASCAL,
+            seaLevelPressure: Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.5,
             gasMix: [
                 ["H2", 0.83],
@@ -359,7 +359,7 @@ export function getSolSystemModel(): StarSystemModel {
             textureId: "neptune",
         },
         atmosphere: {
-            seaLevelPressure: 1.0 * Settings.BAR_TO_PASCAL,
+            seaLevelPressure: Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.7,
             gasMix: [
                 ["H2", 0.8],

--- a/src/ts/backend/universe/customSystems/sol/sol.ts
+++ b/src/ts/backend/universe/customSystems/sol/sol.ts
@@ -82,7 +82,7 @@ export function getSolSystemModel(): StarSystemModel {
         name: "Venus",
         type: OrbitalObjectType.TELLURIC_PLANET,
         radius: 6_051.8e3,
-        mass: 4.8e20,
+        mass: 4.865e24,
         axialTilt: Tools.ToRadians(177.36),
         siderealDaySeconds: 60 * 60 * 24 * 243.025,
         waterAmount: 0,
@@ -319,7 +319,7 @@ export function getSolSystemModel(): StarSystemModel {
             textureId: "uranus",
         },
         atmosphere: {
-            pressure: 0.1 * Settings.BAR_TO_PASCAL,
+            pressure: 1.0 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.5,
             gasMix: [
                 ["H2", 0.83],
@@ -359,7 +359,7 @@ export function getSolSystemModel(): StarSystemModel {
             textureId: "neptune",
         },
         atmosphere: {
-            pressure: 0.1 * Settings.BAR_TO_PASCAL,
+            pressure: 1.0 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.7,
             gasMix: [
                 ["H2", 0.8],

--- a/src/ts/backend/universe/customSystems/sol/sol.ts
+++ b/src/ts/backend/universe/customSystems/sol/sol.ts
@@ -114,7 +114,7 @@ export function getSolSystemModel(): StarSystemModel {
         },
         rings: null,
         atmosphere: {
-            pressure: 93 * Settings.BAR_TO_PASCAL,
+            seaLevelPressure: 93 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.99,
             gasMix: [
                 ["CO2", 0.96],
@@ -174,7 +174,7 @@ export function getSolSystemModel(): StarSystemModel {
         },
         rings: null,
         atmosphere: {
-            pressure: 1 * Settings.BAR_TO_PASCAL,
+            seaLevelPressure: 1 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.5,
             gasMix: [
                 ["N2", 0.78],
@@ -277,7 +277,7 @@ export function getSolSystemModel(): StarSystemModel {
             mountains_frequency: 0,
         },
         atmosphere: {
-            pressure: 0.006 * Settings.BAR_TO_PASCAL,
+            seaLevelPressure: 0.006 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.1,
             gasMix: [
                 ["CO2", 0.95],
@@ -319,7 +319,7 @@ export function getSolSystemModel(): StarSystemModel {
             textureId: "uranus",
         },
         atmosphere: {
-            pressure: 1.0 * Settings.BAR_TO_PASCAL,
+            seaLevelPressure: 1.0 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.5,
             gasMix: [
                 ["H2", 0.83],
@@ -359,7 +359,7 @@ export function getSolSystemModel(): StarSystemModel {
             textureId: "neptune",
         },
         atmosphere: {
-            pressure: 1.0 * Settings.BAR_TO_PASCAL,
+            seaLevelPressure: 1.0 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.7,
             gasMix: [
                 ["H2", 0.8],

--- a/src/ts/backend/universe/customSystems/sol/sol.ts
+++ b/src/ts/backend/universe/customSystems/sol/sol.ts
@@ -116,6 +116,10 @@ export function getSolSystemModel(): StarSystemModel {
         atmosphere: {
             pressure: 93 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.99,
+            gasMix: [
+                ["CO2", 0.96],
+                ["N2", 0.04],
+            ],
         },
         clouds: {
             layerRadius: 6_051.8e3 + 10e3,
@@ -172,6 +176,11 @@ export function getSolSystemModel(): StarSystemModel {
         atmosphere: {
             pressure: 1 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.5,
+            gasMix: [
+                ["N2", 0.78],
+                ["O2", 0.21],
+                ["Ar", 0.01],
+            ],
         },
         clouds: {
             layerRadius: 6_371e3 + 30e3,
@@ -270,6 +279,12 @@ export function getSolSystemModel(): StarSystemModel {
         atmosphere: {
             pressure: 0.006 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.1,
+            gasMix: [
+                ["CO2", 0.95],
+                ["N2", 0.03],
+                ["Ar", 0.01],
+                ["O2", 0.01],
+            ],
         },
         rings: null,
         clouds: null,
@@ -306,6 +321,11 @@ export function getSolSystemModel(): StarSystemModel {
         atmosphere: {
             pressure: 0.1 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.5,
+            gasMix: [
+                ["H2", 0.83],
+                ["He", 0.15],
+                ["CH4", 0.02],
+            ],
         },
         rings: {
             innerRadius: 50_724e3,
@@ -341,6 +361,11 @@ export function getSolSystemModel(): StarSystemModel {
         atmosphere: {
             pressure: 0.1 * Settings.BAR_TO_PASCAL,
             greenHouseEffectFactor: 0.7,
+            gasMix: [
+                ["H2", 0.8],
+                ["He", 0.19],
+                ["CH4", 0.01],
+            ],
         },
         rings: null,
         seed: 0,

--- a/src/ts/backend/universe/orbitalObjects/atmosphereModel.ts
+++ b/src/ts/backend/universe/orbitalObjects/atmosphereModel.ts
@@ -19,9 +19,10 @@ export type Gas = "N2" | "O2" | "Ar" | "CO2" | "He" | "Ne" | "H2" | "CH4" | "SO2
 
 export type AtmosphereModel = {
     /**
-     * The pressure of the atmosphere in Pa
+     * The pressure of the atmosphere in Pa at sea level.
+     * For Gas giants, this is always 101325 Pa (1 bar) by definition.
      */
-    pressure: number;
+    seaLevelPressure: number;
 
     /**
      * The amount of greenhouse gases in the atmosphere (between 0 and 1)

--- a/src/ts/backend/universe/orbitalObjects/atmosphereModel.ts
+++ b/src/ts/backend/universe/orbitalObjects/atmosphereModel.ts
@@ -15,6 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { Gas } from "@/utils/physics/atmosphere/gas";
+
 export type AtmosphereModel = {
     /**
      * The pressure of the atmosphere in Pa
@@ -25,4 +27,10 @@ export type AtmosphereModel = {
      * The amount of greenhouse gases in the atmosphere (between 0 and 1)
      */
     greenHouseEffectFactor: number;
+
+    /**
+     * The composition of the atmosphere, as a list of gas and its associated Mole/volume fraction.
+     * The sum of all fractions must add up to 1.0
+     */
+    gasMix: Array<[Gas, number]>;
 };

--- a/src/ts/backend/universe/orbitalObjects/atmosphereModel.ts
+++ b/src/ts/backend/universe/orbitalObjects/atmosphereModel.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Gas } from "@/utils/physics/atmosphere/gas";
+export type Gas = "N2" | "O2" | "Ar" | "CO2" | "He" | "Ne" | "H2" | "CH4" | "SO2";
 
 export type AtmosphereModel = {
     /**

--- a/src/ts/backend/universe/orbitalObjects/gasPlanetModel.ts
+++ b/src/ts/backend/universe/orbitalObjects/gasPlanetModel.ts
@@ -42,7 +42,12 @@ export type GasPlanetColorPalette = GasPlanetProceduralColorPalette | GasPlanetT
 
 export type GasPlanetModel = CelestialBodyModelBase<OrbitalObjectType.GAS_PLANET> &
     HasSeed & {
-        atmosphere: AtmosphereModel;
+        atmosphere: AtmosphereModel & {
+            /**
+             * For gas giants, the surface is defined by the height at which the pressure is equal to 100,000 Pa (1 bar).
+             */
+            seaLevelPressure: 100_000;
+        };
         rings: RingsModel | null;
         colorPalette: GasPlanetColorPalette;
     };

--- a/src/ts/backend/universe/proceduralGenerators/gasPlanetModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/gasPlanetModelGenerator.ts
@@ -106,7 +106,7 @@ export function newSeededGasPlanetModel(
         axialTilt,
         mass,
         atmosphere: {
-            seaLevelPressure: Settings.EARTH_SEA_LEVEL_PRESSURE,
+            seaLevelPressure: 100_000, // 1 bar
             greenHouseEffectFactor: 0.5,
             gasMix: [
                 ["H2", 0.9],

--- a/src/ts/backend/universe/proceduralGenerators/gasPlanetModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/gasPlanetModelGenerator.ts
@@ -108,6 +108,10 @@ export function newSeededGasPlanetModel(
         atmosphere: {
             pressure: Settings.EARTH_SEA_LEVEL_PRESSURE,
             greenHouseEffectFactor: 0.5,
+            gasMix: [
+                ["H2", 0.9],
+                ["He", 0.1],
+            ],
         },
         rings: rings,
         colorPalette: {

--- a/src/ts/backend/universe/proceduralGenerators/gasPlanetModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/gasPlanetModelGenerator.ts
@@ -106,7 +106,7 @@ export function newSeededGasPlanetModel(
         axialTilt,
         mass,
         atmosphere: {
-            pressure: Settings.EARTH_SEA_LEVEL_PRESSURE,
+            seaLevelPressure: Settings.EARTH_SEA_LEVEL_PRESSURE,
             greenHouseEffectFactor: 0.5,
             gasMix: [
                 ["H2", 0.9],

--- a/src/ts/backend/universe/proceduralGenerators/telluricPlanetModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/telluricPlanetModelGenerator.ts
@@ -18,7 +18,7 @@
 import { Tools } from "@babylonjs/core/Misc/tools";
 import { normalRandom, randRangeInt, uniformRandBool } from "extended-random";
 
-import { AtmosphereModel } from "@/backend/universe/orbitalObjects/atmosphereModel";
+import { AtmosphereModel, Gas } from "@/backend/universe/orbitalObjects/atmosphereModel";
 import { CloudsModel, newCloudsModel } from "@/backend/universe/orbitalObjects/cloudsModel";
 import { CelestialBodyModel } from "@/backend/universe/orbitalObjects/index";
 import { OceanModel } from "@/backend/universe/orbitalObjects/oceanModel";
@@ -58,19 +58,6 @@ export function newSeededTelluricPlanetModel(
     );
     if (radius <= 0.3 * Settings.EARTH_RADIUS) pressure = 0;
 
-    const atmosphere: AtmosphereModel | null =
-        pressure > 0
-            ? {
-                  seaLevelPressure: pressure,
-                  greenHouseEffectFactor: 0.5,
-                  gasMix: [
-                      ["N2", 0.78],
-                      ["O2", 0.21],
-                      ["Ar", 0.01],
-                  ],
-              }
-            : null;
-
     //TODO: use distance to star to determine min temperature when using 1:1 scale
     const minTemperature = Math.max(0, normalRandom(celsiusToKelvin(-20), 30, rng, 80));
     // when pressure is close to 1, the max temperature is close to the min temperature (the atmosphere does thermal regulation)
@@ -88,6 +75,28 @@ export function newSeededTelluricPlanetModel(
               depth: (Settings.OCEAN_DEPTH * waterAmount * pressure) / Settings.EARTH_SEA_LEVEL_PRESSURE,
           }
         : null;
+
+    const gasMix: Array<[Gas, number]> =
+        ocean !== null
+            ? [
+                  ["N2", 0.78],
+                  ["O2", 0.21],
+                  ["Ar", 0.01],
+              ]
+            : [
+                  ["CO2", 0.95],
+                  ["N2", 0.04],
+                  ["Ar", 0.01],
+              ];
+
+    const atmosphere: AtmosphereModel | null =
+        pressure > 0
+            ? {
+                  seaLevelPressure: pressure,
+                  greenHouseEffectFactor: 0.5,
+                  gasMix,
+              }
+            : null;
 
     const clouds: CloudsModel | null =
         ocean !== null

--- a/src/ts/backend/universe/proceduralGenerators/telluricPlanetModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/telluricPlanetModelGenerator.ts
@@ -61,7 +61,7 @@ export function newSeededTelluricPlanetModel(
     const atmosphere: AtmosphereModel | null =
         pressure > 0
             ? {
-                  pressure,
+                  seaLevelPressure: pressure,
                   greenHouseEffectFactor: 0.5,
                   gasMix: [
                       ["N2", 0.78],

--- a/src/ts/backend/universe/proceduralGenerators/telluricPlanetModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/telluricPlanetModelGenerator.ts
@@ -63,6 +63,11 @@ export function newSeededTelluricPlanetModel(
             ? {
                   pressure,
                   greenHouseEffectFactor: 0.5,
+                  gasMix: [
+                      ["N2", 0.78],
+                      ["O2", 0.21],
+                      ["Ar", 0.01],
+                  ],
               }
             : null;
 

--- a/src/ts/backend/universe/proceduralGenerators/telluricSatelliteModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/telluricSatelliteModelGenerator.ts
@@ -89,7 +89,7 @@ export function newSeededTelluricSatelliteModel(
     const atmosphere: AtmosphereModel | null =
         pressure > 0
             ? {
-                  pressure: pressure,
+                  seaLevelPressure: pressure,
                   greenHouseEffectFactor: 0.5,
                   gasMix: [
                       ["N2", 0.78],

--- a/src/ts/backend/universe/proceduralGenerators/telluricSatelliteModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/telluricSatelliteModelGenerator.ts
@@ -91,6 +91,11 @@ export function newSeededTelluricSatelliteModel(
             ? {
                   pressure: pressure,
                   greenHouseEffectFactor: 0.5,
+                  gasMix: [
+                      ["N2", 0.78],
+                      ["O2", 0.21],
+                      ["Ar", 0.01],
+                  ],
               }
             : null;
 

--- a/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
+++ b/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
@@ -98,7 +98,7 @@ export class AtmosphereUniforms {
     constructor(planetBoundingRadius: number, mass: number, temperature: number, model: DeepReadonly<AtmosphereModel>) {
         const rayleighScatteringCoefficients = computeRayleighBetaRGB(
             model.gasMix,
-            model.pressure,
+            model.seaLevelPressure,
             temperature,
             PresetBands.PHOTOPIC,
         );
@@ -113,7 +113,7 @@ export class AtmosphereUniforms {
         const atmosphereThickness = getHeightForPressure(
             earthPressureAtKarmannLine,
             {
-                pressure: model.pressure,
+                pressure: model.seaLevelPressure,
                 height: 0,
             },
             rayleighScaleHeight,

--- a/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
+++ b/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
@@ -18,6 +18,11 @@
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
+import { AtmosphereModel } from "@/backend/universe/orbitalObjects/atmosphereModel";
+
+import { computeRayleighBetaRGB } from "@/utils/physics/atmosphere/rayleighScattering";
+import { DeepReadonly } from "@/utils/types";
+
 import { Settings } from "@/settings";
 
 const AtmosphereUniformNames = {
@@ -86,12 +91,14 @@ export class AtmosphereUniforms {
      */
     lightIntensity: number;
 
-    constructor(planetBoundingRadius: number, atmosphereThickness: number) {
+    constructor(planetBoundingRadius: number, atmosphereThickness: number, model: DeepReadonly<AtmosphereModel>) {
+        //TODO: do not hardcode temperature
+        const rayleighScatteringCoefficients = computeRayleighBetaRGB(model.gasMix, model.pressure, 273);
+
         this.atmosphereRadius = planetBoundingRadius + atmosphereThickness;
         this.rayleighHeight = (8e3 * atmosphereThickness) / Settings.EARTH_ATMOSPHERE_THICKNESS;
-        this.rayleighScatteringCoefficients = new Vector3(5.8e-6, 13.5e-6, 33.1e-6).scaleInPlace(
-            Settings.EARTH_ATMOSPHERE_THICKNESS / atmosphereThickness,
-        );
+        this.rayleighScatteringCoefficients = Vector3.FromArray(rayleighScatteringCoefficients);
+
         this.mieHeight = (1.2e3 * atmosphereThickness) / Settings.EARTH_ATMOSPHERE_THICKNESS;
         this.mieScatteringCoefficients = new Vector3(3.9e-6, 3.9e-6, 3.9e-6).scaleInPlace(
             Settings.EARTH_ATMOSPHERE_THICKNESS / atmosphereThickness,

--- a/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
+++ b/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
@@ -20,7 +20,10 @@ import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 import { AtmosphereModel } from "@/backend/universe/orbitalObjects/atmosphereModel";
 
+import { computeMeanMolecularWeight } from "@/utils/physics/atmosphere/gas";
 import { computeRayleighBetaRGB } from "@/utils/physics/atmosphere/rayleighScattering";
+import { computeAtmospherePressureScaleHeight } from "@/utils/physics/atmosphere/scaleHeight";
+import { computeGravityAcceleration } from "@/utils/physics/gravity";
 import { DeepReadonly } from "@/utils/types";
 
 import { Settings } from "@/settings";
@@ -91,12 +94,24 @@ export class AtmosphereUniforms {
      */
     lightIntensity: number;
 
-    constructor(planetBoundingRadius: number, atmosphereThickness: number, model: DeepReadonly<AtmosphereModel>) {
-        //TODO: do not hardcode temperature
-        const rayleighScatteringCoefficients = computeRayleighBetaRGB(model.gasMix, model.pressure, 273);
+    constructor(
+        planetBoundingRadius: number,
+        atmosphereThickness: number,
+        mass: number,
+        temperature: number,
+        model: DeepReadonly<AtmosphereModel>,
+    ) {
+        const rayleighScatteringCoefficients = computeRayleighBetaRGB(model.gasMix, model.pressure, temperature);
+
+        const meanMolecularWeight = computeMeanMolecularWeight(model.gasMix);
+
+        const gravity = computeGravityAcceleration(mass, planetBoundingRadius);
+
+        const rayleighScaleHeight = computeAtmospherePressureScaleHeight(temperature, gravity, meanMolecularWeight);
 
         this.atmosphereRadius = planetBoundingRadius + atmosphereThickness;
-        this.rayleighHeight = (8e3 * atmosphereThickness) / Settings.EARTH_ATMOSPHERE_THICKNESS;
+
+        this.rayleighHeight = rayleighScaleHeight;
         this.rayleighScatteringCoefficients = Vector3.FromArray(rayleighScatteringCoefficients);
 
         this.mieHeight = (1.2e3 * atmosphereThickness) / Settings.EARTH_ATMOSPHERE_THICKNESS;
@@ -104,11 +119,13 @@ export class AtmosphereUniforms {
             Settings.EARTH_ATMOSPHERE_THICKNESS / atmosphereThickness,
         );
         this.mieAsymmetry = 0.8;
+
         this.ozoneHeight = (25e3 * atmosphereThickness) / Settings.EARTH_ATMOSPHERE_THICKNESS;
         this.ozoneAbsorptionCoefficients = new Vector3(0.6e-6, 1.8e-6, 0.085e-6).scaleInPlace(
             Settings.EARTH_ATMOSPHERE_THICKNESS / atmosphereThickness,
         );
         this.ozoneFalloff = (5e3 * atmosphereThickness) / Settings.EARTH_ATMOSPHERE_THICKNESS;
+
         this.lightIntensity = 15;
     }
 

--- a/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
+++ b/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
@@ -20,6 +20,7 @@ import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 import { AtmosphereModel } from "@/backend/universe/orbitalObjects/atmosphereModel";
 
+import { PresetBands } from "@/utils/physics/atmosphere/common";
 import { computeMeanMolecularWeight } from "@/utils/physics/atmosphere/gas";
 import { computeRayleighBetaRGB } from "@/utils/physics/atmosphere/rayleighScattering";
 import { computeAtmospherePressureScaleHeight } from "@/utils/physics/atmosphere/scaleHeight";
@@ -101,7 +102,12 @@ export class AtmosphereUniforms {
         temperature: number,
         model: DeepReadonly<AtmosphereModel>,
     ) {
-        const rayleighScatteringCoefficients = computeRayleighBetaRGB(model.gasMix, model.pressure, temperature);
+        const rayleighScatteringCoefficients = computeRayleighBetaRGB(
+            model.gasMix,
+            model.pressure,
+            temperature,
+            PresetBands.PHOTOPIC,
+        );
 
         const meanMolecularWeight = computeMeanMolecularWeight(model.gasMix);
 

--- a/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
+++ b/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
@@ -23,7 +23,7 @@ import { AtmosphereModel } from "@/backend/universe/orbitalObjects/atmosphereMod
 import { PresetBands } from "@/utils/physics/atmosphere/common";
 import { computeMeanMolecularWeight } from "@/utils/physics/atmosphere/gas";
 import { computeRayleighBetaRGB } from "@/utils/physics/atmosphere/rayleighScattering";
-import { computeAtmospherePressureScaleHeight } from "@/utils/physics/atmosphere/scaleHeight";
+import { computeAtmospherePressureScaleHeight, getHeightForPressure } from "@/utils/physics/atmosphere/scaleHeight";
 import { computeGravityAcceleration } from "@/utils/physics/gravity";
 import { DeepReadonly } from "@/utils/types";
 
@@ -95,13 +95,7 @@ export class AtmosphereUniforms {
      */
     lightIntensity: number;
 
-    constructor(
-        planetBoundingRadius: number,
-        atmosphereThickness: number,
-        mass: number,
-        temperature: number,
-        model: DeepReadonly<AtmosphereModel>,
-    ) {
+    constructor(planetBoundingRadius: number, mass: number, temperature: number, model: DeepReadonly<AtmosphereModel>) {
         const rayleighScatteringCoefficients = computeRayleighBetaRGB(
             model.gasMix,
             model.pressure,
@@ -114,6 +108,16 @@ export class AtmosphereUniforms {
         const gravity = computeGravityAcceleration(mass, planetBoundingRadius);
 
         const rayleighScaleHeight = computeAtmospherePressureScaleHeight(temperature, gravity, meanMolecularWeight);
+
+        const earthPressureAtKarmannLine = 3.2e-2; // Pa at 100 km altitude
+        const atmosphereThickness = getHeightForPressure(
+            earthPressureAtKarmannLine,
+            {
+                pressure: model.pressure,
+                height: 0,
+            },
+            rayleighScaleHeight,
+        );
 
         this.atmosphereRadius = planetBoundingRadius + atmosphereThickness;
 

--- a/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
+++ b/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
@@ -120,11 +120,8 @@ export class GasPlanet implements PlanetaryMassObjectBase<OrbitalObjectType.GAS_
 
         this.mesh.material = this.material;
 
-        const atmosphereThickness =
-            Settings.EARTH_ATMOSPHERE_THICKNESS * Math.max(1, this.model.radius / Settings.EARTH_RADIUS);
         this.atmosphereUniforms = new AtmosphereUniforms(
             this.getBoundingRadius(),
-            atmosphereThickness,
             model.mass,
             273, //TODO: do not hardcode temperature
             model.atmosphere,

--- a/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
+++ b/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
@@ -125,6 +125,8 @@ export class GasPlanet implements PlanetaryMassObjectBase<OrbitalObjectType.GAS_
         this.atmosphereUniforms = new AtmosphereUniforms(
             this.getBoundingRadius(),
             atmosphereThickness,
+            model.mass,
+            273, //TODO: do not hardcode temperature
             model.atmosphere,
         );
 

--- a/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
+++ b/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
@@ -122,7 +122,11 @@ export class GasPlanet implements PlanetaryMassObjectBase<OrbitalObjectType.GAS_
 
         const atmosphereThickness =
             Settings.EARTH_ATMOSPHERE_THICKNESS * Math.max(1, this.model.radius / Settings.EARTH_RADIUS);
-        this.atmosphereUniforms = new AtmosphereUniforms(this.getBoundingRadius(), atmosphereThickness);
+        this.atmosphereUniforms = new AtmosphereUniforms(
+            this.getBoundingRadius(),
+            atmosphereThickness,
+            model.atmosphere,
+        );
 
         if (this.model.rings !== null) {
             this.ringsUniforms = RingsUniforms.New(this.model.rings, textures, Settings.RINGS_FADE_OUT_DISTANCE, scene);

--- a/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanet.ts
+++ b/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanet.ts
@@ -112,7 +112,11 @@ export class TelluricPlanet
         if (this.model.atmosphere !== null) {
             const atmosphereThickness =
                 Settings.EARTH_ATMOSPHERE_THICKNESS * Math.max(1, this.model.radius / Settings.EARTH_RADIUS);
-            this.atmosphereUniforms = new AtmosphereUniforms(this.getBoundingRadius(), atmosphereThickness);
+            this.atmosphereUniforms = new AtmosphereUniforms(
+                this.getBoundingRadius(),
+                atmosphereThickness,
+                this.model.atmosphere,
+            );
         } else {
             this.atmosphereUniforms = null;
         }

--- a/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanet.ts
+++ b/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanet.ts
@@ -115,6 +115,8 @@ export class TelluricPlanet
             this.atmosphereUniforms = new AtmosphereUniforms(
                 this.getBoundingRadius(),
                 atmosphereThickness,
+                this.model.mass,
+                this.model.temperature.max,
                 this.model.atmosphere,
             );
         } else {

--- a/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanet.ts
+++ b/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanet.ts
@@ -110,11 +110,8 @@ export class TelluricPlanet
         this.aggregate.shape.addChildFromParent(this.getTransform(), physicsShape, this.getTransform());
 
         if (this.model.atmosphere !== null) {
-            const atmosphereThickness =
-                Settings.EARTH_ATMOSPHERE_THICKNESS * Math.max(1, this.model.radius / Settings.EARTH_RADIUS);
             this.atmosphereUniforms = new AtmosphereUniforms(
                 this.getBoundingRadius(),
-                atmosphereThickness,
                 this.model.mass,
                 this.model.temperature.max,
                 this.model.atmosphere,

--- a/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanetMaterial.ts
+++ b/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanetMaterial.ts
@@ -166,7 +166,7 @@ export class TelluricPlanetMaterial extends ShaderMaterial {
         lut.setPlanetPhysicsInfo(
             this.planetModel.temperature.min,
             this.planetModel.temperature.max,
-            this.planetModel.atmosphere?.pressure ?? 0,
+            this.planetModel.atmosphere?.seaLevelPressure ?? 0,
         );
         lut.getTexture().executeWhenReady(() => {
             this.setTexture(TelluricPlanetMaterialSamplerNames.LUT, lut.getTexture());
@@ -218,7 +218,7 @@ export class TelluricPlanetMaterial extends ShaderMaterial {
 
         this.setFloat(TelluricPlanetMaterialUniformNames.MIN_TEMPERATURE, this.planetModel.temperature.min);
         this.setFloat(TelluricPlanetMaterialUniformNames.MAX_TEMPERATURE, this.planetModel.temperature.max);
-        this.setFloat(TelluricPlanetMaterialUniformNames.PRESSURE, this.planetModel.atmosphere?.pressure ?? 0);
+        this.setFloat(TelluricPlanetMaterialUniformNames.PRESSURE, this.planetModel.atmosphere?.seaLevelPressure ?? 0);
         this.setFloat(TelluricPlanetMaterialUniformNames.WATER_AMOUNT, this.planetModel.waterAmount);
 
         this.setFloat(

--- a/src/ts/playgrounds/atmosphericScattering.ts
+++ b/src/ts/playgrounds/atmosphericScattering.ts
@@ -57,7 +57,7 @@ export function createAtmosphericScatteringScene(
     const sphere = MeshBuilder.CreateSphere("sphere", { diameter: 2 * scalingFactor, segments: 64 }, scene);
 
     const atmosphereModel: AtmosphereModel = {
-        pressure: 101325, // Sea level pressure in Pascals
+        seaLevelPressure: 101325, // Sea level pressure in Pascals
         greenHouseEffectFactor: 0.5, // Arbitrary value for greenhouse effect
         gasMix: [
             ["N2", 0.78], // Nitrogen

--- a/src/ts/playgrounds/atmosphericScattering.ts
+++ b/src/ts/playgrounds/atmosphericScattering.ts
@@ -19,6 +19,8 @@ import { Color4, MeshBuilder, PointLight, Vector3 } from "@babylonjs/core";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
+import { AtmosphereModel } from "@/backend/universe/orbitalObjects/atmosphereModel";
+
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { AtmosphereUniforms } from "@/frontend/postProcesses/atmosphere/atmosphereUniforms";
 import { AtmosphericScatteringPostProcess } from "@/frontend/postProcesses/atmosphere/atmosphericScatteringPostProcess";
@@ -53,7 +55,17 @@ export function createAtmosphericScatteringScene(
     // Our built-in 'sphere' shape. Params: name, options, scene
     const sphere = MeshBuilder.CreateSphere("sphere", { diameter: 2 * scalingFactor, segments: 64 }, scene);
 
-    const atmosphereUniforms = new AtmosphereUniforms(scalingFactor, 100e3);
+    const atmosphereModel: AtmosphereModel = {
+        pressure: 101325, // Sea level pressure in Pascals
+        greenHouseEffectFactor: 0.5, // Arbitrary value for greenhouse effect
+        gasMix: [
+            ["N2", 0.78], // Nitrogen
+            ["O2", 0.21], // Oxygen
+            ["Ar", 0.01], // Argon
+        ],
+    };
+
+    const atmosphereUniforms = new AtmosphereUniforms(scalingFactor, 100e3, atmosphereModel);
 
     const atmosphere = new AtmosphericScatteringPostProcess(sphere, scalingFactor, atmosphereUniforms, [light], scene);
     camera.attachPostProcess(atmosphere);

--- a/src/ts/playgrounds/atmosphericScattering.ts
+++ b/src/ts/playgrounds/atmosphericScattering.ts
@@ -33,6 +33,7 @@ export function createAtmosphericScatteringScene(
     scene.useRightHandedSystem = true;
 
     const scalingFactor = 6_000e3;
+    const earthMass = 5.972e24; // kg
 
     const controls = new DefaultControls(scene);
 
@@ -65,7 +66,7 @@ export function createAtmosphericScatteringScene(
         ],
     };
 
-    const atmosphereUniforms = new AtmosphereUniforms(scalingFactor, 100e3, atmosphereModel);
+    const atmosphereUniforms = new AtmosphereUniforms(scalingFactor, 100e3, earthMass, 298, atmosphereModel);
 
     const atmosphere = new AtmosphericScatteringPostProcess(sphere, scalingFactor, atmosphereUniforms, [light], scene);
     camera.attachPostProcess(atmosphere);

--- a/src/ts/playgrounds/atmosphericScattering.ts
+++ b/src/ts/playgrounds/atmosphericScattering.ts
@@ -66,7 +66,7 @@ export function createAtmosphericScatteringScene(
         ],
     };
 
-    const atmosphereUniforms = new AtmosphereUniforms(scalingFactor, 100e3, earthMass, 298, atmosphereModel);
+    const atmosphereUniforms = new AtmosphereUniforms(scalingFactor, earthMass, 298, atmosphereModel);
 
     const atmosphere = new AtmosphericScatteringPostProcess(sphere, scalingFactor, atmosphereUniforms, [light], scene);
     camera.attachPostProcess(atmosphere);

--- a/src/ts/playgrounds/sol/jupiter.ts
+++ b/src/ts/playgrounds/sol/jupiter.ts
@@ -27,8 +27,6 @@ import { GasPlanet } from "@/frontend/universe/planets/gasPlanet/gasPlanet";
 
 import { ItemPool } from "@/utils/itemPool";
 
-import { Settings } from "@/settings";
-
 import { enablePhysics } from "../utils";
 
 export async function createJupiterScene(
@@ -64,8 +62,6 @@ export async function createJupiterScene(
 
     const light = new PointLight("light1", new Vector3(7, 5, -10).scaleInPlace(scalingFactor), scene);
     light.falloffType = Light.FALLOFF_STANDARD;
-
-    Settings.EARTH_RADIUS = 6_371e3;
 
     const gasPlanetModel = getJupiterModel([]);
 

--- a/src/ts/playgrounds/sol/saturn.ts
+++ b/src/ts/playgrounds/sol/saturn.ts
@@ -30,8 +30,6 @@ import { GasPlanet } from "@/frontend/universe/planets/gasPlanet/gasPlanet";
 
 import { ItemPool } from "@/utils/itemPool";
 
-import { Settings } from "@/settings";
-
 import { enablePhysics } from "../utils";
 
 export async function createSaturnScene(
@@ -71,8 +69,6 @@ export async function createSaturnScene(
     const light = new PointLight("light1", Vector3.Zero(), scene);
     light.falloffType = Light.FALLOFF_STANDARD;
     light.parent = sun;
-
-    Settings.EARTH_RADIUS = 6_371e3;
 
     const gasPlanetModel = getSaturnModel([]);
 

--- a/src/ts/playgrounds/sol/sol.ts
+++ b/src/ts/playgrounds/sol/sol.ts
@@ -59,7 +59,7 @@ export async function createSolScene(
 
     await scene.setActiveControls(controls);
 
-    scene.enableDepthRenderer(null, false, true);
+    scene.enableDepthRenderer(null, true, true);
 
     const chunkForge = new ChunkForgeWorkers(Settings.VERTEX_RESOLUTION);
 

--- a/src/ts/settings.ts
+++ b/src/ts/settings.ts
@@ -125,7 +125,7 @@ export const Settings = {
     TUTORIAL_SAVE_UUID: "00000000-0000-0000-0000-000000000000",
 
     QUALITY_CHARS: "FEDCBA",
-};
+} as const;
 
 export const CollisionMask = {
     ENVIRONMENT: 0b00000001,

--- a/src/ts/utils/atmosphere.spec.ts
+++ b/src/ts/utils/atmosphere.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { computeRayleighBetaRGB } from "./atmosphere";
+
+const relErr = (calc: number, ref: number) => Math.abs(calc - ref) / ref;
+
+describe("computeRayleighBetaRGB", () => {
+    it("should compute Earth's rayleigh beta scattering coefficients within 5 %", () => {
+        const earthAtmosphereComposition = [
+            ["N2", 0.78084],
+            ["O2", 0.209476],
+            ["Ar", 0.00934],
+            ["CO2", 0.0004],
+        ] as const;
+        const prediction = computeRayleighBetaRGB(earthAtmosphereComposition, 101_325, 288.15);
+        const groundTruth = [4.9e-6, 1.14e-5, 2.79e-5] as const;
+
+        expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
+        expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);
+        expect(relErr(prediction[2], groundTruth[2])).toBeLessThan(0.05);
+    });
+
+    it("should compute Mars's rayleigh beta scattering coefficients within 5 %", () => {
+        const marsAtmosphereComposition = [
+            ["CO2", 0.959],
+            ["N2", 0.027],
+            ["Ar", 0.014],
+        ] as const;
+        const prediction = computeRayleighBetaRGB(marsAtmosphereComposition, 600, 210);
+        const groundTruth = [8.7e-8, 2.04e-7, 4.98e-7] as const;
+
+        expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
+        expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);
+        expect(relErr(prediction[2], groundTruth[2])).toBeLessThan(0.05);
+    });
+});

--- a/src/ts/utils/atmosphere.spec.ts
+++ b/src/ts/utils/atmosphere.spec.ts
@@ -33,4 +33,17 @@ describe("computeRayleighBetaRGB", () => {
         expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);
         expect(relErr(prediction[2], groundTruth[2])).toBeLessThan(0.05);
     });
+
+    it("should compute Titan's rayleigh beta scattering coefficients within 5 %", () => {
+        const titanAtmosphereComposition = [
+            ["N2", 0.95], // Cassini/Huygens shows 94–98 % N₂
+            ["CH4", 0.05], // and 1–5 % CH₄; trace H₂ neglected
+        ] as const;
+        const prediction = computeRayleighBetaRGB(titanAtmosphereComposition, 146_700, 94);
+        const groundTruth = [2.34e-5, 5.46e-5, 1.33e-4] as const;
+
+        expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
+        expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);
+        expect(relErr(prediction[2], groundTruth[2])).toBeLessThan(0.05);
+    });
 });

--- a/src/ts/utils/atmosphere.ts
+++ b/src/ts/utils/atmosphere.ts
@@ -31,6 +31,11 @@ const N_S = 2.686_78e25;
 
 export type Gas = "N2" | "O2" | "Ar" | "CO2" | "He" | "Ne" | "H2" | "CH4";
 
+/**
+ * @param gas The gas for which to return the refractive index.
+ * @returns The refractive index of the gas at standard conditions.
+ * @see https://www.engineeringtoolbox.com/refractive-index-d_1264.html
+ */
 export function getGasRefractiveIndex(gas: Gas): number {
     switch (gas) {
         case "N2":
@@ -114,6 +119,14 @@ export function computeRayleighBetaRGB(
     ];
 }
 
+/**
+ * Computes the Rayleigh scattering cross section for a gas for the given wavelength
+ * @param wavelength Wavelength of light (m)
+ * @param n Refractive index of the gas at standard conditions (dimensionless)
+ * @param F King correction factor (dimensionless)
+ * @returns Rayleigh scattering cross section (m²mol⁻¹)
+ * @see https://pmc.ncbi.nlm.nih.gov/articles/PMC6800691/pdf/nihms-1036079.pdf Rayleigh scattering cross sections of argon, carbon dioxide, sulfur hexafluoride, and methane in the UV-A region using Broadband Cavity Enhanced Spectroscopy
+ */
 function computeRayleighCrossSection(wavelength: number, n: number, F: number): number {
     return ((24 * Math.PI ** 3 * (n ** 2 - 1) ** 2) / (wavelength ** 4 * N_S ** 2)) * (F / (n ** 2 + 2) ** 2);
 }

--- a/src/ts/utils/atmosphere.ts
+++ b/src/ts/utils/atmosphere.ts
@@ -121,11 +121,12 @@ export function computeRayleighBetaRGB(
 
 /**
  * Computes the Rayleigh scattering cross section for a gas for the given wavelength
- * @param wavelength Wavelength of light (m)
+ * @param wavelength Wavelength of light (m) Inverse of frequency nu.
  * @param n Refractive index of the gas at standard conditions (dimensionless)
  * @param F King correction factor (dimensionless)
  * @returns Rayleigh scattering cross section (m²mol⁻¹)
  * @see https://pmc.ncbi.nlm.nih.gov/articles/PMC6800691/pdf/nihms-1036079.pdf Rayleigh scattering cross sections of argon, carbon dioxide, sulfur hexafluoride, and methane in the UV-A region using Broadband Cavity Enhanced Spectroscopy
+ * @see https://acp.copernicus.org/articles/21/14927/2021/ Scattering and absorption cross sections of atmospheric gases in the ultraviolet–visible wavelength range (307–725nm)
  */
 function computeRayleighCrossSection(wavelength: number, n: number, F: number): number {
     return ((24 * Math.PI ** 3 * (n ** 2 - 1) ** 2) / (wavelength ** 4 * N_S ** 2)) * (F / (n ** 2 + 2) ** 2);

--- a/src/ts/utils/atmosphere.ts
+++ b/src/ts/utils/atmosphere.ts
@@ -1,0 +1,119 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { DeepReadonly } from "./types";
+
+/**
+ * Boltzmann constant, J K⁻¹  (CODATA 2019)
+ * @see https://en.wikipedia.org/wiki/Boltzmann_constant
+ */
+const K_B = 1.380_649e-23;
+
+/**
+ * Loschmidt constant, m⁻³ at 273 K & 101 325 Pa
+ * @see https://en.wikipedia.org/wiki/Loschmidt_constant
+ */
+const N_S = 2.686_78e25;
+
+export type Gas = "N2" | "O2" | "Ar" | "CO2" | "He" | "Ne" | "H2" | "CH4";
+
+export function getGasRefractiveIndex(gas: Gas): number {
+    switch (gas) {
+        case "N2":
+            return 1.000298;
+        case "O2":
+            return 1.000271;
+        case "Ar":
+            return 1.000281;
+        case "CO2":
+            return 1.00045;
+        case "He":
+            return 1.000036;
+        case "Ne":
+            return 1.000067;
+        case "H2":
+            return 1.000132;
+        case "CH4":
+            return 1.000444;
+        default:
+            throw new Error(`Unknown gas: ${String(gas)}`);
+    }
+}
+
+export function getGasDepolarization(gas: Gas): number {
+    switch (gas) {
+        case "N2":
+            return 0.022;
+        case "O2":
+            return 0.054;
+        case "Ar":
+        case "CO2":
+        case "He":
+        case "Ne":
+        case "H2":
+        case "CH4":
+            return 0; // Remaining gases assumed ≈ 0
+        default:
+            throw new Error(`Unknown gas: ${String(gas)}`);
+    }
+}
+
+/**
+ * Default photopic RGB band-centres (metres)
+ */
+const RGB_WAVELENGTHS = [680e-9, 550e-9, 440e-9] as const;
+
+/**
+ * Compute Rayleigh β_R, β_G, β_B (m⁻¹) for a well-mixed gas atmosphere.
+ *
+ * @param fractions An array of tuples containing a gas and its associated Mole/volume fraction. The sum of all fractions must add up to 1.0
+ * @param pressure Ambient pressure (Pa)
+ * @param temperature Ambient temperature (K)
+ * @param waveLengths Wavelength array (m). Default: RGB_WAVELENGTHS
+ * @returns Tuple [β_R, β_G, β_B] in m⁻¹
+ */
+export function computeRayleighBetaRGB(
+    fractions: DeepReadonly<Array<[Gas, number]>>,
+    pressure: number,
+    temperature: number,
+    waveLengths: DeepReadonly<[number, number, number]> = RGB_WAVELENGTHS,
+): [number, number, number] {
+    /* --- (1) Mixture refractive index and depolarisation --- */
+    let nMinus1 = 0;
+    let delta = 0;
+
+    for (const [gas, fraction] of fractions) {
+        nMinus1 += fraction * (getGasRefractiveIndex(gas) - 1);
+        delta += fraction * getGasDepolarization(gas);
+    }
+    const n = 1 + nMinus1;
+    const F = (6 + 3 * delta) / (6 - 7 * delta); // King correction
+
+    /* --- (2) Molecular number density at (P,T) --- */
+    const N = pressure / (K_B * temperature);
+
+    /* --- (3) β(λ) for each wavelength --- */
+    return [
+        N * computeRayleighCrossSection(waveLengths[0], n, F),
+        N * computeRayleighCrossSection(waveLengths[1], n, F),
+        N * computeRayleighCrossSection(waveLengths[2], n, F),
+    ];
+}
+
+function computeRayleighCrossSection(wavelength: number, n: number, F: number): number {
+    return ((24 * Math.PI ** 3 * (n ** 2 - 1) ** 2) / (wavelength ** 4 * N_S ** 2)) * (F / (n ** 2 + 2) ** 2);
+}

--- a/src/ts/utils/distanceToStellarObject.spec.ts
+++ b/src/ts/utils/distanceToStellarObject.spec.ts
@@ -84,7 +84,7 @@ describe("distanceToStellarObject", () => {
                 rings: null,
                 atmosphere: {
                     greenHouseEffectFactor: 1,
-                    pressure: 1,
+                    seaLevelPressure: 1,
                     gasMix: [
                         ["H2", 0.9],
                         ["He", 0.1],

--- a/src/ts/utils/distanceToStellarObject.spec.ts
+++ b/src/ts/utils/distanceToStellarObject.spec.ts
@@ -84,7 +84,7 @@ describe("distanceToStellarObject", () => {
                 rings: null,
                 atmosphere: {
                     greenHouseEffectFactor: 1,
-                    seaLevelPressure: 1,
+                    seaLevelPressure: 100_000,
                     gasMix: [
                         ["H2", 0.9],
                         ["He", 0.1],

--- a/src/ts/utils/distanceToStellarObject.spec.ts
+++ b/src/ts/utils/distanceToStellarObject.spec.ts
@@ -85,6 +85,10 @@ describe("distanceToStellarObject", () => {
                 atmosphere: {
                     greenHouseEffectFactor: 1,
                     pressure: 1,
+                    gasMix: [
+                        ["H2", 0.9],
+                        ["He", 0.1],
+                    ],
                 },
                 colorPalette: {
                     type: "textured",

--- a/src/ts/utils/physics/atmosphere/common.ts
+++ b/src/ts/utils/physics/atmosphere/common.ts
@@ -19,5 +19,5 @@ export const PresetBands = {
     /**
      * Default photopic RGB band-centres (metres)
      */
-    PHOTOPIC: [680e-9, 550e-9, 440e-9],
+    PHOTOPIC: [650e-9, 550e-9, 450e-9],
 } as const;

--- a/src/ts/utils/physics/atmosphere/common.ts
+++ b/src/ts/utils/physics/atmosphere/common.ts
@@ -1,0 +1,23 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+export const PresetBands = {
+    /**
+     * Default photopic RGB band-centres (metres)
+     */
+    PHOTOPIC: [680e-9, 550e-9, 440e-9],
+} as const;

--- a/src/ts/utils/physics/atmosphere/gas.ts
+++ b/src/ts/utils/physics/atmosphere/gas.ts
@@ -1,0 +1,70 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+export type Gas = "N2" | "O2" | "Ar" | "CO2" | "He" | "Ne" | "H2" | "CH4" | "SO2";
+
+/**
+ * @param gas The gas for which to return the refractive index.
+ * @returns The refractive index of the gas at standard conditions.
+ * @see https://www.engineeringtoolbox.com/refractive-index-d_1264.html
+ */
+export function getGasRefractiveIndex(gas: Gas): number {
+    switch (gas) {
+        case "N2":
+            return 1.000298;
+        case "O2":
+            return 1.000271;
+        case "Ar":
+            return 1.000281;
+        case "CO2":
+            return 1.00045;
+        case "He":
+            return 1.000036;
+        case "Ne":
+            return 1.000067;
+        case "H2":
+            return 1.000132;
+        case "CH4":
+            return 1.000444;
+        case "SO2":
+            return 1.3396; // https://pubchem.ncbi.nlm.nih.gov/compound/Sulfur-Dioxide#section=Refractive-Index
+        default:
+            throw new Error(`Unknown gas: ${String(gas)}`);
+    }
+}
+
+export function getGasDepolarization(gas: Gas): number {
+    switch (gas) {
+        case "N2":
+            return 0.022;
+        case "O2":
+            return 0.054;
+        case "CO2":
+            // King correction is 1.1364 according to https://acp.copernicus.org/articles/21/14927/2021/acp-21-14927-2021.pdf
+            // So solving for delta in the King correction formula gives us 0.075
+            return 0.075;
+        case "Ar":
+        case "He":
+        case "Ne":
+        case "H2":
+        case "CH4":
+        case "SO2":
+            return 0; // Remaining gases assumed ≈ 0
+        default:
+            throw new Error(`Unknown gas: ${String(gas)}`);
+    }
+}

--- a/src/ts/utils/physics/atmosphere/gas.ts
+++ b/src/ts/utils/physics/atmosphere/gas.ts
@@ -35,11 +35,11 @@ export function getGasRefractiveIndex(gas: Gas): number {
         case "CO2":
             return 1.00045;
         case "He":
-            return 1.000036;
+            return 1.00003;
         case "Ne":
             return 1.000067;
         case "H2":
-            return 1.000132;
+            return 1.000118;
         case "CH4":
             return 1.000444;
         case "SO2":

--- a/src/ts/utils/physics/atmosphere/gas.ts
+++ b/src/ts/utils/physics/atmosphere/gas.ts
@@ -15,6 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { DeepReadonly } from "@/utils/types";
+
 export type Gas = "N2" | "O2" | "Ar" | "CO2" | "He" | "Ne" | "H2" | "CH4" | "SO2";
 
 /**
@@ -42,8 +44,6 @@ export function getGasRefractiveIndex(gas: Gas): number {
             return 1.000444;
         case "SO2":
             return 1.3396; // https://pubchem.ncbi.nlm.nih.gov/compound/Sulfur-Dioxide#section=Refractive-Index
-        default:
-            throw new Error(`Unknown gas: ${String(gas)}`);
     }
 }
 
@@ -64,7 +64,41 @@ export function getGasDepolarization(gas: Gas): number {
         case "CH4":
         case "SO2":
             return 0; // Remaining gases assumed ≈ 0
-        default:
-            throw new Error(`Unknown gas: ${String(gas)}`);
     }
+}
+
+/**
+ * @param gas The gas for which to return the molar mass in g/mol.
+ * @returns The molar mass of the gas in grams per mole.
+ * @see https://en.wikipedia.org/wiki/Molar_mass
+ */
+export function getMolarMass(gas: Gas): number {
+    switch (gas) {
+        case "N2":
+            return 28.0134;
+        case "O2":
+            return 31.9988;
+        case "Ar":
+            return 39.948;
+        case "CO2":
+            return 44.0095;
+        case "He":
+            return 4.002602;
+        case "Ne":
+            return 20.1797;
+        case "H2":
+            return 2.01588;
+        case "CH4":
+            return 16.043;
+        case "SO2":
+            return 64.066;
+    }
+}
+
+/**
+ * Mean molecular weight μ (kg mol-1) of a gas mixture.
+ */
+export function computeMeanMolecularWeight(fractions: DeepReadonly<Array<[Gas, number]>>): number {
+    const sum = fractions.reduce((s, [, x]) => s + x, 0);
+    return 1e-3 * fractions.reduce((mean, [gas, x]) => mean + (x / sum) * getMolarMass(gas), 0);
 }

--- a/src/ts/utils/physics/atmosphere/gas.ts
+++ b/src/ts/utils/physics/atmosphere/gas.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { DeepReadonly } from "@/utils/types";
+import { Gas } from "@/backend/universe/orbitalObjects/atmosphereModel";
 
-export type Gas = "N2" | "O2" | "Ar" | "CO2" | "He" | "Ne" | "H2" | "CH4" | "SO2";
+import { DeepReadonly } from "@/utils/types";
 
 /**
  * @param gas The gas for which to return the refractive index.

--- a/src/ts/utils/physics/atmosphere/gas.ts
+++ b/src/ts/utils/physics/atmosphere/gas.ts
@@ -43,7 +43,7 @@ export function getGasRefractiveIndex(gas: Gas): number {
         case "CH4":
             return 1.000444;
         case "SO2":
-            return 1.3396; // https://pubchem.ncbi.nlm.nih.gov/compound/Sulfur-Dioxide#section=Refractive-Index
+            return 1.000686;
     }
 }
 

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.spec.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeRayleighBetaRGB } from "./atmosphere";
+import { computeRayleighBetaRGB } from "./rayleighScattering";
 
 const relErr = (calc: number, ref: number) => Math.abs(calc - ref) / ref;
 

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.spec.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.spec.ts
@@ -13,7 +13,7 @@ describe("computeRayleighBetaRGB", () => {
             ["CO2", 0.0004],
         ] as const;
         const prediction = computeRayleighBetaRGB(earthAtmosphereComposition, 101_325, 288.15);
-        const groundTruth = [4.9e-6, 1.14e-5, 2.79e-5] as const;
+        const groundTruth = [4.9e-6, 1.14e-5, 2.79e-5] as const; // Bodhaine-Penndorf tables (101 325 Pa, 288 K)
 
         expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
         expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);
@@ -27,11 +27,11 @@ describe("computeRayleighBetaRGB", () => {
             ["Ar", 0.014],
         ] as const;
         const prediction = computeRayleighBetaRGB(marsAtmosphereComposition, 600, 210);
-        const groundTruth = [8.7e-8, 2.04e-7, 4.98e-7] as const;
+        const groundTruth = [1.06e-7, 2.43e-7, 5.83e-7] as const; // He et al. 2021
 
-        expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
-        expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);
-        expect(relErr(prediction[2], groundTruth[2])).toBeLessThan(0.05);
+        expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.07);
+        expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.07);
+        expect(relErr(prediction[2], groundTruth[2])).toBeLessThan(0.07);
     });
 
     it("should compute Titan's rayleigh beta scattering coefficients within 5 %", () => {
@@ -40,7 +40,7 @@ describe("computeRayleighBetaRGB", () => {
             ["CH4", 0.05], // and 1–5 % CH₄; trace H₂ neglected
         ] as const;
         const prediction = computeRayleighBetaRGB(titanAtmosphereComposition, 146_700, 94);
-        const groundTruth = [2.34e-5, 5.46e-5, 1.33e-4] as const;
+        const groundTruth = [2.34e-5, 5.46e-5, 1.33e-4] as const; // Cassini/HASI
 
         expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
         expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.spec.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.spec.ts
@@ -29,7 +29,12 @@ describe("computeRayleighBetaRGB", () => {
             ["Ar", 0.00934],
             ["CO2", 0.0004],
         ] as const;
-        const prediction = computeRayleighBetaRGB(earthAtmosphereComposition, 101_325, 288.15);
+        const prediction = computeRayleighBetaRGB(
+            earthAtmosphereComposition,
+            101_325,
+            288.15,
+            [680e-9, 550e-9, 440e-9],
+        );
         const groundTruth = [4.9e-6, 1.14e-5, 2.79e-5] as const; // Bodhaine-Penndorf tables (101 325 Pa, 288 K)
 
         expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
@@ -43,7 +48,7 @@ describe("computeRayleighBetaRGB", () => {
             ["N2", 0.027],
             ["Ar", 0.014],
         ] as const;
-        const prediction = computeRayleighBetaRGB(marsAtmosphereComposition, 600, 210);
+        const prediction = computeRayleighBetaRGB(marsAtmosphereComposition, 600, 210, [680e-9, 550e-9, 440e-9]);
         const groundTruth = [1.06e-7, 2.43e-7, 5.83e-7] as const; // He et al. 2021
 
         expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.07);
@@ -56,8 +61,20 @@ describe("computeRayleighBetaRGB", () => {
             ["N2", 0.95], // Cassini/Huygens shows 94–98 % N₂
             ["CH4", 0.05], // and 1–5 % CH₄; trace H₂ neglected
         ] as const;
-        const prediction = computeRayleighBetaRGB(titanAtmosphereComposition, 146_700, 94);
+        const prediction = computeRayleighBetaRGB(titanAtmosphereComposition, 146_700, 94, [680e-9, 550e-9, 440e-9]);
         const groundTruth = [2.34e-5, 5.46e-5, 1.33e-4] as const; // Cassini/HASI
+
+        expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
+        expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);
+        expect(relErr(prediction[2], groundTruth[2])).toBeLessThan(0.05);
+    });
+    it("should compute Jupiter's rayleigh beta scattering coefficients within 5 %", () => {
+        const jupiterAtmosphereComposition = [
+            ["H2", 0.898],
+            ["He", 0.102],
+        ] as const;
+        const prediction = computeRayleighBetaRGB(jupiterAtmosphereComposition, 100_000, 273, [650e-9, 550e-9, 450e-9]);
+        const groundTruth = [8.38e-7, 1.629e-6, 3.64e-6] as const;
 
         expect(relErr(prediction[0], groundTruth[0])).toBeLessThan(0.05);
         expect(relErr(prediction[1], groundTruth[1])).toBeLessThan(0.05);

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.spec.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.spec.ts
@@ -1,3 +1,20 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import { describe, expect, it } from "vitest";
 
 import { computeRayleighBetaRGB } from "./rayleighScattering";

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -15,9 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { Gas } from "@/backend/universe/orbitalObjects/atmosphereModel";
+
 import { DeepReadonly } from "@/utils/types";
 
-import { Gas, getGasDepolarization, getGasRefractiveIndex } from "./gas";
+import { getGasDepolarization, getGasRefractiveIndex } from "./gas";
 
 /**
  * Boltzmann constant, J K⁻¹

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { DeepReadonly } from "./types";
+import { DeepReadonly } from "../../types";
 
 /**
  * Boltzmann constant, J K⁻¹  (CODATA 2019)

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -81,5 +81,14 @@ export function computeRayleighBetaRGB(
  * @see https://acp.copernicus.org/articles/21/14927/2021/ Scattering and absorption cross sections of atmospheric gases in the ultraviolet–visible wavelength range (307–725nm)
  */
 function computeRayleighCrossSection(wavelength: number, n: number, F: number): number {
-    return ((24 * Math.PI ** 3 * (n ** 2 - 1) ** 2) / (wavelength ** 4 * N_S ** 2)) * (F / (n ** 2 + 2) ** 2);
+    const n2 = n * n;
+    const lambda4 = wavelength ** 4;
+    const loschmidtSquared = N_S ** 2;
+
+    // Lorentz-Lorenz factor part
+    const polarizabilityTerm = ((n2 - 1) / (n2 + 2)) ** 2;
+
+    const mainTerm = (24 * Math.PI ** 3) / (lambda4 * loschmidtSquared);
+
+    return mainTerm * polarizabilityTerm * F;
 }

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -65,8 +65,11 @@ export function getGasDepolarization(gas: Gas): number {
             return 0.022;
         case "O2":
             return 0.054;
-        case "Ar":
         case "CO2":
+            // King correction is 1.1364 according to https://acp.copernicus.org/articles/21/14927/2021/acp-21-14927-2021.pdf
+            // So solving for delta in the King correction formula gives us 0.075
+            return 0.075;
+        case "Ar":
         case "He":
         case "Ne":
         case "H2":

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -17,7 +17,6 @@
 
 import { DeepReadonly } from "@/utils/types";
 
-import { PresetBands } from "./common";
 import { Gas, getGasDepolarization, getGasRefractiveIndex } from "./gas";
 
 /**
@@ -27,68 +26,84 @@ import { Gas, getGasDepolarization, getGasRefractiveIndex } from "./gas";
 const K_B = 1.380_649e-23;
 
 /**
- * Loschmidt constant, m⁻³ at 273 K & 101 325 Pa
+ * Loschmidt constant (number density at STP), m⁻³ at 273.15 K & 101 325 Pa.
+ * This is the number density of an ideal gas at Standard Temperature and Pressure (STP).
  * @see https://en.wikipedia.org/wiki/Loschmidt_constant
  */
-const N_S = 2.686_78e25;
+const N_S_STP = 2.686_78e25;
 
 /**
  * Compute Rayleigh β_R, β_G, β_B (m⁻¹) for a well-mixed gas atmosphere.
  *
+ * This function calculates the Rayleigh scattering extinction coefficients (beta)
+ * for a gas mixture at specified pressure, temperature, and wavelengths.
+ * It considers the mixture's effective refractive index and depolarization.
+ *
  * @param fractions An array of tuples containing a gas and its associated Mole/volume fraction. The sum of all fractions must add up to 1.0 (will be normalized if not).
  * @param pressure Ambient pressure (Pa)
  * @param temperature Ambient temperature (K)
- * @param waveLengths Wavelength array (m). Default: RGB_WAVELENGTHS
+ * @param waveLengths Wavelength array (m).
  * @returns Tuple [β_R, β_G, β_B] in m⁻¹
  */
 export function computeRayleighBetaRGB(
     fractions: DeepReadonly<Array<[Gas, number]>>,
     pressure: number,
     temperature: number,
-    waveLengths: DeepReadonly<[number, number, number]> = PresetBands.PHOTOPIC,
+    waveLengths: DeepReadonly<[number, number, number]>,
 ): [number, number, number] {
-    /* --- (1) Mixture refractive index and depolarisation --- */
+    /* --- (1) Calculate mixture refractive index and depolarization at STP --- */
     let nMinus1 = 0;
     let delta = 0;
 
-    const sum = fractions.map((fraction) => fraction[1]).reduce((acc, fraction) => acc + fraction, 0);
+    // Normalize fractions in case their sum is not exactly 1.0
+    const sumFractions = fractions.map((fraction) => fraction[1]).reduce((acc, fraction) => acc + fraction, 0);
 
     for (const [gas, fraction] of fractions) {
-        nMinus1 += (fraction * (getGasRefractiveIndex(gas) - 1)) / sum;
-        delta += (fraction * getGasDepolarization(gas)) / sum;
+        // These gas refractive indices and depolarization values are for standard conditions
+        nMinus1 += (fraction * (getGasRefractiveIndex(gas) - 1)) / sumFractions;
+        delta += (fraction * getGasDepolarization(gas)) / sumFractions;
     }
-    const n = 1 + nMinus1;
-    const F = (6 + 3 * delta) / (6 - 7 * delta); // King correction
+    const n_mixture_STP = 1 + nMinus1; // Effective refractive index of the mixture at STP
+    const F_king = (6 + 3 * delta) / (6 - 7 * delta); // King correction factor for the mixture
 
-    /* --- (2) Molecular number density at (P,T) --- */
-    const N = pressure / (K_B * temperature);
+    /* --- (2) Calculate actual molecular number density at given (P,T) --- */
+    // This is the number of molecules per cubic meter at the specified pressure and temperature.
+    const N_actual = pressure / (K_B * temperature);
 
-    /* --- (3) β(λ) for each wavelength --- */
+    /* --- (3) Compute β(λ) for each wavelength --- */
+    // β (extinction coefficient) = N_actual * σ_molecular
+    // where σ_molecular is the molecular Rayleigh scattering cross-section.
     return [
-        N * computeRayleighCrossSection(waveLengths[0], n, F),
-        N * computeRayleighCrossSection(waveLengths[1], n, F),
-        N * computeRayleighCrossSection(waveLengths[2], n, F),
+        N_actual * computeMolecularRayleighCrossSection(waveLengths[0], n_mixture_STP, F_king),
+        N_actual * computeMolecularRayleighCrossSection(waveLengths[1], n_mixture_STP, F_king),
+        N_actual * computeMolecularRayleighCrossSection(waveLengths[2], n_mixture_STP, F_king),
     ];
 }
 
 /**
- * Computes the Rayleigh scattering cross section for a gas for the given wavelength
- * @param wavelength Wavelength of light (m) Inverse of frequency nu.
- * @param n Refractive index of the gas at standard conditions (dimensionless)
- * @param F King correction factor (dimensionless)
- * @returns Rayleigh scattering cross section (m²)
+ * Computes the **molecular Rayleigh scattering cross section** (m²/molecule)
+ * for a gas mixture at a given wavelength.
+ *
+ * This cross-section is derived from the effective refractive index and King factor
+ * of the mixture, assuming these properties are defined at Standard Temperature and Pressure (STP).
+ *
+ * @param wavelength Wavelength of light (m)
+ * @param n_mixture_STP Effective refractive index of the gas mixture at STP (dimensionless)
+ * @param F_king King correction factor for the gas mixture (dimensionless)
+ * @returns Rayleigh scattering molecular cross section (m²)
  * @see https://pmc.ncbi.nlm.nih.gov/articles/PMC6800691/pdf/nihms-1036079.pdf Rayleigh scattering cross sections of argon, carbon dioxide, sulfur hexafluoride, and methane in the UV-A region using Broadband Cavity Enhanced Spectroscopy
  * @see https://acp.copernicus.org/articles/21/14927/2021/ Scattering and absorption cross sections of atmospheric gases in the ultraviolet–visible wavelength range (307–725nm)
  */
-function computeRayleighCrossSection(wavelength: number, n: number, F: number): number {
-    const n2 = n * n;
+function computeMolecularRayleighCrossSection(wavelength: number, n_mixture_STP: number, F_king: number): number {
+    const n2_mixture_STP = n_mixture_STP * n_mixture_STP;
     const lambda4 = wavelength ** 4;
-    const loschmidtSquared = N_S ** 2;
 
-    // Lorentz-Lorenz factor part
-    const polarizabilityTerm = ((n2 - 1) / (n2 + 2)) ** 2;
+    // This term represents the molecular polarizability component squared,
+    // derived from the Lorentz-Lorenz relation using the refractive index at STP and Loschmidt constant.
+    const polarizabilityTermSquared = ((n2_mixture_STP - 1) / ((n2_mixture_STP + 2) * N_S_STP)) ** 2;
 
-    const mainTerm = (24 * Math.PI ** 3) / (lambda4 * loschmidtSquared);
+    // The pre-factor for the molecular Rayleigh scattering cross-section formula.
+    const preFactor = (24 * Math.PI ** 3) / lambda4;
 
-    return mainTerm * polarizabilityTerm * F;
+    return preFactor * polarizabilityTermSquared * F_king;
 }

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -127,7 +127,7 @@ export function computeRayleighBetaRGB(
  * @param wavelength Wavelength of light (m) Inverse of frequency nu.
  * @param n Refractive index of the gas at standard conditions (dimensionless)
  * @param F King correction factor (dimensionless)
- * @returns Rayleigh scattering cross section (m²mol⁻¹)
+ * @returns Rayleigh scattering cross section (m²)
  * @see https://pmc.ncbi.nlm.nih.gov/articles/PMC6800691/pdf/nihms-1036079.pdf Rayleigh scattering cross sections of argon, carbon dioxide, sulfur hexafluoride, and methane in the UV-A region using Broadband Cavity Enhanced Spectroscopy
  * @see https://acp.copernicus.org/articles/21/14927/2021/ Scattering and absorption cross sections of atmospheric gases in the ultraviolet–visible wavelength range (307–725nm)
  */

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -80,10 +80,12 @@ export function getGasDepolarization(gas: Gas): number {
     }
 }
 
-/**
- * Default photopic RGB band-centres (metres)
- */
-const RGB_WAVELENGTHS = [680e-9, 550e-9, 440e-9] as const;
+const PresetBands = {
+    /**
+     * Default photopic RGB band-centres (metres)
+     */
+    PHOTOPIC: [680e-9, 550e-9, 440e-9],
+} as const;
 
 /**
  * Compute Rayleigh β_R, β_G, β_B (m⁻¹) for a well-mixed gas atmosphere.
@@ -98,7 +100,7 @@ export function computeRayleighBetaRGB(
     fractions: DeepReadonly<Array<[Gas, number]>>,
     pressure: number,
     temperature: number,
-    waveLengths: DeepReadonly<[number, number, number]> = RGB_WAVELENGTHS,
+    waveLengths: DeepReadonly<[number, number, number]> = PresetBands.PHOTOPIC,
 ): [number, number, number] {
     /* --- (1) Mixture refractive index and depolarisation --- */
     let nMinus1 = 0;

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -90,7 +90,7 @@ const PresetBands = {
 /**
  * Compute Rayleigh β_R, β_G, β_B (m⁻¹) for a well-mixed gas atmosphere.
  *
- * @param fractions An array of tuples containing a gas and its associated Mole/volume fraction. The sum of all fractions must add up to 1.0
+ * @param fractions An array of tuples containing a gas and its associated Mole/volume fraction. The sum of all fractions must add up to 1.0 (will be normalized if not).
  * @param pressure Ambient pressure (Pa)
  * @param temperature Ambient temperature (K)
  * @param waveLengths Wavelength array (m). Default: RGB_WAVELENGTHS
@@ -106,9 +106,11 @@ export function computeRayleighBetaRGB(
     let nMinus1 = 0;
     let delta = 0;
 
+    const sum = fractions.map((fraction) => fraction[1]).reduce((acc, fraction) => acc + fraction, 0);
+
     for (const [gas, fraction] of fractions) {
-        nMinus1 += fraction * (getGasRefractiveIndex(gas) - 1);
-        delta += fraction * getGasDepolarization(gas);
+        nMinus1 += (fraction * (getGasRefractiveIndex(gas) - 1)) / sum;
+        delta += (fraction * getGasDepolarization(gas)) / sum;
     }
     const n = 1 + nMinus1;
     const F = (6 + 3 * delta) / (6 - 7 * delta); // King correction

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -21,7 +21,7 @@ import { PresetBands } from "./common";
 import { Gas, getGasDepolarization, getGasRefractiveIndex } from "./gas";
 
 /**
- * Boltzmann constant, J K⁻¹  (CODATA 2019)
+ * Boltzmann constant, J K⁻¹
  * @see https://en.wikipedia.org/wiki/Boltzmann_constant
  */
 const K_B = 1.380_649e-23;

--- a/src/ts/utils/physics/atmosphere/rayleighScattering.ts
+++ b/src/ts/utils/physics/atmosphere/rayleighScattering.ts
@@ -15,7 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { DeepReadonly } from "../../types";
+import { DeepReadonly } from "@/utils/types";
+
+import { PresetBands } from "./common";
+import { Gas, getGasDepolarization, getGasRefractiveIndex } from "./gas";
 
 /**
  * Boltzmann constant, J K⁻¹  (CODATA 2019)
@@ -28,64 +31,6 @@ const K_B = 1.380_649e-23;
  * @see https://en.wikipedia.org/wiki/Loschmidt_constant
  */
 const N_S = 2.686_78e25;
-
-export type Gas = "N2" | "O2" | "Ar" | "CO2" | "He" | "Ne" | "H2" | "CH4";
-
-/**
- * @param gas The gas for which to return the refractive index.
- * @returns The refractive index of the gas at standard conditions.
- * @see https://www.engineeringtoolbox.com/refractive-index-d_1264.html
- */
-export function getGasRefractiveIndex(gas: Gas): number {
-    switch (gas) {
-        case "N2":
-            return 1.000298;
-        case "O2":
-            return 1.000271;
-        case "Ar":
-            return 1.000281;
-        case "CO2":
-            return 1.00045;
-        case "He":
-            return 1.000036;
-        case "Ne":
-            return 1.000067;
-        case "H2":
-            return 1.000132;
-        case "CH4":
-            return 1.000444;
-        default:
-            throw new Error(`Unknown gas: ${String(gas)}`);
-    }
-}
-
-export function getGasDepolarization(gas: Gas): number {
-    switch (gas) {
-        case "N2":
-            return 0.022;
-        case "O2":
-            return 0.054;
-        case "CO2":
-            // King correction is 1.1364 according to https://acp.copernicus.org/articles/21/14927/2021/acp-21-14927-2021.pdf
-            // So solving for delta in the King correction formula gives us 0.075
-            return 0.075;
-        case "Ar":
-        case "He":
-        case "Ne":
-        case "H2":
-        case "CH4":
-            return 0; // Remaining gases assumed ≈ 0
-        default:
-            throw new Error(`Unknown gas: ${String(gas)}`);
-    }
-}
-
-const PresetBands = {
-    /**
-     * Default photopic RGB band-centres (metres)
-     */
-    PHOTOPIC: [680e-9, 550e-9, 440e-9],
-} as const;
 
 /**
  * Compute Rayleigh β_R, β_G, β_B (m⁻¹) for a well-mixed gas atmosphere.

--- a/src/ts/utils/physics/atmosphere/scaleHeight.spec.ts
+++ b/src/ts/utils/physics/atmosphere/scaleHeight.spec.ts
@@ -17,7 +17,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { computeAtmospherePressureScaleHeight } from "./scaleHeight";
+import { computeAtmospherePressureScaleHeight, getHeightForPressure } from "./scaleHeight";
 
 const relErr = (calc: number, ref: number) => Math.abs(calc - ref) / ref;
 
@@ -57,6 +57,17 @@ describe("computeAtmospherePressureScaleHeight", () => {
         expect(prediction / 1000).toBeGreaterThan(15.0); // at least 15 km
         expect(prediction / 1000).toBeLessThan(25.0); // below 25 km (lower stratosphere)
     });
+    it("should compute Venus's pressure scale height within 5%", () => {
+        const temperature = 737; // K (average surface temperature)
+        const gravity = 8.87; // m/s²
+        const meanMolecularWeight = 0.04345; // kg/mol (43.45 g/mol, mostly CO2)
+
+        const prediction = computeAtmospherePressureScaleHeight(temperature, gravity, meanMolecularWeight);
+        const groundTruth = 15.9e3; // 15.9 km = 15900 m
+
+        expect(relErr(prediction, groundTruth)).toBeLessThan(0.05);
+        expect(prediction / 1000).toBeCloseTo(15.9, 1); // in km, rounded to 1 decimal point
+    });
     it("should compute Jupiter's pressure scale height within 15%", () => {
         const temperature = 165; // K
         const gravity = 25.92; // m/s²
@@ -66,5 +77,36 @@ describe("computeAtmospherePressureScaleHeight", () => {
         const groundTruth = 27.0e3; // 27.0 km = 27000 m see https://nssdc.gsfc.nasa.gov/planetary/factsheet/jupiterfact.html
 
         expect(relErr(prediction, groundTruth)).toBeLessThan(0.15);
+    });
+});
+
+describe("getHeightForPressure", () => {
+    it("should compute height for pressure on Earth", () => {
+        const targetPressure = 101325; // Pa (sea level)
+        const reference = { pressure: 101325, height: 0 }; // sea level
+        const scaleHeight = 8400; // m
+
+        const height = getHeightForPressure(targetPressure, reference, scaleHeight);
+        expect(height).toBeCloseTo(0, 1); // should be close to sea level
+    });
+
+    it("should compute height for pressure on Mars", () => {
+        const targetPressure = 610; // Pa (average surface pressure)
+        const reference = { pressure: 610, height: 0 }; // Mars surface
+        const scaleHeight = 11200; // m
+
+        const height = getHeightForPressure(targetPressure, reference, scaleHeight);
+        expect(height).toBeCloseTo(0, 1); // should be close to Mars surface
+    });
+
+    it("should predict Earth's Karmann line at 100 km", () => {
+        const targetPressure = 3.2e-2; // Pa (Kármán line, 100 km) see https://www.pdas.com/bigtables.html (Table 1, Z=100km)
+        const reference = { pressure: 101_325, height: 0 }; // sea level
+        const scaleHeight = 8_400; // m
+
+        const height = getHeightForPressure(targetPressure, reference, scaleHeight);
+        const groundTruth = 100_000; // 100 km in meters
+        expect(height).toBeGreaterThan(groundTruth); // approximation should always be above ground truth for atmosphere heights
+        expect(Math.abs(height - groundTruth)).toBeLessThan(30_000);
     });
 });

--- a/src/ts/utils/physics/atmosphere/scaleHeight.spec.ts
+++ b/src/ts/utils/physics/atmosphere/scaleHeight.spec.ts
@@ -1,0 +1,60 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { describe, expect, it } from "vitest";
+
+import { computeAtmospherePressureScaleHeight } from "./scaleHeight";
+
+const relErr = (calc: number, ref: number) => Math.abs(calc - ref) / ref;
+
+describe("computeAtmospherePressureScaleHeight", () => {
+    it("should compute Earth's pressure scale height within 5%", () => {
+        const temperature = 288; // K
+        const gravity = 9.81; // m/s²
+        const meanMolecularWeight = 0.02897; // kg/mol (28.97 g/mol)
+
+        const prediction = computeAtmospherePressureScaleHeight(temperature, gravity, meanMolecularWeight);
+        const groundTruth = 8.4e3; // 8.4 km = 8400 m
+
+        expect(relErr(prediction, groundTruth)).toBeLessThan(0.05);
+        expect(prediction / 1000).toBeCloseTo(8.4, 1); // in km, rounded to 1 decimal point
+    });
+    it("should compute Mars's pressure scale height within 5%", () => {
+        const temperature = 210; // K
+        const gravity = 3.71; // m/s²
+        const meanMolecularWeight = 0.04334; // kg/mol (43.34 g/mol)
+
+        const prediction = computeAtmospherePressureScaleHeight(temperature, gravity, meanMolecularWeight);
+        const groundTruth = 11.2e3; // 11.2 km = 11200 m
+
+        expect(relErr(prediction, groundTruth)).toBeLessThan(0.05);
+        expect(prediction / 1000).toBeCloseTo(10.9, 1); // in km, rounded to 1 decimal point
+    });
+    it("should compute Titan's pressure scale height within 22%", () => {
+        const temperature = 94; // K
+        const gravity = 1.35; // m/s²
+        const meanMolecularWeight = 0.028; // kg/mol (28.0 g/mol)
+
+        const prediction = computeAtmospherePressureScaleHeight(temperature, gravity, meanMolecularWeight);
+        const groundTruth = 17.0e3; // 17.0 km = 17000 m
+
+        // Allow for a larger tolerance as Titan's atmosphere has a wider range of observed scale heights (15-50 km)
+        expect(relErr(prediction, groundTruth)).toBeLessThan(0.22);
+        expect(prediction / 1000).toBeGreaterThan(15.0); // at least 15 km
+        expect(prediction / 1000).toBeLessThan(25.0); // below 25 km (lower stratosphere)
+    });
+});

--- a/src/ts/utils/physics/atmosphere/scaleHeight.spec.ts
+++ b/src/ts/utils/physics/atmosphere/scaleHeight.spec.ts
@@ -57,4 +57,14 @@ describe("computeAtmospherePressureScaleHeight", () => {
         expect(prediction / 1000).toBeGreaterThan(15.0); // at least 15 km
         expect(prediction / 1000).toBeLessThan(25.0); // below 25 km (lower stratosphere)
     });
+    it("should compute Jupiter's pressure scale height within 15%", () => {
+        const temperature = 165; // K
+        const gravity = 25.92; // m/s²
+        const meanMolecularWeight = 0.00222; // kg/mol (2.22 g/mol, mostly H2) see https://nssdc.gsfc.nasa.gov/planetary/factsheet/jupiterfact.html
+
+        const prediction = computeAtmospherePressureScaleHeight(temperature, gravity, meanMolecularWeight);
+        const groundTruth = 27.0e3; // 27.0 km = 27000 m see https://nssdc.gsfc.nasa.gov/planetary/factsheet/jupiterfact.html
+
+        expect(relErr(prediction, groundTruth)).toBeLessThan(0.15);
+    });
 });

--- a/src/ts/utils/physics/atmosphere/scaleHeight.ts
+++ b/src/ts/utils/physics/atmosphere/scaleHeight.ts
@@ -35,3 +35,23 @@ export function computeAtmospherePressureScaleHeight(
     // Scale height formula: H = R * T / (M * g)
     return (R * temperature) / (meanMolecularWeight * gravity);
 }
+
+/**
+ * Computes the height at which a given pressure is reached in an atmosphere with a known scale height.
+ * @param targetPressure The pressure in Pascals at the desired height.
+ * @param reference The reference pressure and height to calculate from.
+ * @param scaleHeight The scale height of the atmosphere in meters.
+ * @returns The height at which the target pressure is reached in meters.
+ */
+export function getHeightForPressure(
+    targetPressure: number,
+    reference: { pressure: number; height: number },
+    scaleHeight: number,
+): number {
+    // Using the exponential decay of pressure with height
+    // P = P0 * exp(-h / H)
+    // Rearranging gives us: h = -H * ln(P / P0)
+    const { pressure: referencePressure, height: referenceHeight } = reference;
+
+    return referenceHeight - scaleHeight * Math.log(targetPressure / referencePressure);
+}

--- a/src/ts/utils/physics/atmosphere/scaleHeight.ts
+++ b/src/ts/utils/physics/atmosphere/scaleHeight.ts
@@ -1,0 +1,37 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Universal gas constant, J/(mol·K)
+ */
+const R = 8.314462618;
+
+/**
+ * @param temperature Temperature in Kelvin
+ * @param gravity Gravitational acceleration in m/s²
+ * @param meanMolecularWeight Mean molecular weight of the atmosphere in kg/mol
+ * @returns The Rayleigh scale height in meters.
+ * @see https://en.wikipedia.org/wiki/Scale_height
+ */
+export function computeAtmospherePressureScaleHeight(
+    temperature: number,
+    gravity: number,
+    meanMolecularWeight: number,
+): number {
+    // Scale height formula: H = R * T / (M * g)
+    return (R * temperature) / (meanMolecularWeight * gravity);
+}

--- a/src/ts/utils/physics/gravity.ts
+++ b/src/ts/utils/physics/gravity.ts
@@ -1,0 +1,32 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Gravitational constant, m³ kg⁻¹ s⁻²
+ * @see https://en.wikipedia.org/wiki/Gravitational_constant
+ */
+export const G = 6.674_30e-11;
+
+/**
+ * @param mass The mass of the object (kg)
+ * @param distance The distance from the center of the object to the point where the gravitational acceleration is computed (m)
+ * @returns The gravitational acceleration at the given distance (m/s²)
+ * @see https://en.wikipedia.org/wiki/Newton%27s_law_of_universal_gravitation
+ */
+export function computeGravityAcceleration(mass: number, distance: number): number {
+    return (G * mass) / (distance * distance);
+}

--- a/tests/e2e/atmosphereScattering.spec.ts-snapshots/baseline-linux.png
+++ b/tests/e2e/atmosphereScattering.spec.ts-snapshots/baseline-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac604719712bacc5d24f78e4b4b48dbf9b4994f302dcda5669e57db5e045464c
-size 86747
+oid sha256:20a67185faa7dbe4a84011dacec96a27ea96d988ddc6d598a53cb229b8ec3ee0
+size 85180

--- a/tests/e2e/gasPlanet.spec.ts-snapshots/baseline-linux.png
+++ b/tests/e2e/gasPlanet.spec.ts-snapshots/baseline-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2677512c3df15d28f66eabd830cd42c1062173377fca8dfbdb8c75448559b628
-size 357637
+oid sha256:b223efc0dc61de5e62485b7f491da485d1364f20bc2bc5e1a2b6f8e2249614e6
+size 357834

--- a/tests/e2e/sol/jupiter.spec.ts-snapshots/baseline-linux.png
+++ b/tests/e2e/sol/jupiter.spec.ts-snapshots/baseline-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74eb56c3ecd56704e97abaec4ae5f0f116ccbe2e5f200c3882d360e6407c9793
-size 372659
+oid sha256:8f7e3830579deaf1182237abf548560a9e515718f9a5d2301ecf859d1c1f9d29
+size 376736

--- a/tests/e2e/sol/saturn.spec.ts-snapshots/baseline-linux.png
+++ b/tests/e2e/sol/saturn.spec.ts-snapshots/baseline-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ddc103e1e43ce6a02c76d8e634f089a03a5ba3f5ee5e9bc709dab721ff593cd
-size 237463
+oid sha256:f6428e355987b83a209668527d86fcc5fccb54dbf6e896fab1c1e36b8cee8fa3
+size 250456


### PR DESCRIPTION
## Related Tickets

Fixes #306 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Thanks to physics, rayleigh scattering coefficients can be computed from the atmospheric composition. This is an important step toward making the game more immersive and believable.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

E2E test should suffice for this one.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

Next up is Mie scattering #454 
