### PR TITLE
Fix: billboarding must be handled per instance in starmap

### DIFF
--- a/src/ts/frontend/starmap/starMap.ts
+++ b/src/ts/frontend/starmap/starMap.ts
@@ -411,7 +411,7 @@ export class StarMap implements View {
         );
     }
 
-    public translateCameraBackToOrigin(camera: Camera) {
+    private translateCameraBackToOrigin(camera: Camera) {
         const translationToOrigin = camera.globalPosition.negate();
         this.controls.getTransform().position.addInPlace(translationToOrigin);
         this.controls.getActiveCamera().getViewMatrix(true);

--- a/src/ts/frontend/starmap/starMap.ts
+++ b/src/ts/frontend/starmap/starMap.ts
@@ -238,7 +238,6 @@ export class StarMap implements View {
         this.starMapCenterPosition = Vector3.Zero();
 
         this.starTemplate = MeshBuilder.CreatePlane("star", { size: 0.6 }, this.scene);
-        this.starTemplate.billboardMode = Mesh.BILLBOARDMODE_ALL;
         this.starTemplate.isPickable = true;
         this.starTemplate.isVisible = false;
         this.starTemplate.hasVertexAlpha = true;
@@ -254,7 +253,6 @@ export class StarMap implements View {
         this.starTemplate.material = starMaterial;
 
         this.blackHoleTemplate = MeshBuilder.CreatePlane("blackHole", { size: 0.8 }, this.scene);
-        this.blackHoleTemplate.billboardMode = Mesh.BILLBOARDMODE_ALL;
         this.blackHoleTemplate.isPickable = true;
         this.blackHoleTemplate.isVisible = false;
 
@@ -568,7 +566,7 @@ export class StarMap implements View {
         //TODO: when implementing binary star systems, this will need to be updated to display all stellar objects and not just the first one
         const stellarObjectModel = starSystemModel.stellarObjects[0];
 
-        const instanceName = JSON.stringify(starSystemCoordinates);
+        const instanceName = `${starSystemModel.name} Billboard instance`;
 
         let instance: InstancedMesh | null = null;
         let recycled = false;
@@ -590,6 +588,7 @@ export class StarMap implements View {
         }
 
         const initializedInstance = instance;
+        initializedInstance.billboardMode = Mesh.BILLBOARDMODE_ALL;
 
         this.coordinatesToInstanceMap.set(JSON.stringify(starSystemCoordinates), initializedInstance);
         this.instanceToCoordinatesMap.set(initializedInstance, JSON.stringify(starSystemCoordinates));

--- a/src/ts/playgrounds/starMap.ts
+++ b/src/ts/playgrounds/starMap.ts
@@ -20,11 +20,14 @@ import { Scene } from "@babylonjs/core/scene";
 
 import { EncyclopaediaGalacticaLocal } from "@/backend/encyclopaedia/encyclopaediaGalacticaLocal";
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
+import { StarSystemCoordinatesSchema } from "@/backend/universe/starSystemCoordinates";
 import { StarSystemDatabase } from "@/backend/universe/starSystemDatabase";
 
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { Player } from "@/frontend/player/player";
 import { StarMap } from "@/frontend/starmap/starMap";
+
+import { jsonSafeParse } from "@/utils/json";
 
 import { initI18n } from "@/i18n";
 
@@ -44,6 +47,20 @@ export async function createStarMapScene(
 
     const starMap = new StarMap(player, engine, encyclopaediaGalactica, starSystemDatabase, soundPlayerMock);
     starMap.setCurrentStarSystem(starSystemDatabase.fallbackSystem.coordinates);
+
+    // Get system coordinates from URL parameters
+    const urlParams = new URLSearchParams(window.location.search);
+    const customSystemCoordinates = urlParams.get("systemCoordinates");
+
+    // If system parameter was provided, focus on the specified system
+    if (customSystemCoordinates !== null) {
+        const systemCoordinates = jsonSafeParse(decodeURIComponent(customSystemCoordinates));
+        if (systemCoordinates === null) {
+            throw new Error("Invalid system coordinates json provided in URL parameters.");
+        }
+
+        starMap.focusOnSystem(StarSystemCoordinatesSchema.parse(systemCoordinates), true);
+    }
 
     progressCallback(1, "Loaded star map");
 

--- a/tests/e2e/starMap.spec.ts
+++ b/tests/e2e/starMap.spec.ts
@@ -10,3 +10,24 @@ test("The star map playground renders correctly", async ({ page }) => {
         urlParams: { freeze: 3 },
     });
 });
+
+test("The star map playground renders correctly when targeting another system", async ({ page }) => {
+    await renderAndSnap(page, {
+        shotName: "baselineOtherSystem",
+        scene: "starMap",
+        flagToWait: "frozen",
+        urlParams: {
+            freeze: 3,
+            systemCoordinates: encodeURIComponent(
+                JSON.stringify({
+                    localX: -0.1547746381977455,
+                    localY: -0.4600146743282744,
+                    localZ: 0.35319629770386796,
+                    starSectorX: 7,
+                    starSectorY: -9,
+                    starSectorZ: 9,
+                }),
+            ),
+        },
+    });
+});

--- a/tests/e2e/starMap.spec.ts-snapshots/baselineOtherSystem-linux.png
+++ b/tests/e2e/starMap.spec.ts-snapshots/baselineOtherSystem-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85a6148d47ac1d35f25567bb764914ca0b3f703768c078c48c0aba276ddaf774
+size 134417


### PR DESCRIPTION
## Related Tickets

Fixes #466 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR adapts the starmap to a recent babylonjs change: https://forum.babylonjs.com/t/billboard-mode-for-instances-differ-from-previous-release/58798/2

## Unexpected difficulties

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

None

## How to test

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

- Open the star map
- Rotate the camera
- Stars should be facing the camera

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

None
