### PR TITLE
Fix orbit rendering

### DIFF
--- a/src/ts/frontend/starSystemView.ts
+++ b/src/ts/frontend/starSystemView.ts
@@ -91,6 +91,7 @@ import { Player } from "./player/player";
 import { isScannerInRange } from "./spaceship/components/discoveryScanner";
 import { Transformable } from "./universe/architecture/transformable";
 import { TypedObject } from "./universe/architecture/typedObject";
+import { CreateLinesHelper } from "./universe/lineRendering";
 
 // register cosmos journeyer as part of window object
 declare global {
@@ -162,13 +163,13 @@ export class StarSystemView implements View {
      * A debug helper to display the orbits of the orbital objects
      * @private
      */
-    private readonly orbitRenderer: OrbitRenderer = new OrbitRenderer();
+    private readonly orbitRenderer: OrbitRenderer = new OrbitRenderer(CreateLinesHelper);
 
     /**
      * A debug helper to display the axes of the orbital objects
      * @private
      */
-    private readonly axisRenderer: AxisRenderer = new AxisRenderer();
+    private readonly axisRenderer: AxisRenderer = new AxisRenderer(CreateLinesHelper);
 
     /**
      * The controller of the current star system. This controller is unique per star system and is destroyed when the star system is changed.

--- a/src/ts/frontend/universe/axisRenderer.ts
+++ b/src/ts/frontend/universe/axisRenderer.ts
@@ -15,22 +15,27 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { GreasedLineMeshColorMode } from "@babylonjs/core/Materials/GreasedLine/greasedLineMaterialInterfaces";
 import { Vector3 } from "@babylonjs/core/Maths/math";
-import { Color3 } from "@babylonjs/core/Maths/math.color";
-import { CreateGreasedLine, GreasedLineBaseMesh, GreasedLineMesh, GreasedLineRibbonMesh } from "@babylonjs/core/Meshes";
+import { Mesh } from "@babylonjs/core/Meshes";
 import { Scene } from "@babylonjs/core/scene";
 
 import { HasBoundingSphere } from "./architecture/hasBoundingSphere";
 import { Transformable } from "./architecture/transformable";
+import { CreateLinesMeshFunction } from "./lineRendering";
 
 /**
  * Visual helper designed to display the rotation axis of given objects
  */
 export class AxisRenderer {
-    private axisMeshes: (GreasedLineBaseMesh | GreasedLineMesh | GreasedLineRibbonMesh)[] = [];
+    private axisMeshes: Array<Mesh> = [];
 
     private _isVisible = false;
+
+    private readonly createAxisMeshFromPoints: CreateLinesMeshFunction;
+
+    constructor(createAxisMeshFromPoints: CreateLinesMeshFunction) {
+        this.createAxisMeshFromPoints = createAxisMeshFromPoints;
+    }
 
     /**
      * Disposes all previously created axis meshes by calling reset() and then creates new axis meshes for the given objects
@@ -48,21 +53,15 @@ export class AxisRenderer {
     }
 
     private createAxisMesh(orbitalObject: Transformable & HasBoundingSphere, scene: Scene) {
-        const rotationAxisHelper = CreateGreasedLine(
+        const points = [
+            new Vector3(0, -orbitalObject.getBoundingRadius() * 2, 0),
+            new Vector3(0, orbitalObject.getBoundingRadius() * 2, 0),
+        ];
+
+        const rotationAxisHelper = this.createAxisMeshFromPoints(
             `${orbitalObject.getTransform().name}AxisHelper`,
-            {
-                points: [
-                    new Vector3(0, -orbitalObject.getBoundingRadius() * 2, 0),
-                    new Vector3(0, orbitalObject.getBoundingRadius() * 2, 0),
-                ],
-                updatable: false,
-            },
-            {
-                color: new Color3(0.4, 0.4, 0.4),
-                width: 5,
-                colorMode: GreasedLineMeshColorMode.COLOR_MODE_SET,
-                sizeAttenuation: true,
-            },
+            points,
+            { r: 0.4, g: 0.4, b: 0.4 },
             scene,
         );
 

--- a/src/ts/frontend/universe/lineRendering.ts
+++ b/src/ts/frontend/universe/lineRendering.ts
@@ -1,0 +1,66 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { GreasedLineMeshColorMode } from "@babylonjs/core/Materials/GreasedLine/greasedLineMaterialInterfaces";
+import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { CreateGreasedLine } from "@babylonjs/core/Meshes/Builders/greasedLineBuilder";
+import { CreateLines } from "@babylonjs/core/Meshes/Builders/linesBuilder";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { Scene } from "@babylonjs/core/scene";
+
+import { RGBColor } from "@/utils/colors";
+
+export type CreateLinesMeshFunction = (
+    name: string,
+    points: ReadonlyArray<Vector3>,
+    color: RGBColor,
+    scene: Scene,
+) => Mesh;
+
+export const CreateGreasedLineHelper: CreateLinesMeshFunction = (
+    name: string,
+    points: ReadonlyArray<Vector3>,
+    color: RGBColor,
+    scene: Scene,
+) => {
+    return CreateGreasedLine(
+        name,
+        {
+            points: [...points],
+            updatable: false,
+        },
+        {
+            color: new Color3(color.r, color.g, color.b),
+            width: 5,
+            colorMode: GreasedLineMeshColorMode.COLOR_MODE_SET,
+            sizeAttenuation: true,
+        },
+        scene,
+    );
+};
+
+export const CreateLinesHelper: CreateLinesMeshFunction = (
+    name: string,
+    points: ReadonlyArray<Vector3>,
+    color: RGBColor,
+    scene: Scene,
+) => {
+    const color4 = new Color4(color.r, color.g, color.b, 1.0);
+    const colors = points.map(() => color4);
+    return CreateLines(name, { points: [...points], colors, updatable: false }, scene);
+};

--- a/src/ts/frontend/universe/orbitRenderer.ts
+++ b/src/ts/frontend/universe/orbitRenderer.ts
@@ -15,22 +15,28 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { GreasedLineMeshColorMode } from "@babylonjs/core/Materials/GreasedLine/greasedLineMaterialInterfaces";
 import { Matrix, Quaternion, Vector3 } from "@babylonjs/core/Maths/math";
-import { Color3 } from "@babylonjs/core/Maths/math.color";
-import { CreateGreasedLine, GreasedLineBaseMesh } from "@babylonjs/core/Meshes";
+import { Mesh } from "@babylonjs/core/Meshes";
 import { Scene } from "@babylonjs/core/scene";
 
 import { OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
 
 import { getOrbitalPeriod, getPointOnOrbitLocal } from "@/utils/physics/orbit";
 
+import { CreateLinesMeshFunction } from "./lineRendering";
+
 export class OrbitRenderer {
-    private orbitMeshes: Map<OrbitalObject, GreasedLineBaseMesh> = new Map();
+    private orbitMeshes: Map<OrbitalObject, Mesh> = new Map();
 
     private orbitalObjectToParents: Map<OrbitalObject, ReadonlyArray<OrbitalObject>> = new Map();
 
     private _isVisible = false;
+
+    private readonly createOrbitMeshFromPoints: CreateLinesMeshFunction;
+
+    constructor(createOrbitMeshFromPoints: CreateLinesMeshFunction) {
+        this.createOrbitMeshFromPoints = createOrbitMeshFromPoints;
+    }
 
     setOrbitalObjects(orbitalObjects: ReadonlyArray<OrbitalObject>, scene: Scene) {
         this.reset();
@@ -66,18 +72,10 @@ export class OrbitRenderer {
             points.push(points[0]);
         }
 
-        const orbitMesh = CreateGreasedLine(
-            `${orbitalObject.getTransform().name}OrbitHelper`,
-            {
-                points: points,
-                updatable: false,
-            },
-            {
-                color: new Color3(0.4, 0.4, 0.4),
-                width: 5,
-                colorMode: GreasedLineMeshColorMode.COLOR_MODE_SET,
-                sizeAttenuation: true,
-            },
+        const orbitMesh = this.createOrbitMeshFromPoints(
+            `${orbitalObject.model.name}OrbitHelper`,
+            points,
+            { r: 0.4, g: 0.4, b: 0.4 },
             scene,
         );
         this.orbitMeshes.set(orbitalObject, orbitMesh);

--- a/src/ts/playgrounds/orbitalDemo.ts
+++ b/src/ts/playgrounds/orbitalDemo.ts
@@ -29,6 +29,7 @@ import { OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
 import { setOrbitalPosition, setRotation } from "@/frontend/universe/architecture/orbitalObjectUtils";
 import { AxisRenderer } from "@/frontend/universe/axisRenderer";
 import { CustomOrbitalObject } from "@/frontend/universe/customOrbitalObject";
+import { CreateGreasedLineHelper } from "@/frontend/universe/lineRendering";
 import { OrbitRenderer } from "@/frontend/universe/orbitRenderer";
 
 export function createOrbitalDemoScene(
@@ -110,11 +111,11 @@ export function createOrbitalDemoScene(
     bodyToParents.set(earth, [sun]);
     bodyToParents.set(moon, [earth]);
 
-    const orbitRenderer = new OrbitRenderer();
+    const orbitRenderer = new OrbitRenderer(CreateGreasedLineHelper);
     orbitRenderer.setOrbitalObjects(bodies, scene);
     orbitRenderer.setVisibility(true);
 
-    const axisRenderer = new AxisRenderer();
+    const axisRenderer = new AxisRenderer(CreateGreasedLineHelper);
     axisRenderer.setVisibility(true);
     axisRenderer.setOrbitalObjects(bodies, scene);
 


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Switch back to Lines meshes. Injection allows going back to greased lines easily in the future

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Play the game and press "O", the orbit should not be flickering.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

Try and fix the greased lines (see https://forum.babylonjs.com/t/greased-line-visual-glitch-at-large-scale/59320)
