### PR TITLE
Fix inverted textures for custom planets

### DIFF
--- a/src/ts/utils/bslExtensions.ts
+++ b/src/ts/utils/bslExtensions.ts
@@ -47,7 +47,7 @@ export function unitSphereToUv(positionUnitSphere: NodeMaterialConnectionPoint) 
     const u = div(add(phi, f(Math.PI)), f(2.0 * Math.PI));
     const v = div(theta, f(Math.PI));
 
-    return merge(sub(f(1.0), u), sub(f(1.0), v), null, null).xyOut;
+    return merge(sub(f(1.0), u), v, null, null).xyOut;
 }
 
 export function bslTextureSample2d(
@@ -71,14 +71,10 @@ export function bslTexture2dArrayMosaicSample(
     uv: NodeMaterialConnectionPoint,
     options?: Partial<TextureBlockOptions>,
 ): TextureBlock {
-    const splitUv = split(uv);
-
-    const uvInvertedY = vec2(splitUv.x, sub(f(1.0), splitUv.y));
-
     const tileCountX = f(texture.tileCount.x);
     const tileCountY = f(texture.tileCount.y);
 
-    const uvScaled = mul(uvInvertedY, vec2(tileCountX, tileCountY));
+    const uvScaled = mul(uv, vec2(tileCountX, tileCountY));
 
     const { x: tileIndexX, y: tileIndexY } = split(floor(uvScaled));
 


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Planet textures got inverted, this fixed the issue.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

Indexing is hard

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Open any of the custom planet playground (earth, mars, moon, mercury) and check that the normal map aligns with the height field and also aligns with the color map.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->

None