### PR TITLE
Add NME to playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cosmos-journeyer",
-    "version": "1.10.4-dev",
+    "version": "1.10.4",
     "engines": {
         "node": ">=18.0.0",
         "pnpm": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "@babylonjs/inspector": "^8.10.0",
         "@babylonjs/loaders": "^8.10.0",
         "@babylonjs/materials": "^8.10.0",
+        "@babylonjs/node-editor": "^8.10.0",
         "@brianchirls/game-input": "^0.1.1",
         "d3": "^7.9.0",
         "extended-random": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@babylonjs/materials':
         specifier: ^8.10.0
         version: 8.10.0(@babylonjs/core@8.10.0)
+      '@babylonjs/node-editor':
+        specifier: 8.10.0
+        version: 8.10.0(@babylonjs/core@8.10.0)(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)
       '@brianchirls/game-input':
         specifier: ^0.1.1
         version: 0.1.1
@@ -250,6 +253,13 @@ packages:
     resolution: {integrity: sha512-XqbOjQ51rO30K4Eyh3c1tl6dlKmQS75hqAy7QbHUIQrANz4HmdOc2wUYpXvkFSmiC55wMO/3+umwCc62tU3z3A==}
     peerDependencies:
       '@babylonjs/core': ^8.6.0
+
+  '@babylonjs/node-editor@8.10.0':
+    resolution: {integrity: sha512-VcJvgFOBTibxNGlfSoMfbO+LqZyOoP/DxpiU65KPut71EXUUe9ASMzLnoJdSSBDWCGOTvp6QLMJT+/LCvRhgXA==}
+    peerDependencies:
+      '@babylonjs/core': ^8.0.0
+      '@types/react': '>=16.7.3'
+      '@types/react-dom': '>=16.0.9'
 
   '@babylonjs/serializers@8.4.0':
     resolution: {integrity: sha512-ZOdwicpdv6lLPUZQOlP1UW54lSAEPazW831FoBupBTfYleXm5/YVQvHWC4IsuJ0qKjqGUg+L8jWc9tNxJSBQLQ==}
@@ -4316,6 +4326,12 @@ snapshots:
     dependencies:
       '@babylonjs/core': 8.10.0
 
+  '@babylonjs/node-editor@8.10.0(@babylonjs/core@8.10.0)(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)':
+    dependencies:
+      '@babylonjs/core': 8.10.0
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+
   '@babylonjs/serializers@8.4.0(@babylonjs/core@8.10.0)(babylonjs-gltf2interface@8.4.0)':
     dependencies:
       '@babylonjs/core': 8.10.0
@@ -6286,7 +6302,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.2)(eslint@9.28.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.2(eslint-plugin-import@2.31.0)(eslint@9.28.0))(eslint@9.28.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -6308,7 +6324,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.28.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.2)(eslint@9.28.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.2(eslint-plugin-import@2.31.0)(eslint@9.28.0))(eslint@9.28.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         specifier: ^8.10.0
         version: 8.10.0(@babylonjs/core@8.10.0)
       '@babylonjs/node-editor':
-        specifier: 8.10.0
+        specifier: ^8.10.0
         version: 8.10.0(@babylonjs/core@8.10.0)(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)
       '@brianchirls/game-input':
         specifier: ^0.1.1

--- a/src/ts/frontend/assets/textures/rings.ts
+++ b/src/ts/frontend/assets/textures/rings.ts
@@ -15,8 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Scene } from "@babylonjs/core";
 import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
+import { type Scene } from "@babylonjs/core/scene";
 
 import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
 import { loadTextureAsync } from "./utils";

--- a/src/ts/playground.ts
+++ b/src/ts/playground.ts
@@ -17,6 +17,7 @@
 
 import "@styles/index.scss";
 import "@babylonjs/inspector";
+import "@babylonjs/node-editor";
 
 import { Engine, PhysicsViewer, Tools, type Scene } from "@babylonjs/core";
 


### PR DESCRIPTION
## Related Tickets

Fixes #495 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

This PR adds NME to playground, allowing to tweak material nodes directly while running the scenes, improving iteration speed.

Also included: a fix for tree shaking and a version bump

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Open a PG with a node material like `spaceStation` with the debug flag: http://localhost:8080/playground.html?scene=spaceStation&debug

Go to the materials section of the left panel and click on the edit button for the solar panel material. The NME should open in a new window. 

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

None

<!--
What should we do next to take advantage of this work?
-->
