### PR TITLE
Fix TypeDoc documentation warnings

### DIFF
--- a/src/ts/backend/save/saveBackendSingleFile.ts
+++ b/src/ts/backend/save/saveBackendSingleFile.ts
@@ -32,7 +32,7 @@ import { SaveLoadingErrorType, type SaveLoadingError } from "./saveLoadingError"
 export interface IFile {
     /**
      * Writes save data to the storage backend.
-     * @param saves - Record of commander saves, keyed by commander string
+     * @param content - JSON string containing all commander saves
      * @returns Boolean indicating success or failure of the write operation
      */
     write(content: string): Promise<boolean>;

--- a/src/ts/backend/universe/proceduralGenerators/starSystemModelGenerator.ts
+++ b/src/ts/backend/universe/proceduralGenerators/starSystemModelGenerator.ts
@@ -69,7 +69,10 @@ const enum GenerationSteps {
 
 /**
  * Generates a new star system data model given a seed using a pseudo-random number generator.
- * @param seed The seed of the star system.
+ * @param systemRng The pseudo-random generator for the star system.
+ * @param coordinates The coordinates of the star system within the galaxy.
+ * @param position The position of the star system within its sector.
+ * @param isCivilized Whether the generated system should be considered civilized.
  * @returns The data model of the generated star system.
  */
 export function newSeededStarSystemModel(

--- a/src/ts/backend/universe/starSystemDatabase.ts
+++ b/src/ts/backend/universe/starSystemDatabase.ts
@@ -450,7 +450,6 @@ export class StarSystemDatabase {
     /**
      * Searches the database for the given id
      * @param universeObjectId The id to look for
-     * @param starSystemDatabase The database to look in
      * @returns The model if it exists, null otherwise
      */
     public getObjectModelByUniverseId(universeObjectId: UniverseObjectId): DeepReadonly<OrbitalObjectModel> | null {

--- a/src/ts/frontend/spaceship/components/fuelTank.ts
+++ b/src/ts/frontend/spaceship/components/fuelTank.ts
@@ -27,8 +27,8 @@ export class FuelTank {
     readonly quality: number;
 
     /**
-     * Creates an empty fuel tank with the given maximum fuel capacity.
-     * @param maxFuel The maximum fuel capacity of the tank.
+     * Creates a fuel tank based on serialized data.
+     * @param serializedFuelTank The serialized specification of the fuel tank.
      */
     constructor(serializedFuelTank: SerializedFuelTank) {
         this.type = serializedFuelTank.type;

--- a/src/ts/frontend/starSystemView.ts
+++ b/src/ts/frontend/starSystemView.ts
@@ -232,7 +232,7 @@ export class StarSystemView implements View {
      * To fill it with a star system, use `loadStarSystem` and then `initStarSystem`
      * @param player The player object shared with the rest of the game
      * @param engine The BabylonJS engine
-     * @param havokInstance The Havok physics instance
+     * @param havokPlugin The Havok physics plugin instance
      */
     constructor(
         scene: UberScene,

--- a/src/ts/frontend/universe/architecture/orbitalObjectUtils.ts
+++ b/src/ts/frontend/universe/architecture/orbitalObjectUtils.ts
@@ -27,7 +27,6 @@ import { type OrbitalObject } from "./orbitalObject";
  * @param object The object we want to compute the position of
  * @param parents
  * @param elapsedSeconds The time elapsed since the beginning of time in seconds
- * @constructor
  */
 export function getOrbitalPosition(
     object: OrbitalObject,
@@ -55,7 +54,6 @@ export function getOrbitalPosition(
  * @param object The object we want to update the position of
  * @param parents
  * @param elapsedSeconds The time elapsed since the beginning of time in seconds
- * @constructor
  */
 export function setOrbitalPosition(
     object: OrbitalObject,
@@ -76,7 +74,6 @@ export function setOrbitalPosition(
  * Computes the rotation angle of the object around its axis for a given time
  * @param object The object we want to compute the rotation of
  * @param deltaSeconds The time span in seconds
- * @constructor
  */
 export function getRotationAngle(object: OrbitalObject, deltaSeconds: number): number {
     if (object.model.siderealDaySeconds === 0) return 0;

--- a/src/ts/frontend/universe/asteroidFields/asteroidField.ts
+++ b/src/ts/frontend/universe/asteroidFields/asteroidField.ts
@@ -56,8 +56,8 @@ export class AsteroidField implements IDisposable {
      * Creates a new asteroid field around a given transform
      * @param seed The seed of the asteroid field
      * @param parent A parent transform node for the asteroids
-     * @param averageRadius The average distance to the parent of the asteroids
-     * @param spread The spread of the distance to the parent around the average distance
+     * @param innerRadius The minimum distance from the parent at which asteroids can spawn
+     * @param outerRadius The maximum distance from the parent at which asteroids can spawn
      * @param scene The scene where the asteroid field exists
      */
     constructor(seed: number, parent: TransformNode, innerRadius: number, outerRadius: number, scene: Scene) {

--- a/src/ts/utils/bsl.ts
+++ b/src/ts/utils/bsl.ts
@@ -579,7 +579,6 @@ export function vec4(
 /**
  * Splits a vec2/3/4 into its components.
  * @param inputVec - The input vec.
- * @param dim - The dimension of the input vector
  * @param options - Optional target options.
  */
 export function split(inputVec: NodeMaterialConnectionPoint, options?: Partial<TargetOptions>): VectorSplitterBlock {

--- a/src/ts/utils/physics/orbit.ts
+++ b/src/ts/utils/physics/orbit.ts
@@ -100,9 +100,10 @@ export function getPointOnOrbit(
 }
 
 /**
- * Returns the multiplicative factor to transform the Euclidean orbit into a p-norm orbit for a given theta angle and p-norm
- * @param theta
- * @param p
+ * Returns the multiplicative factor to transform the Euclidean orbit into a p-norm orbit for the given coordinates and p-norm
+ * @param x The x-coordinate of the point along the orbit.
+ * @param y The y-coordinate of the point along the orbit.
+ * @param p The p-norm shaping the orbit.
  */
 export function computeLpFactor(x: number, y: number, p: number) {
     return 1 / (Math.abs(x) ** p + Math.abs(y) ** p) ** (1 / p);

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,6 +3,7 @@
     "out": "doc",
     "plugin": ["typedoc-github-theme", "typedoc-plugin-missing-exports"],
     "theme": "typedoc-github-theme",
+    "sourceLinkTemplate": "https://github.com/BarthPaleologue/CosmosJourneyer/blob/{gitRevision}/{path}#L{line}",
 
     "entryPointStrategy": "expand",
     "entryPoints": ["src/ts"],


### PR DESCRIPTION
## Summary
- align TypeDoc annotations with function and constructor parameters to eliminate warnings
- remove unsupported tags in orbital utilities documentation
- configure TypeDoc source link template to avoid git remote warnings when generating docs

## Testing
- pnpm doc

------
https://chatgpt.com/codex/tasks/task_e_68c91974c7408328a119661fd1c9c200