### PR TITLE
Fix radar dot X position

### DIFF
--- a/src/ts/frontend/ui/spaceShipLayer.ts
+++ b/src/ts/frontend/ui/spaceShipLayer.ts
@@ -150,7 +150,7 @@ export class SpaceShipLayer {
 
             // set top and left of targetDot based on direction2D (use %)
             this.targetDot.style.top = `${50 - 50 * directionLocal.y}%`;
-            this.targetDot.style.left = `${50 - 50 * directionLocal.x}%`;
+            this.targetDot.style.left = `${50 + 50 * directionLocal.x}%`;
         }
 
         this.currentMissionDisplay.update(missionContext, keyboardLayout, starSystemDatabase);


### PR DESCRIPTION
## Related Tickets

Spontaneous
<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Radar dot position was inverted along the X axis (left when should have been right and vice-versa)

Probably caused by handedness shenanigans in latest Babylon update


<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Target an object. Dot should be to the left of the circle when target is to the left of the ship.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

None

<!--
What should we do next to take advantage of this work?
-->
