### PR TITLE
Ensure player creation date default is lazy

### DIFF
--- a/src/ts/backend/player/serializedPlayer.ts
+++ b/src/ts/backend/player/serializedPlayer.ts
@@ -28,7 +28,7 @@ export const SerializedPlayerSchema = z.object({
         .default(() => crypto.randomUUID()),
     name: z.string().default("Python"),
     balance: z.number().default(10000),
-    creationDate: z.string().default(new Date().toISOString()),
+    creationDate: z.string().default(() => new Date().toISOString()),
     timePlayedSeconds: z.number().default(0),
     visitedSystemHistory: z.array(StarSystemCoordinatesSchema).default([]),
     discoveries: z

--- a/src/ts/frontend/player/player.spec.ts
+++ b/src/ts/frontend/player/player.spec.ts
@@ -74,6 +74,24 @@ describe("Player", () => {
         });
     });
 
+    describe("SerializedPlayerSchema", () => {
+        it("should assign a unique creationDate default for each parse", () => {
+            vi.useFakeTimers();
+
+            try {
+                vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+                const firstCreationDate = SerializedPlayerSchema.parse({}).creationDate;
+
+                vi.setSystemTime(new Date("2024-01-01T00:00:01.000Z"));
+                const secondCreationDate = SerializedPlayerSchema.parse({}).creationDate;
+
+                expect(firstCreationDate).not.toBe(secondCreationDate);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
+
     describe("Serialization and Deserialization", () => {
         it("should serialize and deserialize a default player without data loss", () => {
             const originalPlayer = Player.Default(starSystemDatabase);


### PR DESCRIPTION
## Summary
- change the SerializedPlayerSchema creationDate default to use a lazy callback so each parse gets a fresh timestamp
- add a unit test that parses the schema twice without a creationDate and asserts the generated values differ

## Testing
- pnpm test:unit -- --runInBand --filter player.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d90a34e8b48328b7d556bbe0055624