### PR TITLE
Ensure serialized player defaults are lazily generated

### DIFF
--- a/src/ts/backend/player/serializedPlayer.ts
+++ b/src/ts/backend/player/serializedPlayer.ts
@@ -30,28 +30,28 @@ export const SerializedPlayerSchema = z.object({
     balance: z.number().default(10000),
     creationDate: z.string().default(() => new Date().toISOString()),
     timePlayedSeconds: z.number().default(0),
-    visitedSystemHistory: z.array(StarSystemCoordinatesSchema).default([]),
+    visitedSystemHistory: z.array(StarSystemCoordinatesSchema).default(() => []),
     discoveries: z
         .object({
-            local: z.array(SpaceDiscoveryDataSchema).default([]),
-            uploaded: z.array(SpaceDiscoveryDataSchema).default([]),
+            local: z.array(SpaceDiscoveryDataSchema).default(() => []),
+            uploaded: z.array(SpaceDiscoveryDataSchema).default(() => []),
         })
-        .default({
+        .default(() => ({
             local: [],
             uploaded: [],
-        }),
+        })),
     currentItinerary: ItinerarySchema.nullable().catch(null),
-    systemBookmarks: z.array(StarSystemCoordinatesSchema).default([]),
-    currentMissions: z.array(MissionSerializedSchema).default([]),
-    completedMissions: z.array(MissionSerializedSchema).default([]),
-    spaceShips: z.array(SerializedSpaceshipSchema).default([getDefaultSerializedSpaceship()]),
-    spareSpaceshipComponents: z.array(SerializedComponentSchema).default([]),
-    tutorials: CompletedTutorialsSchema.default({
+    systemBookmarks: z.array(StarSystemCoordinatesSchema).default(() => []),
+    currentMissions: z.array(MissionSerializedSchema).default(() => []),
+    completedMissions: z.array(MissionSerializedSchema).default(() => []),
+    spaceShips: z.array(SerializedSpaceshipSchema).default(() => [getDefaultSerializedSpaceship()]),
+    spareSpaceshipComponents: z.array(SerializedComponentSchema).default(() => []),
+    tutorials: CompletedTutorialsSchema.default(() => ({
         flightCompleted: false,
         stationLandingCompleted: false,
         starMapCompleted: false,
         fuelScoopingCompleted: false,
-    }),
+    })),
 });
 
 export type SerializedPlayer = z.infer<typeof SerializedPlayerSchema>;

--- a/src/ts/frontend/player/player.spec.ts
+++ b/src/ts/frontend/player/player.spec.ts
@@ -72,6 +72,15 @@ describe("Player", () => {
 
             expect(player1.uuid).not.toBe(player2.uuid);
         });
+
+        it("should generate new default spaceships for each schema parse", () => {
+            const parsed1 = SerializedPlayerSchema.parse({});
+            const parsed2 = SerializedPlayerSchema.parse({});
+
+            expect(parsed1.spaceShips).toHaveLength(1);
+            expect(parsed2.spaceShips).toHaveLength(1);
+            expect(parsed1.spaceShips[0]?.id).not.toBe(parsed2.spaceShips[0]?.id);
+        });
     });
 
     describe("SerializedPlayerSchema", () => {


### PR DESCRIPTION
## Summary
- update serialized player schema defaults to lazily construct arrays, objects, and default spaceships
- ensure creation timestamps and nested defaults are unique per parse
- add coverage confirming repeated parsing yields distinct default spaceship IDs

## Testing
- pnpm vitest run src/ts/frontend/player/player.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d90a5339b48328a15c315f1172f102