### PR TITLE
Remove hardcoded pnpm version from GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,8 @@ jobs:
                   path: ~/.git/lfs/ # default client cache
                   key: lfs-${{ runner.os }}-${{ hashFiles('.gitattributes') }}
 
-            - name: Determine pnpm version
-              id: pnpm-version
-              run: |
-                  echo "version=$(jq -r '.packageManager' package.json | cut -d'@' -f2)" >> "$GITHUB_OUTPUT"
-
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: ${{ steps.pnpm-version.outputs.version }}
 
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,6 @@ jobs:
 
             - name: Setup Node.js with pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 9
 
             - name: Install dependencies
               run: pnpm i

--- a/.github/workflows/main-preview.yml
+++ b/.github/workflows/main-preview.yml
@@ -20,8 +20,6 @@ jobs:
 
             - name: Setup Node.js with pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 9
 
             - name: Install dependencies
               run: pnpm i


### PR DESCRIPTION
## Summary
- stop hardcoding the pnpm version in CI and deploy workflows so the package.json packageManager field is authoritative
- simplify the CI workflow by removing the manual pnpm version extraction step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e272d0f67c83289eccf6c859796611