### PR TITLE
Refactor notification handling into a manager service

### DIFF
--- a/packages/game/src/styles/helmetOverlay/notifications.scss
+++ b/packages/game/src/styles/helmetOverlay/notifications.scss
@@ -1,4 +1,4 @@
-#notificationContainer {
+.notification-container {
     // positioned at top-center of the screen
     // children are notifications that have a text and a progress bar
     position: absolute;

--- a/packages/game/src/ts/frontend/starmap/starMap.ts
+++ b/packages/game/src/ts/frontend/starmap/starMap.ts
@@ -47,7 +47,7 @@ import { TransformTranslationAnimation } from "@/frontend/helpers/animations/tra
 import { lookAt, translate } from "@/frontend/helpers/transform";
 import { type Player } from "@/frontend/player/player";
 import { alertModal } from "@/frontend/ui/dialogModal";
-import { createNotification, NotificationIntent, NotificationOrigin } from "@/frontend/ui/notification";
+import { NotificationIntent, NotificationOrigin } from "@/frontend/ui/notification";
 import { type View } from "@/frontend/view";
 
 import { getRgbFromTemperature } from "@/utils/specrend";
@@ -55,6 +55,7 @@ import { type DeepReadonly } from "@/utils/types";
 
 import { Settings } from "@/settings";
 
+import { type INotificationManager } from "../ui/notificationManager";
 import { StarMapControls } from "./starMapControls";
 import { StarMapInputs } from "./starMapInputs";
 import { StarMapUI } from "./starMapUI";
@@ -157,6 +158,7 @@ export class StarMap implements View {
     private static readonly SHIMMER_DURATION = 1000;
 
     private readonly soundPlayer: ISoundPlayer;
+    private readonly notificationManager: INotificationManager;
 
     constructor(
         player: Player,
@@ -164,6 +166,7 @@ export class StarMap implements View {
         encyclopaedia: EncyclopaediaGalactica,
         starSystemDatabase: StarSystemDatabase,
         soundPlayer: ISoundPlayer,
+        notificationManager: INotificationManager,
     ) {
         this.scene = new Scene(engine);
         this.scene.clearColor = new Color4(0, 0, 0, 1);
@@ -173,6 +176,7 @@ export class StarMap implements View {
         });
 
         this.soundPlayer = soundPlayer;
+        this.notificationManager = notificationManager;
 
         this.controls = new StarMapControls(this.scene);
         this.controls.getCameras().forEach((camera) => (camera.minZ = 0.01));
@@ -372,12 +376,11 @@ export class StarMap implements View {
                         this.drawPath(parsedItinerary.data);
                         this.player.currentItinerary = parsedItinerary.data;
                     } else {
-                        createNotification(
+                        this.notificationManager.create(
                             NotificationOrigin.GENERAL,
                             NotificationIntent.ERROR,
                             `Failed to parse itinerary: ${parsedItinerary.error.message}`,
                             5000,
-                            this.soundPlayer,
                         );
                         this.player.currentItinerary = null;
                     }
@@ -388,12 +391,11 @@ export class StarMap implements View {
                         this.onTargetSetObservable.notifyObservers(nextDestination);
                     }
                 } else if (this.stellarPathfinder.getNbIterations() >= pathfinderMaxIterations) {
-                    createNotification(
+                    this.notificationManager.create(
                         NotificationOrigin.GENERAL,
                         NotificationIntent.ERROR,
                         `Could not find a path to the target system after ${pathfinderMaxIterations} iterations`,
                         5000,
-                        this.soundPlayer,
                     );
                 }
             }

--- a/packages/game/src/ts/frontend/ui/notification.ts
+++ b/packages/game/src/ts/frontend/ui/notification.ts
@@ -1,3 +1,20 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import { SoundType, type ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import informationIcon from "@assets/icons/information.webp";
@@ -19,7 +36,7 @@ export const enum NotificationIntent {
     ERROR = "error",
 }
 
-class Notification {
+export class Notification {
     private progressSeconds = 0;
     private readonly progressDurationSeconds;
     private removalProgressSeconds = 0;
@@ -35,22 +52,19 @@ class Notification {
         text: string,
         durationSeconds: number,
         soundPlayer: ISoundPlayer,
+        container: HTMLDivElement,
+        documentRef: Document,
     ) {
-        let container = document.getElementById("notificationContainer");
-        if (container === null) {
-            container = document.createElement("div");
-            container.id = "notificationContainer";
-            document.body.appendChild(container);
-        }
+        const doc = documentRef;
 
-        this.htmlRoot = document.createElement("div");
+        this.htmlRoot = doc.createElement("div");
         this.htmlRoot.classList.add("notification", origin);
 
-        const contentContainer = document.createElement("div");
+        const contentContainer = doc.createElement("div");
         contentContainer.classList.add("notification-content");
         this.htmlRoot.appendChild(contentContainer);
 
-        const iconNode = document.createElement("img");
+        const iconNode = doc.createElement("img");
         switch (origin) {
             case NotificationOrigin.GENERAL:
                 iconNode.src = informationIcon;
@@ -68,14 +82,14 @@ class Notification {
         iconNode.classList.add("notification-icon");
         contentContainer.appendChild(iconNode);
 
-        const textNode = document.createElement("p");
+        const textNode = doc.createElement("p");
         textNode.textContent = text;
         contentContainer.appendChild(textNode);
 
-        const progress = document.createElement("div");
+        const progress = doc.createElement("div");
         progress.classList.add("notification-progress");
 
-        const progressBar = document.createElement("div");
+        const progressBar = doc.createElement("div");
         progressBar.classList.add("notification-progress-bar");
         progress.appendChild(progressBar);
 
@@ -131,36 +145,4 @@ class Notification {
     dispose(): void {
         this.htmlRoot.remove();
     }
-}
-
-let activeNotifications: Notification[] = [];
-
-export function updateNotifications(deltaSeconds: number): void {
-    activeNotifications.forEach((notification) => {
-        notification.update(deltaSeconds);
-        if (notification.getProgress() === 1 && !notification.hasRemovalStarted()) {
-            notification.startRemoval();
-        }
-        if (notification.getRemovalProgress() === 1) {
-            notification.dispose();
-        }
-    });
-
-    activeNotifications = activeNotifications.filter((notification) => notification.getRemovalProgress() < 1);
-}
-
-/**
- * Create a notification with a text and a duration (in ms)
- * @param text The text to display
- * @param durationMillis The duration of the notification in ms
- */
-export function createNotification(
-    type: NotificationOrigin,
-    intent: NotificationIntent,
-    text: string,
-    durationMillis: number,
-    soundPlayer: ISoundPlayer,
-) {
-    const notification = new Notification(type, intent, text, durationMillis / 1000, soundPlayer);
-    activeNotifications.push(notification);
 }

--- a/packages/game/src/ts/frontend/ui/notificationManager.ts
+++ b/packages/game/src/ts/frontend/ui/notificationManager.ts
@@ -1,0 +1,89 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ISoundPlayer } from "../audio/soundPlayer";
+import { Notification, type NotificationIntent, type NotificationOrigin } from "./notification";
+
+export interface INotificationManager {
+    update(deltaSeconds: number): void;
+    create(type: NotificationOrigin, intent: NotificationIntent, text: string, durationMillis: number): void;
+    setVisible(visible: boolean): void;
+}
+
+export class NotificationManager implements INotificationManager {
+    private readonly container: HTMLDivElement;
+    private activeNotifications: Notification[] = [];
+    private isVisible = true;
+    private readonly soundPlayer: ISoundPlayer;
+    private readonly document: Document;
+
+    constructor(soundPlayer: ISoundPlayer, documentRef: Document = document) {
+        this.soundPlayer = soundPlayer;
+        this.document = documentRef;
+
+        const createdContainer = this.document.createElement("div");
+        createdContainer.classList.add("notification-container");
+        this.document.body.appendChild(createdContainer);
+        this.container = createdContainer;
+    }
+
+    update(deltaSeconds: number): void {
+        this.activeNotifications.forEach((notification) => {
+            notification.update(deltaSeconds);
+            if (notification.getProgress() === 1 && !notification.hasRemovalStarted()) {
+                notification.startRemoval();
+            }
+            if (notification.getRemovalProgress() === 1) {
+                notification.dispose();
+            }
+        });
+
+        this.activeNotifications = this.activeNotifications.filter(
+            (notification) => notification.getRemovalProgress() < 1,
+        );
+    }
+
+    create(type: NotificationOrigin, intent: NotificationIntent, text: string, durationMillis: number): void {
+        const notification = new Notification(
+            type,
+            intent,
+            text,
+            durationMillis / 1000,
+            this.soundPlayer,
+            this.container,
+            this.document,
+        );
+        this.activeNotifications.push(notification);
+    }
+
+    setVisible(visible: boolean): void {
+        if (this.isVisible === visible) return;
+
+        this.isVisible = visible;
+        if (visible) {
+            this.container.style.removeProperty("display");
+        } else {
+            this.container.style.display = "none";
+        }
+    }
+}
+
+export class NotificationManagerMock implements INotificationManager {
+    update(): void {}
+    create(): void {}
+    setVisible(): void {}
+}

--- a/packages/game/src/ts/frontend/ui/panels/loadSavePanel.ts
+++ b/packages/game/src/ts/frontend/ui/panels/loadSavePanel.ts
@@ -21,14 +21,19 @@ import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import i18n from "@/i18n";
 
+import { type INotificationManager } from "../notificationManager";
 import { SaveLoadingPanelContent } from "../saveLoadingPanelContent";
 
 export class LoadSavePanel {
     readonly htmlRoot: HTMLElement;
     readonly content: SaveLoadingPanelContent;
 
-    constructor(starSystemDatabase: StarSystemDatabase, soundPlayer: ISoundPlayer) {
-        this.content = new SaveLoadingPanelContent(starSystemDatabase, soundPlayer);
+    constructor(
+        starSystemDatabase: StarSystemDatabase,
+        soundPlayer: ISoundPlayer,
+        notificationManager: INotificationManager,
+    ) {
+        this.content = new SaveLoadingPanelContent(starSystemDatabase, soundPlayer, notificationManager);
         this.htmlRoot = this.createPanelHTML();
     }
 

--- a/packages/game/src/ts/frontend/ui/saveLoadingPanelContent.ts
+++ b/packages/game/src/ts/frontend/ui/saveLoadingPanelContent.ts
@@ -8,11 +8,13 @@ import { type StarSystemDatabase } from "@/backend/universe/starSystemDatabase";
 
 import { SoundType, type ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { alertModal, promptModalBoolean } from "@/frontend/ui/dialogModal";
-import { createNotification, NotificationIntent, NotificationOrigin } from "@/frontend/ui/notification";
+import { NotificationIntent, NotificationOrigin } from "@/frontend/ui/notification";
 
 import { type DeepReadonly, type Result } from "@/utils/types";
 
 import i18n from "@/i18n";
+
+import { type INotificationManager } from "./notificationManager";
 
 import collapseIconPath from "@assets/icons/collapse.webp";
 import downloadIconPath from "@assets/icons/download.webp";
@@ -29,12 +31,18 @@ export class SaveLoadingPanelContent {
     readonly onLoadSaveObservable: Observable<DeepReadonly<Save>> = new Observable<DeepReadonly<Save>>();
 
     private readonly soundPlayer: ISoundPlayer;
+    private readonly notificationManager: INotificationManager;
 
-    constructor(starSystemDatabase: StarSystemDatabase, soundPlayer: ISoundPlayer) {
+    constructor(
+        starSystemDatabase: StarSystemDatabase,
+        soundPlayer: ISoundPlayer,
+        notificationManager: INotificationManager,
+    ) {
         this.htmlRoot = document.createElement("div");
         this.htmlRoot.classList.add("saveLoadingPanelContent");
 
         this.soundPlayer = soundPlayer;
+        this.notificationManager = notificationManager;
 
         const dropFileZone = document.createElement("div");
         dropFileZone.id = "dropFileZone";
@@ -203,12 +211,11 @@ export class SaveLoadingPanelContent {
                     return;
                 }
                 await navigator.clipboard.writeText(url.toString()).then(() => {
-                    createNotification(
+                    this.notificationManager.create(
                         NotificationOrigin.GENERAL,
                         NotificationIntent.SUCCESS,
                         i18n.t("notifications:copiedToClipboard"),
                         5000,
-                        this.soundPlayer,
                     );
                 });
             });
@@ -335,12 +342,11 @@ export class SaveLoadingPanelContent {
                 return;
             }
             await navigator.clipboard.writeText(url.toString()).then(() => {
-                createNotification(
+                this.notificationManager.create(
                     NotificationOrigin.GENERAL,
                     NotificationIntent.INFO,
                     i18n.t("notifications:copiedToClipboard"),
                     5000,
-                    this.soundPlayer,
                 );
             });
         });

--- a/packages/game/src/ts/frontend/ui/sidePanels.ts
+++ b/packages/game/src/ts/frontend/ui/sidePanels.ts
@@ -6,6 +6,7 @@ import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { assertUnreachable } from "@/utils/types";
 
 import { type MusicConductor } from "../audio/musicConductor";
+import { type INotificationManager } from "./notificationManager";
 import { AboutPanel } from "./panels/aboutPanel";
 import { ContributePanel } from "./panels/contributePanel";
 import { CreditsPanel } from "./panels/creditsPanel";
@@ -40,12 +41,13 @@ export class SidePanels {
         saveManager: ISaveBackend,
         soundPlayer: ISoundPlayer,
         musicConductor: MusicConductor,
+        notificationManager: INotificationManager,
     ) {
         this.starSystemDatabase = starSystemDatabase;
         this.saveBackend = saveManager;
 
         // Create panel instances
-        this.loadSavePanel = new LoadSavePanel(starSystemDatabase, soundPlayer);
+        this.loadSavePanel = new LoadSavePanel(starSystemDatabase, soundPlayer, notificationManager);
         this.attachCloseButton(this.loadSavePanel.htmlRoot);
         document.body.appendChild(this.loadSavePanel.htmlRoot);
 

--- a/packages/game/src/ts/frontend/ui/spaceStation/discoveryDetails.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/discoveryDetails.ts
@@ -25,13 +25,15 @@ import { SoundType, type ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
 import { type Player } from "@/frontend/player/player";
 import { alertModal } from "@/frontend/ui/dialogModal";
-import { createNotification, NotificationIntent, NotificationOrigin } from "@/frontend/ui/notification";
+import { NotificationIntent, NotificationOrigin } from "@/frontend/ui/notification";
 
 import { getOrbitalPeriod } from "@/utils/physics/orbit";
 import { parseDistance, parseSecondsPrecise } from "@/utils/strings/parseToStrings";
 
 import i18n from "@/i18n";
 import { Settings } from "@/settings";
+
+import { type INotificationManager } from "../notificationManager";
 
 export class DiscoveryDetails {
     readonly htmlRoot: HTMLElement;
@@ -59,14 +61,17 @@ export class DiscoveryDetails {
     private readonly encyclopaedia: EncyclopaediaGalactica;
 
     private readonly soundPlayer: ISoundPlayer;
+    private readonly notificationManager: INotificationManager;
 
     constructor(
         player: Player,
         encyclopaedia: EncyclopaediaGalactica,
         starSystemDatabase: StarSystemDatabase,
         soundPlayer: ISoundPlayer,
+        notificationManager: INotificationManager,
     ) {
         this.soundPlayer = soundPlayer;
+        this.notificationManager = notificationManager;
 
         this.player = player;
         this.encyclopaedia = encyclopaedia;
@@ -97,12 +102,11 @@ export class DiscoveryDetails {
             this.soundPlayer.playNow(SoundType.SUCCESS);
             const valueResult = await encyclopaedia.estimateDiscovery(this.currentDiscovery.objectId);
             if (!valueResult.success) {
-                createNotification(
+                this.notificationManager.create(
                     NotificationOrigin.GENERAL,
                     NotificationIntent.ERROR,
                     valueResult.error,
                     5_000,
-                    this.soundPlayer,
                 );
                 return;
             }

--- a/packages/game/src/ts/frontend/ui/spaceStation/spaceStationLayer.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/spaceStationLayer.ts
@@ -30,6 +30,7 @@ import { type DeepReadonly } from "@/utils/types";
 import i18n from "@/i18n";
 import { Settings } from "@/settings";
 
+import { type INotificationManager } from "../notificationManager";
 import { ExplorationCenterPanel } from "./explorationCenterPanel";
 import { SpaceshipDockUI } from "./spaceshipDock";
 import { generateInfoHTML } from "./spaceStationInfos";
@@ -92,6 +93,7 @@ export class SpaceStationLayer {
         encyclopaedia: EncyclopaediaGalacticaManager,
         starSystemDatabase: StarSystemDatabase,
         soundPlayer: ISoundPlayer,
+        notificationManager: INotificationManager,
     ) {
         this.soundPlayer = soundPlayer;
 
@@ -163,6 +165,7 @@ export class SpaceStationLayer {
             player,
             starSystemDatabase,
             this.soundPlayer,
+            notificationManager,
         );
 
         this.actionsContainer = document.createElement("div");

--- a/packages/game/src/ts/playgrounds/flightDemo.ts
+++ b/packages/game/src/ts/playgrounds/flightDemo.ts
@@ -33,6 +33,7 @@ import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";
 import { ShipControls } from "@/frontend/spaceship/shipControls";
 import { SpaceShipControlsInputs } from "@/frontend/spaceship/spaceShipControlsInputs";
+import { NotificationManagerMock } from "@/frontend/ui/notificationManager";
 
 import { enablePhysics } from "./utils";
 
@@ -50,8 +51,9 @@ export async function createFlightDemoScene(
 
     const soundPlayer = new SoundPlayerMock();
     const tts = new TtsMock();
+    const notificationManager = new NotificationManagerMock();
 
-    const ship = ShipControls.CreateDefault(scene, assets, tts, soundPlayer);
+    const ship = ShipControls.CreateDefault(scene, assets, tts, soundPlayer, notificationManager);
 
     const camera = ship.getActiveCamera();
     camera.minZ = 0.1;

--- a/packages/game/src/ts/playgrounds/saveLoadingPanelContent.ts
+++ b/packages/game/src/ts/playgrounds/saveLoadingPanelContent.ts
@@ -27,6 +27,7 @@ import { StarSystemDatabase } from "@/backend/universe/starSystemDatabase";
 import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { alertModal } from "@/frontend/ui/dialogModal";
+import { NotificationManagerMock } from "@/frontend/ui/notificationManager";
 import { SaveLoadingPanelContent } from "@/frontend/ui/saveLoadingPanelContent";
 
 import { initI18n } from "@/i18n";
@@ -46,8 +47,9 @@ export async function createSaveLoadingPanelContentScene(
     const starSystemDatabase = new StarSystemDatabase(getLoneStarSystem());
 
     const soundPlayer = new SoundPlayerMock();
+    const notificationManager = new NotificationManagerMock();
 
-    const saveLoadingPanelContent = new SaveLoadingPanelContent(starSystemDatabase, soundPlayer);
+    const saveLoadingPanelContent = new SaveLoadingPanelContent(starSystemDatabase, soundPlayer, notificationManager);
     saveLoadingPanelContent.htmlRoot.style.position = "absolute";
     document.body.appendChild(saveLoadingPanelContent.htmlRoot);
 

--- a/packages/game/src/ts/playgrounds/spaceStationUI.ts
+++ b/packages/game/src/ts/playgrounds/spaceStationUI.ts
@@ -29,6 +29,7 @@ import { TtsMock } from "@/frontend/audio/tts";
 import { Player } from "@/frontend/player/player";
 import { ShipControls } from "@/frontend/spaceship/shipControls";
 import { Spaceship } from "@/frontend/spaceship/spaceship";
+import { NotificationManagerMock } from "@/frontend/ui/notificationManager";
 import { SpaceStationLayer } from "@/frontend/ui/spaceStation/spaceStationLayer";
 
 import { initI18n } from "@/i18n";
@@ -50,6 +51,7 @@ export async function createSpaceStationUIScene(
 
     const soundPlayer = new SoundPlayerMock();
     const tts = new TtsMock();
+    const notificationManager = new NotificationManagerMock();
 
     const systemDatabase = new StarSystemDatabase(getLoneStarSystem());
 
@@ -69,7 +71,7 @@ export async function createSpaceStationUIScene(
     );
     player.instancedSpaceships.push(spaceship);
 
-    const shipControls = new ShipControls(spaceship, scene, soundPlayer, tts);
+    const shipControls = new ShipControls(spaceship, scene, soundPlayer, tts, notificationManager);
 
     const camera = shipControls.thirdPersonCamera;
     camera.attachControl();
@@ -79,7 +81,13 @@ export async function createSpaceStationUIScene(
 
     const encyclopaedia = new EncyclopaediaGalacticaManager();
 
-    const spaceStationUI = new SpaceStationLayer(player, encyclopaedia, systemDatabase, soundPlayer);
+    const spaceStationUI = new SpaceStationLayer(
+        player,
+        encyclopaedia,
+        systemDatabase,
+        soundPlayer,
+        notificationManager,
+    );
 
     const stationModel = systemModel.orbitalFacilities[0];
     if (stationModel === undefined) {

--- a/packages/game/src/ts/playgrounds/starMap.ts
+++ b/packages/game/src/ts/playgrounds/starMap.ts
@@ -27,6 +27,7 @@ import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressM
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { Player } from "@/frontend/player/player";
 import { StarMap } from "@/frontend/starmap/starMap";
+import { NotificationManagerMock } from "@/frontend/ui/notificationManager";
 
 import { jsonSafeParse } from "@/utils/json";
 
@@ -46,8 +47,16 @@ export async function createStarMapScene(
     const encyclopaediaGalactica = new EncyclopaediaGalacticaLocal(starSystemDatabase);
 
     const soundPlayerMock = new SoundPlayerMock();
+    const notificationManager = new NotificationManagerMock();
 
-    const starMap = new StarMap(player, engine, encyclopaediaGalactica, starSystemDatabase, soundPlayerMock);
+    const starMap = new StarMap(
+        player,
+        engine,
+        encyclopaediaGalactica,
+        starSystemDatabase,
+        soundPlayerMock,
+        notificationManager,
+    );
     starMap.setCurrentStarSystem(starSystemDatabase.fallbackSystem.coordinates);
 
     // Get system coordinates from URL parameters

--- a/packages/game/src/ts/playgrounds/starSystemView.ts
+++ b/packages/game/src/ts/playgrounds/starSystemView.ts
@@ -31,7 +31,7 @@ import { positionNearObjectBrightSide } from "@/frontend/helpers/positionNearObj
 import { UberScene } from "@/frontend/helpers/uberScene";
 import { Player } from "@/frontend/player/player";
 import { StarSystemView } from "@/frontend/starSystemView";
-import { updateNotifications } from "@/frontend/ui/notification";
+import { NotificationManagerMock, type INotificationManager } from "@/frontend/ui/notificationManager";
 
 import { initI18n } from "@/i18n";
 
@@ -52,6 +52,7 @@ export async function createStarSystemViewScene(
     const soundPlayerMock = new SoundPlayerMock();
 
     const ttsMock = new TtsMock();
+    const notificationManager: INotificationManager = new NotificationManagerMock();
 
     const scene = new UberScene(engine);
     scene.useRightHandedSystem = true;
@@ -69,6 +70,7 @@ export async function createStarSystemViewScene(
         starSystemDatabase,
         soundPlayerMock,
         ttsMock,
+        notificationManager,
         assets,
     );
 
@@ -89,7 +91,7 @@ export async function createStarSystemViewScene(
 
     scene.onBeforeRenderObservable.add(() => {
         const deltaSeconds = scene.getEngine().getDeltaTime() / 1000;
-        updateNotifications(deltaSeconds);
+        notificationManager.update(deltaSeconds);
     });
 
     return starSystemView.scene;


### PR DESCRIPTION
## Summary
- replace the global notification helpers with a NotificationManager class that owns lifecycle and DOM container
- inject the notification manager through CosmosJourneyer into star map, star system view, panels, and controls
- update gameplay, UI, and playground modules (ship controls, star system view, star map, save/load panels, and demos) to depend on the new manager interface for easier stubbing
- add a visibility toggle on the notification manager so hiding the UI also hides notifications
- spawn a class-based notification container for each manager instance and provide a NotificationManagerMock for demos and tests
- drop the unused NotificationManagerOptions wrapper and let the constructor optionally take a document directly

## Testing
- pnpm --filter game lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d87046e08328afa0cc615ce636e1