### PR TITLE
Add parallax occlusion mapping to BSL

### DIFF
--- a/packages/game/src/ts/frontend/assets/procedural/solarPanel/solarPanelMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/solarPanel/solarPanelMaterial.ts
@@ -62,7 +62,7 @@ export class SolarPanelMaterial extends NodeMaterial {
             metallicRoughness.r,
             metallicRoughness.g,
             null,
-            perturbedNormal,
+            perturbedNormal.output,
             normalW,
             view,
             cameraPosition,

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/climber/climberRingMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/climber/climberRingMaterial.ts
@@ -63,7 +63,7 @@ export class ClimberRingMaterial extends NodeMaterial {
             metallicRoughnesstexture.r,
             metallicRoughnesstexture.g,
             aoTexture.r,
-            perturbedNormal,
+            perturbedNormal.output,
             normalW,
             view,
             cameraPosition,

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/cylinder/cylinderHabitatMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/cylinder/cylinderHabitatMaterial.ts
@@ -109,7 +109,7 @@ export class CylinderHabitatMaterial extends NodeMaterial {
             metallicRoughness.r,
             metallicRoughness.g,
             occlusion.r,
-            perturbedNormal,
+            perturbedNormal.output,
             normalW,
             view,
             cameraPosition,

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/helix/helixHabitatMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/helix/helixHabitatMaterial.ts
@@ -98,7 +98,7 @@ export class HelixHabitatMaterial extends NodeMaterial {
             metallicRoughness.r,
             metallicRoughness.g,
             occlusion.r,
-            perturbedNormal,
+            perturbedNormal.output,
             normalW,
             view,
             cameraPosition,

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/ring/ringHabitatMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/ring/ringHabitatMaterial.ts
@@ -92,7 +92,7 @@ export class RingHabitatMaterial extends NodeMaterial {
             metallicRoughness.r,
             metallicRoughness.g,
             occlusion.r,
-            perturbedNormal,
+            perturbedNormal.output,
             normalW,
             view,
             cameraPosition,

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingBay/landingBayMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingBay/landingBayMaterial.ts
@@ -178,7 +178,7 @@ export class LandingBayMaterial extends NodeMaterial {
             finalMetallic,
             finalRoughness,
             finalAo,
-            perturbedNormal,
+            perturbedNormal.output,
             normalW,
             view,
             cameraPosition,

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingPad/landingPadMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingPad/landingPadMaterial.ts
@@ -141,7 +141,7 @@ export class LandingPadMaterial extends NodeMaterial {
             finalMetallic,
             finalRoughness,
             finalAmbientOcclusion,
-            perturbedNormal,
+            perturbedNormal.output,
             normalW,
             view,
             cameraPosition,

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/metalSectionMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/metalSectionMaterial.ts
@@ -67,7 +67,7 @@ export class MetalSectionMaterial extends NodeMaterial {
             metallicRoughnesstexture.r,
             metallicRoughnesstexture.g,
             aoTexture.r,
-            perturbedNormal,
+            perturbedNormal.output,
             normalW,
             view,
             cameraPosition,

--- a/packages/game/src/ts/frontend/helpers/bsl.ts
+++ b/packages/game/src/ts/frontend/helpers/bsl.ts
@@ -814,6 +814,18 @@ export function max(
     return maxBlock.output;
 }
 
+export type PerturbNormalOptions = TargetOptions & {
+    parallax: {
+        viewDirection: NodeMaterialConnectionPoint;
+        scale: NodeMaterialConnectionPoint;
+    };
+};
+
+export type PerturbNormalOutput = {
+    output: PerturbNormalBlock["output"];
+    uvOffset: PerturbNormalBlock["uvOffset"];
+};
+
 /**
  * Perturbs the normal vector using the given parameters.
  * @param uv - The UV coordinates.
@@ -829,18 +841,21 @@ export function perturbNormal(
     normalWorldVec3: NodeMaterialConnectionPoint,
     normalTexture: NodeMaterialConnectionPoint,
     bumpStrengthFloat: NodeMaterialConnectionPoint,
-    options?: Partial<TargetOptions>,
-): NodeMaterialConnectionPoint {
+    options?: Partial<PerturbNormalOptions>,
+): PerturbNormalOutput {
     const perturbedNormal = new PerturbNormalBlock("Perturb normal");
     perturbedNormal.target = options?.target ?? NodeMaterialBlockTargets.Fragment;
+    perturbedNormal.useParallaxOcclusion = options?.parallax !== undefined;
 
     uv.connectTo(perturbedNormal.uv);
     positionWorldVec3.connectTo(perturbedNormal.worldPosition);
     normalWorldVec3.connectTo(perturbedNormal.worldNormal);
     normalTexture.connectTo(perturbedNormal.normalMapColor);
     bumpStrengthFloat.connectTo(perturbedNormal.strength);
+    options?.parallax?.scale.connectTo(perturbedNormal.parallaxScale);
+    options?.parallax?.viewDirection.connectTo(perturbedNormal.viewDirection);
 
-    return perturbedNormal.output;
+    return perturbedNormal;
 }
 
 export type PBRMetallicRoughnessMaterialOptions = TargetOptions & {


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Parallax Occlusion Mapping (POM) is a shading technique that goes beyond simple normal mapping to give the illusion of depth for a material. This was developped for the upcomming rover tires, which look quite good with POM:

https://github.com/user-attachments/assets/5188152c-09ca-4b98-b6f6-f456e0edb78f

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

I had to go back to https://forum.babylonjs.com/t/parallax-occlusion-mapping-nme-incorrect-height/59811/3 to understand how POM works with NME.

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Not possible to test at the moment oupsiii.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

POM will be used everywhere, especially for planet surface textures when I get around to rework them.

<!--
What should we do next to take advantage of this work?
-->
