### PR TITLE
Fix starmap clear color

### DIFF
--- a/packages/game/src/ts/frontend/cosmosJourneyer.ts
+++ b/packages/game/src/ts/frontend/cosmosJourneyer.ts
@@ -446,6 +446,7 @@ export class CosmosJourneyer {
 
         const starMapScene = new Scene(engine, { useFloatingOrigin: true });
         starMapScene.useRightHandedSystem = true;
+        starMapScene.clearColor.set(0, 0, 0, 1);
 
         const mainHavokPlugin = new HavokPlugin(true, havokInstance);
         mainHavokPlugin.setVelocityLimits(10_000, 10_000);


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

The recent starmap refactor dropped the clear color setting, hence reverting to Babylon's blue shade. This PR brings back the pitch black background.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

None

<!--
What should we do next to take advantage of this work?
-->
