### PR TITLE
Fix interaction layer not using correct keyboard layout when available

### DIFF
--- a/packages/game/src/ts/frontend/starSystemView.ts
+++ b/packages/game/src/ts/frontend/starSystemView.ts
@@ -278,7 +278,7 @@ export class StarSystemView implements View {
             return choice;
         });
 
-        this.interactionLayer = new InteractionLayer(this.interactionSystem);
+        this.interactionLayer = new InteractionLayer(this.interactionSystem, this.keyboardLayoutMap);
         document.body.appendChild(this.interactionLayer.root);
 
         void getGlobalKeyboardLayoutMap().then((keyboardLayoutMap) => {

--- a/packages/game/src/ts/frontend/ui/interactionLayer.ts
+++ b/packages/game/src/ts/frontend/ui/interactionLayer.ts
@@ -44,7 +44,9 @@ export class InteractionLayer {
     private readonly fadeOutSeconds = 0.1;
     private readonly fadeInSeconds = 0.1;
 
-    constructor(interactionSystem: InteractionSystem) {
+    private readonly keyboardLayoutMap: Map<string, string> | null;
+
+    constructor(interactionSystem: InteractionSystem, keyboardLayoutMap: Map<string, string> | null) {
         this.root = document.createElement("div");
         this.root.style.position = "absolute";
         this.root.style.top = "0";
@@ -77,6 +79,7 @@ export class InteractionLayer {
         this.root.appendChild(this.crosshair);
 
         this.interactionSystem = interactionSystem;
+        this.keyboardLayoutMap = keyboardLayoutMap;
     }
 
     public update(deltaSeconds: number) {
@@ -105,7 +108,7 @@ export class InteractionLayer {
             this.interactionText.style.display = "none";
             this.crosshair.style.display = "block";
         } else {
-            const keys = pressInteractionToStrings(this.interactionSystem.pressInteraction, null);
+            const keys = pressInteractionToStrings(this.interactionSystem.pressInteraction, this.keyboardLayoutMap);
             const keyString = keys.join(" / ");
             this.interactionText.style.display = "block";
             this.interactionText.innerText = `[${keyString}] ${currentInteractions[0].label}`;

--- a/packages/game/src/ts/playgrounds/interaction.ts
+++ b/packages/game/src/ts/playgrounds/interaction.ts
@@ -40,6 +40,8 @@ import { Button } from "@/frontend/ui/3d/button";
 import { radialChoiceModal } from "@/frontend/ui/dialogModal";
 import { InteractionLayer } from "@/frontend/ui/interactionLayer";
 
+import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
+
 import { initI18n } from "@/i18n";
 import { CollisionMask } from "@/settings";
 
@@ -119,7 +121,7 @@ export async function createInteractionDemo(
         },
     );
 
-    const interactionLayer = new InteractionLayer(interactionSystem);
+    const interactionLayer = new InteractionLayer(interactionSystem, await getGlobalKeyboardLayoutMap());
     document.body.appendChild(interactionLayer.root);
 
     //spawn a bunch of boxes


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

The input helper would always display the qwerty location of the key even when the correct layout was available. That's now fixed!

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Launch the interaction PG in a browser supporting the Keyboard API. The correct key should be displayed instead of "KeyE"

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

None

<!--
What should we do next to take advantage of this work?
-->
