### PR TITLE
Do not exit pointer lock when using radial choice modal

### DIFF
--- a/packages/game/src/styles/index.scss
+++ b/packages/game/src/styles/index.scss
@@ -19,6 +19,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 @use "variables";
+@use "virtualCursor";
 
 @font-face {
     font-family: "Nasalization";

--- a/packages/game/src/styles/starMapUI.scss
+++ b/packages/game/src/styles/starMapUI.scss
@@ -1,4 +1,5 @@
 @use "variables";
+@use "virtualCursor";
 
 @keyframes loadingAnimation {
     0% {
@@ -14,18 +15,7 @@
     z-index: 30;
 
     .cursor {
-        position: absolute;
-        width: 2vh;
-        height: 2vh;
-        z-index: 31;
-        transform: translate(-50%, -50%);
-        outline: white 0.3vh solid;
-        background: rgba(0, 0, 0, 0.8);
-        border-radius: 50%;
-        pointer-events: none;
-        transform-origin: center;
-        scale: 1;
-        transition: scale variables.$transition-time variables.$bezier-overshoot;
+        @extend .virtualCursor;
     }
 
     .systemIcons {

--- a/packages/game/src/styles/virtualCursor.scss
+++ b/packages/game/src/styles/virtualCursor.scss
@@ -1,0 +1,18 @@
+@use "variables";
+
+.virtualCursor {
+    position: absolute;
+    width: 2vh;
+    height: 2vh;
+    z-index: 31;
+    transform: translate(-50%, -50%);
+    outline: white 0.3vh solid;
+    background: rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
+    border-radius: 50%;
+    pointer-events: none;
+    transform-origin: center;
+    scale: 1;
+    transition: scale variables.$transition-time variables.$bezier-overshoot;
+}

--- a/packages/game/src/ts/frontend/starSystemView.ts
+++ b/packages/game/src/ts/frontend/starSystemView.ts
@@ -268,12 +268,18 @@ export class StarSystemView implements View {
             }
 
             const hasPointerLock = engine.isPointerLock;
+            const activeCamera = scene.activeCamera;
             if (hasPointerLock) {
-                document.exitPointerLock();
+                activeCamera?.detachControl();
             }
-            const choice = await radialChoiceModal(interactions, (interaction) => interaction.label, soundPlayer);
+            const choice = await radialChoiceModal(
+                interactions,
+                (interaction) => interaction.label,
+                soundPlayer,
+                hasPointerLock ? { useVirtualCursor: true } : undefined,
+            );
             if (hasPointerLock) {
-                await engine.getRenderingCanvas()?.requestPointerLock();
+                activeCamera?.attachControl(true);
             }
             return choice;
         });

--- a/packages/game/src/ts/playgrounds/interaction.ts
+++ b/packages/game/src/ts/playgrounds/interaction.ts
@@ -109,14 +109,11 @@ export async function createInteractionDemo(
                 return null;
             }
 
-            const hasPointerLock = engine.isPointerLock;
-            if (hasPointerLock) {
-                document.exitPointerLock();
-            }
-            const choice = await radialChoiceModal(interactions, (interaction) => interaction.label, soundPlayer);
-            if (hasPointerLock) {
-                await engine.getRenderingCanvas()?.requestPointerLock();
-            }
+            scene.activeCamera?.detachControl();
+            const choice = await radialChoiceModal(interactions, (interaction) => interaction.label, soundPlayer, {
+                useVirtualCursor: engine.isPointerLock,
+            });
+            scene.activeCamera?.attachControl(true);
             return choice;
         },
     );


### PR DESCRIPTION
## Related Tickets

Spontaneous
<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Instead, we use a virtual cursor to interact with the modal.

This cursor is the same as the one used in the Star Map UI.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Launch the interaction PG, try long press actions: no more exiting pointer locking (meaning you don't get the browser pop up again when choosing your interaction).

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

None

<!--
What should we do next to take advantage of this work?
-->
