### PR TITLE
Upgrade Node to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
 
-            - name: Use Node.js 22
+            - name: Use Node.js 24
               uses: actions/setup-node@v4
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
 
             - name: Install dependencies

--- a/.github/workflows/deploy-game-vps.yml
+++ b/.github/workflows/deploy-game-vps.yml
@@ -17,10 +17,10 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
 
-            - name: Use Node.js 22
+            - name: Use Node.js 24
               uses: actions/setup-node@v4
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
 
             - name: Install dependencies

--- a/.github/workflows/deploy-website-vps.yml
+++ b/.github/workflows/deploy-website-vps.yml
@@ -17,10 +17,10 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
 
-            - name: Use Node.js 22
+            - name: Use Node.js 24
               uses: actions/setup-node@v4
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
 
             - name: Install dependencies

--- a/.github/workflows/game-ci.yml
+++ b/.github/workflows/game-ci.yml
@@ -39,7 +39,7 @@ jobs:
         timeout-minutes: 20
         strategy:
             matrix:
-                node-version: [22]
+                node-version: [24]
         steps:
             # ─────────── Setup Environment ───────────
 

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [22]
+                node-version: [24]
         steps:
             - name: Checkout repository with LFS
               uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.11.0-dev",
     "packageManager": "pnpm@10.18.0",
     "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
     },
     "description": "Cosmos Journeyer is a space exploration game featuring fully explorable planets, across millions of star systems. It is built using Babylon.JS, and a lot of passion.",
     "homepage": "https://cosmosjourneyer.com",


### PR DESCRIPTION
## Related Tickets

Fixes #563 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description
This PR upgrades the project to Node.js 24.
Changes made:
1.Updated the engine.node in the root package.json to Node 24
2.Updated all the Github Workflows to use node-version:24

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties
While testing locally, I encountered a WebAssembly build error related to:
terrain_generation_bg.wasm
magic header not detected: bad magic number
<img width="1082" height="350" alt="image" src="https://github.com/user-attachments/assets/439c5233-9f31-4909-b938-2ff23f209a20" />


I think this is specific to my local environment, should I make a different PR for it as it isn't related to the Node upgrade, if requireed.




<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->




## Follow-up

If any further changes are needed, please let me know, I’d be happy to update the PR.
Any feedback or suggestions for improvement are also appreciated!
<!--
What should we do next to take advantage of this work?
-->
