### PR TITLE
Set StarSystemView scene clear color to black

### DIFF
--- a/packages/game/src/ts/frontend/cosmosJourneyer.ts
+++ b/packages/game/src/ts/frontend/cosmosJourneyer.ts
@@ -428,6 +428,7 @@ export class CosmosJourneyer {
 
         const starSystemViewScene = new Scene(engine, { useFloatingOrigin: true });
         starSystemViewScene.useRightHandedSystem = true;
+        starSystemViewScene.clearColor.set(0, 0, 0, 1);
 
         const starMapScene = new Scene(engine, { useFloatingOrigin: true });
         starMapScene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/starSystemView.ts
+++ b/packages/game/src/ts/playgrounds/starSystemView.ts
@@ -54,6 +54,7 @@ export async function createStarSystemViewScene(
 
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;
+    scene.clearColor.set(0, 0, 0, 1);
 
     const havokPlugin = await enablePhysics(scene);
 


### PR DESCRIPTION
## Description

This PR sets the StarSystemView scene clear color to black (`0, 0, 0, 1`) in both runtime initialization and the StarSystemView playground setup, so the background is consistently black.

This avoids a flash of default color when the starfield box has not yet loaded

## Unexpected difficulties

No unexpected difficulties.

## How to test

1. Start the game and load into StarSystemView.
2. Verify there is no color flash before loading the starfield box

## Follow-up

No follow-up required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddea40e3288328940238d20b845aed)