### PR TITLE
Improve gas planet atmosphere scaling

### DIFF
--- a/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
+++ b/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
@@ -26,6 +26,7 @@ import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugi
 import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { PhysicsShapeSphere } from "@babylonjs/core/Physics/v2/physicsShape";
 import { type Scene } from "@babylonjs/core/scene";
+import { EarthRadius } from "@cosmos-journeyer/physics";
 import { type GasPlanetModel } from "@cosmos-journeyer/universe-model";
 
 import { type Textures } from "@/frontend/assets/textures";
@@ -118,8 +119,7 @@ export class GasPlanet implements CelestialBodyBase<"gasPlanet">, Cullable {
 
         this.mesh.material = this.material;
 
-        const atmosphereThickness =
-            Settings.EARTH_ATMOSPHERE_THICKNESS * Math.max(1, this.model.radius / Settings.EARTH_RADIUS);
+        const atmosphereThickness = Settings.EARTH_ATMOSPHERE_THICKNESS * Math.max(1, this.model.radius / EarthRadius);
         this.atmosphereUniforms = new AtmosphereUniforms(this.getBoundingRadius(), atmosphereThickness);
 
         if (this.model.rings !== null) {

--- a/packages/game/src/ts/playgrounds/sol/jupiter.ts
+++ b/packages/game/src/ts/playgrounds/sol/jupiter.ts
@@ -30,8 +30,6 @@ import { GasPlanet } from "@/frontend/universe/planets/gasPlanet/gasPlanet";
 
 import { ItemPool } from "@/utils/itemPool";
 
-import { Settings } from "@/settings";
-
 import { enablePhysics } from "../utils";
 
 export async function createJupiterScene(
@@ -64,8 +62,6 @@ export async function createJupiterScene(
 
     const light = new PointLight("light1", new Vector3(7, 5, -10).scaleInPlace(scalingFactor), scene);
     light.falloffType = Light.FALLOFF_STANDARD;
-
-    Settings.EARTH_RADIUS = 6_371e3;
 
     const gasPlanetModel = getJupiterModel([]);
 

--- a/packages/game/src/ts/playgrounds/sol/saturn.ts
+++ b/packages/game/src/ts/playgrounds/sol/saturn.ts
@@ -33,8 +33,6 @@ import { GasPlanet } from "@/frontend/universe/planets/gasPlanet/gasPlanet";
 
 import { ItemPool } from "@/utils/itemPool";
 
-import { Settings } from "@/settings";
-
 import { enablePhysics } from "../utils";
 
 export async function createSaturnScene(
@@ -71,8 +69,6 @@ export async function createSaturnScene(
     const light = new PointLight("light1", Vector3.Zero(), scene);
     light.falloffType = Light.FALLOFF_STANDARD;
     light.parent = sun;
-
-    Settings.EARTH_RADIUS = 6_371e3;
 
     const gasPlanetModel = getSaturnModel([]);
 

--- a/packages/physics/src/constants/astrophysics.ts
+++ b/packages/physics/src/constants/astrophysics.ts
@@ -27,6 +27,9 @@ export const AU = 150e9;
  */
 export const EarthMass = 5.972e24;
 
+/** The radius of the Earth in meters */
+export const EarthRadius = 6_371e3;
+
 /**
  * The mass of the Moon in kilograms.
  */


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Now that gas planet are 1:1 scale, we can use the actual earth radius as reference instead of the scaled down version

<img width="1920" height="933" alt="screenshot_26-4-13_18-18" src="https://github.com/user-attachments/assets/1c6e82b9-f5de-4558-a9f5-623734da45dd" />

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

CI only

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

<!--
What should we do next to take advantage of this work?
-->
