### PR TITLE
Fix 3rd person character controller rotation stale world matrix

### DIFF
--- a/packages/game/src/ts/frontend/controls/characterControls/characterControls.ts
+++ b/packages/game/src/ts/frontend/controls/characterControls/characterControls.ts
@@ -161,6 +161,7 @@ export class CharacterControls implements Controls {
             const cameraPosition = this.thirdPersonCamera.target;
             cameraPosition.applyRotationQuaternionInPlace(Quaternion.RotationAxis(Vector3.Up(), -dtheta));
             this.thirdPersonCamera.target = cameraPosition;
+            this.getTransform().computeWorldMatrix(true);
         } else if (this.activeCamera === this.firstPersonCamera) {
             this.getTransform().position.addInPlace(
                 this.getTransform().right.scale(-xMove * this.avatar.walkSpeed * deltaSeconds),


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

Previously when rotating the character in 3rd person view, the overlay ui would follow the movement of the rotation instead of staying in place as it should.

This was caused by a stale matrix. That's now fixed.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Play the game, land on a planet, go in 3rd person view and rotate the character.

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

None

<!--
What should we do next to take advantage of this work?
-->
