### PR TITLE
Align documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Then, paste inside the content of another language directory and translate the c
 
 You don't need to code at all, the language will be automatically bundled and available inside Cosmos Journeyer.
 
-To test your changes, simply run the project using `npm run serve` and change the url in this format:
+To test your changes, run `pnpm dev:game` from the repository root and change the URL in this format:
 
 ```
 http://localhost:8080/?lang=fr-FR

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you want the cutting edge version, follow these steps:
 1. Install prerequisites:
 
 - [Git](https://git-scm.com/) (install with your package manager or from https://git-scm.com/downloads)
-- [Node.js](https://nodejs.org/) (version 20 or higher)
+- [Node.js](https://nodejs.org/) (version 24 or higher)
 - [Pnpm](https://pnpm.io/) (install with `npm install -g pnpm`)
 
 2. Clone the repo with `git clone https://github.com/BarthPaleologue/CosmosJourneyer.git`
@@ -162,7 +162,7 @@ Cosmos Journeyer is built using the following technologies:
 
 ### Setup
 
-1. Install [Node.js](https://nodejs.org/)
+1. Install [Node.js](https://nodejs.org/) (version 24 or higher)
 2. Install [Pnpm](https://pnpm.io/installation)
 3. Clone the repository with `git clone https://github.com/BarthPaleologue/CosmosJourneyer.git`
 4. Navigate to the project directory with `cd CosmosJourneyer`
@@ -181,6 +181,7 @@ This project uses a pnpm workspace. Packages live under `packages/` and share to
 - `packages/universe-model`: shared source-only star system and orbital object data models
 - `packages/babylonjs-shader-language`: shared source-only wrapper for BabylonJS Node Materials, to be used in the game and in the shader playgrounds
 - `packages/channel-packer`: web-only tool to pack the game channels into a single file for easier distribution
+- `packages/terrain-generation`: Rust + WebAssembly terrain-generation engine consumed by the game
 - `packages/website`: Next.js website sources and build config
 
 ### Development
@@ -192,6 +193,8 @@ You can start the development server for the game with `pnpm dev:game`, for the 
 #### Web
 
 To build the web version of Cosmos Journeyer, run `pnpm build:game`. Everything will be built in `packages/game/dist`.
+
+If you run `pnpm build` at the repository root, it also builds `packages/terrain-generation`, which requires Rust (`wasm32-unknown-unknown` target) and `wasm-pack`.
 
 #### Desktop (Electron)
 

--- a/packages/terrain-generation/README.md
+++ b/packages/terrain-generation/README.md
@@ -13,8 +13,9 @@ pnpm add terrain-generation
 ```
 
 The published package exposes typed WebAssembly bindings and does not require runtime configuration. When this
-repository is used as a workspace dependency, keep in mind that the game project intentionally depends on the npm
-distribution via the `npm:` protocol so that only maintainers need the Rust toolchain.
+repository is used as a workspace dependency, keep in mind that the game project currently consumes
+`terrain-generation` via a workspace dependency. The checked-in `pkg/` artifacts keep Rust tooling optional for most
+contributors, while maintainers touching the Rust source should install the toolchain.
 
 ## Runtime usage
 
@@ -57,7 +58,7 @@ buildData.free();
 
 ## Developing the WASM module locally
 
-Most contributors only need Node.js ≥ 20 and pnpm ≥ 10 to consume the published package. To rebuild the WebAssembly
+Most contributors only need Node.js ≥ 24 and pnpm ≥ 10 to consume the package in this workspace. To rebuild the WebAssembly
 artifacts or run the Rust toolchain you will additionally need:
 
 - [Rust](https://www.rust-lang.org/tools/install) with `wasm32-unknown-unknown` target (`rustup target add wasm32-unknown-unknown`)

--- a/packages/terrain-generation/pkg/README.md
+++ b/packages/terrain-generation/pkg/README.md
@@ -13,8 +13,9 @@ pnpm add terrain-generation
 ```
 
 The published package exposes typed WebAssembly bindings and does not require runtime configuration. When this
-repository is used as a workspace dependency, keep in mind that the game project intentionally depends on the npm
-distribution via the `npm:` protocol so that only maintainers need the Rust toolchain.
+repository is used as a workspace dependency, keep in mind that the game project currently consumes
+`terrain-generation` via a workspace dependency. The checked-in `pkg/` artifacts keep Rust tooling optional for most
+contributors, while maintainers touching the Rust source should install the toolchain.
 
 ## Runtime usage
 
@@ -57,7 +58,7 @@ buildData.free();
 
 ## Developing the WASM module locally
 
-Most contributors only need Node.js ≥ 20 and pnpm ≥ 10 to consume the published package. To rebuild the WebAssembly
+Most contributors only need Node.js ≥ 24 and pnpm ≥ 10 to consume the package in this workspace. To rebuild the WebAssembly
 artifacts or run the Rust toolchain you will additionally need:
 
 - [Rust](https://www.rust-lang.org/tools/install) with `wasm32-unknown-unknown` target (`rustup target add wasm32-unknown-unknown`)

--- a/packages/terrain-generation/pkg/package.json
+++ b/packages/terrain-generation/pkg/package.json
@@ -1,5 +1,6 @@
 {
   "name": "terrain-generation",
+  "type": "module",
   "collaborators": [
     "Barthélemy Paléologue"
   ],
@@ -10,7 +11,7 @@
     "terrain_generation_bg.js",
     "terrain_generation.d.ts"
   ],
-  "module": "terrain_generation.js",
+  "main": "terrain_generation.js",
   "types": "terrain_generation.d.ts",
   "sideEffects": [
     "./terrain_generation.js",

--- a/packages/terrain-generation/pkg/terrain_generation_bg.wasm
+++ b/packages/terrain-generation/pkg/terrain_generation_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ea21121db604a37c5dafc7beed8437076d4a9311f61632775dafad58c2b15eb
-size 50254
+oid sha256:61f65502e37d076447b3b07657cda3f686c52b6f560c706288af0b4761276f63
+size 50192


### PR DESCRIPTION
### Motivation
- Fix documentation drift between READMEs/CONTRIBUTING and the actual workspace/tooling to reduce onboarding friction and silent local failures. 
- Clarify the repo layout and build requirements now that `packages/terrain-generation` is material and brings Rust/WASM tooling into the root `pnpm build` graph. 
- Regenerate the checked-in WebAssembly artifacts so contributors can consume the package from the workspace without needing Rust unless they modify the Rust sources.

### Description
- Updated root `README.md` to require Node.js `>=24` in the local/development setup and to list `packages/terrain-generation` in the repository layout, and to note that `pnpm build` at repo root builds the terrain WASM package. 
- Replaced the outdated translation test instruction in `CONTRIBUTING.md` from `npm run serve` to `pnpm dev:game` and corrected the URL guidance. 
- Updated `packages/terrain-generation/README.md` to reflect that the game currently consumes the package as a workspace dependency and to require Node.js `>=24` in this workspace context. 
- Rebuilt and committed regenerated artifacts under `packages/terrain-generation/pkg` (including `pkg/README.md`, `pkg/package.json`, and the updated `terrain_generation_bg.wasm`).

### Testing
- Ran `pnpm format:check` which completed successfully. 
- Ran `pnpm --filter terrain-generation build` which initially failed due to missing `wasm-pack` and Binaryen, then succeeded after installing `wasm-pack` and `binaryen`. 
- Ran `pnpm --filter terrain-generation lint` (`cargo clippy`) which completed successfully. 
- Ran `pnpm --filter terrain-generation test:unit` (`cargo test`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2327e4ed08328892665353d77ab90)