### PR TITLE
fix(rust): remove redundant cast in simplex grad lookup

### DIFF
--- a/packages/terrain-generation/src/utils/simplex.rs
+++ b/packages/terrain-generation/src/utils/simplex.rs
@@ -367,7 +367,7 @@ fn sdnoise3(x: f32, y: f32, z: f32, gradient: &mut Vector3) -> f32 {
     if t3 < 0.0 {
         t3 = 0.0;
     } else {
-        (gx3, gy3, gz3) = grad3(PERM[ii + 1 + PERM[jj + 1 + PERM[kk + 1]]] as usize);
+        (gx3, gy3, gz3) = grad3(PERM[ii + 1 + PERM[jj + 1 + PERM[kk + 1]]]);
         t23 = t3 * t3;
         t43 = t23 * t23;
         n3 = t43 * (gx3 * x3 + gy3 * y3 + gz3 * z3);


### PR DESCRIPTION
### Motivation
- Resolve a `cargo clippy` lint error caused by an unnecessary `as usize` cast in the simplex noise gradient lookup which failed CI due to `-D warnings`.

### Description
- Removed the redundant `as usize` cast from the `grad3` call in `packages/terrain-generation/src/utils/simplex.rs` (fourth corner / `t3` branch).

### Testing
- Ran `cargo clippy --all-targets --all-features -- -D warnings` in `packages/terrain-generation`, which completed successfully with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6211b07c8328a17892e67314be6a)