### PR TITLE
Fix scattering size distribution

### DIFF
--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/workers/buildScript.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/workers/buildScript.ts
@@ -96,7 +96,7 @@ function handle_build(data: TransferBuildData): void {
     if (scattered_point_buffer.length !== 0) {
         const rockLayer: ScatteringLayer = () => ({
             density: 1 / 15 ** 2,
-            scalingOverride: Vector3.One().scaleInPlace(0.2 + Math.random() * 4),
+            scalingOverride: Vector3.One().scaleInPlace(0.2 + 4 * Math.random() ** 2),
             rotationOverride: Quaternion.FromEulerAngles(
                 Math.random() * Math.PI,
                 Math.random() * Math.PI,
@@ -150,7 +150,7 @@ function handle_build(data: TransferBuildData): void {
                         gravityUp,
                         Quaternion.Identity(),
                     ).multiply(Quaternion.RotationAxis(Axis.Y, Math.random() * 2 * Math.PI)),
-                    scalingOverride: Vector3.One().scaleInPlace(0.5 + Math.random() * 2),
+                    scalingOverride: Vector3.One().scaleInPlace(0.5 + 2 * Math.random() ** 1.5),
                 };
             };
 

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/workers/buildScript.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/workers/buildScript.ts
@@ -124,7 +124,7 @@ function handle_build(data: TransferBuildData): void {
                     density: MaxScatterDensity * flatnessMask * heightMask,
                     rotationOverride: Quaternion.FromUnitVectorsToRef(
                         Vector3.UpReadOnly,
-                        normal,
+                        gravityUp,
                         Quaternion.Identity(),
                     ).multiply(Quaternion.RotationAxis(Axis.Y, Math.random() * 2 * Math.PI)),
                 };


### PR DESCRIPTION
## Related Tickets

Fixes #684 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

<img width="1920" height="933" alt="screenshot_26-5-9_15-04" src="https://github.com/user-attachments/assets/648babd6-7345-4de9-a479-0fdb7f057be6" />

Big rocks have higher chance of breaking. When they break, they create multiple small rocks.

Therefore there are many more small rocks than big rocks.

One way to model this is to use a power law, and this PR brings exactly that to rock scattering.

As a bonus, it also adds a power law for trees and make grass blades grow opposite to gravity instead of growing along the surface normal.

This will make slopes easier to read as well as being more realistic.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Telluric planet PG

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

Better rock and tree models

<!--
What should we do next to take advantage of this work?
-->
