### PR TITLE
Encode universe location in screenshot

### DIFF
--- a/packages/game/src/ts/frontend/cosmosJourneyer.ts
+++ b/packages/game/src/ts/frontend/cosmosJourneyer.ts
@@ -17,7 +17,6 @@
 
 import "@babylonjs/core/Engines/Extensions/";
 import "@babylonjs/core/Engines/WebGPU/Extensions/";
-import "@babylonjs/core/Misc/screenshotTools";
 import "@babylonjs/core/Physics/physicsEngineComponent";
 
 import type { AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
@@ -28,7 +27,6 @@ import { EngineFactory } from "@babylonjs/core/Engines/engineFactory";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { Tools } from "@babylonjs/core/Misc/tools";
 import { VideoRecorder } from "@babylonjs/core/Misc/videoRecorder";
 import type { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
 import { HavokPlugin } from "@babylonjs/core/Physics/v2/Plugins/havokPlugin";
@@ -53,6 +51,7 @@ import { SoundPlayer, SoundPlayerMock, type ISoundPlayer } from "@/frontend/audi
 import { Tts } from "@/frontend/audio/tts";
 import { LoadingScreen } from "@/frontend/helpers/loadingScreen";
 import { positionNearObject } from "@/frontend/helpers/positionNearObject";
+import { bytesToDataUrl, downloadPng, makeScreenshotPng } from "@/frontend/helpers/screenshot";
 import { GeneralInputs } from "@/frontend/inputs/generalInputs";
 import { Player } from "@/frontend/player/player";
 import { StarMapView } from "@/frontend/starmap/starMapView";
@@ -619,15 +618,36 @@ export class CosmosJourneyer {
     /**
      * Takes a screenshot of the current scene. By default, the screenshot is taken at a 4x the resolution of the canvas
      */
-    public async takeScreenshot(): Promise<boolean> {
+    public async takeScreenshot(): Promise<void> {
         const camera = this.activeView.getMainScene().activeCamera;
         if (camera === null) {
             await alertModal("Cannot take screenshot: camera is null", this.soundPlayer);
-            return false;
+            return;
         }
 
-        Tools.CreateScreenshot(this.engine, camera, { precision: 1 });
-        return true;
+        const currentDate = new Date();
+        const timestamp = currentDate.toLocaleString().replace(/[/:]/g, "-").replace(/,/g, "");
+        const screenshotName = `cosmos-journeyer-${timestamp}.png`;
+
+        if (this.activeView !== this.starSystemView) {
+            const screenshotPng = await makeScreenshotPng(this.engine, camera);
+            downloadPng(screenshotPng, screenshotName);
+            return;
+        }
+
+        const activeControls = this.starSystemView.getActiveControls();
+        if (activeControls === null) {
+            const screenshotPng = await makeScreenshotPng(this.engine, camera);
+            downloadPng(screenshotPng, screenshotName);
+            return;
+        }
+
+        const screenshotPng = await makeScreenshotPng(this.engine, camera, {
+            location: this.getCurrentUniverseCoordinates(activeControls.getTransform(), null),
+        });
+
+        downloadPng(screenshotPng, screenshotName);
+        return;
     }
 
     public async takeVideoCapture(): Promise<void> {
@@ -653,7 +673,10 @@ export class CosmosJourneyer {
         }
     }
 
-    public getCurrentUniverseCoordinates(transform: TransformNode): RelativeCoordinates {
+    public getCurrentUniverseCoordinates(
+        transform: TransformNode,
+        minimumDistanceRadiusRatio: number | null = 1.1,
+    ): RelativeCoordinates {
         const currentStarSystem = this.starSystemView.getStarSystem();
 
         const currentWorldPosition = transform.getAbsolutePosition();
@@ -674,9 +697,13 @@ export class CosmosJourneyer {
             nearestOrbitalObjectInverseWorld,
         );
 
-        const distanceToNearestOrbitalObject = currentLocalPosition.length();
-        if (distanceToNearestOrbitalObject < nearestOrbitalObject.getBoundingRadius() * 1.1) {
-            currentLocalPosition.copyFromFloats(0, 0, nearestOrbitalObject.getBoundingRadius() * 5.0);
+        if (minimumDistanceRadiusRatio !== null) {
+            const distanceToNearestOrbitalObject = currentLocalPosition.length();
+            const minimumDistanceToNearestOrbitalObject =
+                nearestOrbitalObject.getBoundingRadius() * minimumDistanceRadiusRatio;
+            if (distanceToNearestOrbitalObject < minimumDistanceToNearestOrbitalObject) {
+                currentLocalPosition.copyFromFloats(0, 0, nearestOrbitalObject.getBoundingRadius() * 5.0);
+            }
         }
 
         // Finding the rotation of the player in the nearest orbital object's frame of reference
@@ -722,13 +749,15 @@ export class CosmosJourneyer {
             : shipUniverseCoordinates;
 
         const camera = this.activeView.getMainScene().activeCamera;
-        let thumbnail = "";
-        if (camera) {
-            thumbnail = await Tools.CreateScreenshotAsync(this.engine, camera, {
-                width: 320,
-                height: 180,
-                precision: 0.8,
+        let thumbnailDataUrl: string | undefined = undefined;
+        if (camera !== null) {
+            const thumbnailBytes = await makeScreenshotPng(this.engine, camera, {
+                size: {
+                    width: 256,
+                    height: 144,
+                },
             });
+            thumbnailDataUrl = bytesToDataUrl(thumbnailBytes, "image/png");
         }
 
         return {
@@ -742,7 +771,7 @@ export class CosmosJourneyer {
             shipLocations: {
                 [spaceship.id]: shipLocation,
             },
-            thumbnail: thumbnail,
+            thumbnail: thumbnailDataUrl,
         };
     }
 

--- a/packages/game/src/ts/frontend/helpers/screenshot.spec.ts
+++ b/packages/game/src/ts/frontend/helpers/screenshot.spec.ts
@@ -1,0 +1,86 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { describe, expect, it } from "vitest";
+
+import packageInfo from "../../../../package.json";
+import { addScreenshotMetadata, createScreenshotMetadata, dataUrlToBytes, readScreenshotMetadata } from "./screenshot";
+
+const minimalPng = new Uint8Array([
+    // PNG signature
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    // IEND chunk length: 0 bytes
+    0x00, 0x00, 0x00, 0x00,
+    // IEND chunk type
+    0x49, 0x45, 0x4e, 0x44,
+    // IEND CRC
+    0xae, 0x42, 0x60, 0x82,
+]);
+
+const relativeLocation = {
+    type: "relative",
+    universeObjectId: {
+        systemCoordinates: {
+            starSectorX: 1,
+            starSectorY: 2,
+            starSectorZ: 3,
+            localX: 0.4,
+            localY: 0.5,
+            localZ: -0.4,
+        },
+        idInSystem: "star0",
+    },
+    position: { x: 7, y: 8, z: 9 },
+    rotation: { x: 0, y: 0, z: 0, w: 1 },
+} as const;
+
+describe("screenshot helpers", () => {
+    it("uses the package version in screenshot metadata", () => {
+        const capturedAt = new Date("2026-05-09T17:00:00.000Z");
+
+        const metadata = createScreenshotMetadata(relativeLocation, capturedAt);
+
+        expect(metadata.schemaVersion).toBe(1);
+        expect(metadata.gameVersion).toBe(packageInfo.version);
+        expect(metadata.capturedAt).toBe("2026-05-09T17:00:00.000Z");
+    });
+
+    it("adds and reads screenshot metadata before IEND", () => {
+        const metadata = createScreenshotMetadata(relativeLocation, new Date("2026-05-09T17:00:00.000Z"));
+
+        const png = addScreenshotMetadata(minimalPng, metadata);
+        const metadataResult = readScreenshotMetadata(png);
+
+        expect(png.length).toBeGreaterThan(minimalPng.length);
+        expect(metadataResult).toEqual({ success: true, value: metadata });
+    });
+
+    it("returns null when a PNG has no screenshot metadata", () => {
+        expect(readScreenshotMetadata(minimalPng)).toEqual({ success: true, value: null });
+    });
+
+    it("decodes base64 PNG data URLs", () => {
+        let binary = "";
+        for (const byte of minimalPng) {
+            binary += String.fromCharCode(byte);
+        }
+
+        const bytes = dataUrlToBytes(`data:image/png;base64,${btoa(binary)}`);
+
+        expect(bytes).toEqual(minimalPng);
+    });
+});

--- a/packages/game/src/ts/frontend/helpers/screenshot.ts
+++ b/packages/game/src/ts/frontend/helpers/screenshot.ts
@@ -1,0 +1,326 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Camera } from "@babylonjs/core/Cameras/camera";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { CreateScreenshotAsync } from "@babylonjs/core/Misc/screenshotTools";
+import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { z } from "zod";
+
+import { RelativeCoordinatesSchema, type RelativeCoordinates } from "@/backend/save/universeCoordinates";
+
+import packageInfo from "../../../../package.json";
+
+export const ScreenshotMetadataKeyword = "CosmosJourneyer.Screenshot";
+
+export const ScreenshotMetadataSchema = z.object({
+    schemaVersion: z.literal(1),
+    gameVersion: z.string(),
+    capturedAt: z.iso.datetime(),
+    location: RelativeCoordinatesSchema,
+});
+
+export type ScreenshotMetadata = z.infer<typeof ScreenshotMetadataSchema>;
+export type ScreenshotMetadataReadError = "invalidPng" | "invalidJson" | "invalidMetadata";
+
+type ScreenshotSize = Parameters<typeof CreateScreenshotAsync>[2];
+
+const pngSignature = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const iendChunkType = "IEND";
+const internationalTextChunkType = "iTXt";
+
+export function createScreenshotMetadata(location: RelativeCoordinates, capturedAt = new Date()): ScreenshotMetadata {
+    return {
+        schemaVersion: 1,
+        gameVersion: packageInfo.version,
+        capturedAt: capturedAt.toISOString(),
+        location: location,
+    };
+}
+
+export async function makeScreenshotPng(
+    engine: AbstractEngine,
+    camera: Camera,
+    options?: Partial<{
+        readonly location: RelativeCoordinates;
+        readonly size?: ScreenshotSize;
+    }>,
+): Promise<Uint8Array> {
+    const screenshotBase64 = await CreateScreenshotAsync(engine, camera, options?.size ?? { precision: 1 });
+    const png = dataUrlToBytes(screenshotBase64);
+
+    if (options?.location === undefined) {
+        return png;
+    }
+
+    return addScreenshotMetadata(png, createScreenshotMetadata(options.location));
+}
+
+export function addScreenshotMetadata(png: Uint8Array, metadata: ScreenshotMetadata): Uint8Array {
+    return addPngInternationalTextChunk(png, ScreenshotMetadataKeyword, JSON.stringify(metadata));
+}
+
+export function readScreenshotMetadata(
+    png: Uint8Array,
+): Result<ScreenshotMetadata | null, ScreenshotMetadataReadError> {
+    let metadataText: string | null;
+    try {
+        metadataText = readPngInternationalTextChunk(png, ScreenshotMetadataKeyword);
+    } catch {
+        return err("invalidPng");
+    }
+
+    if (metadataText === null) {
+        return ok(null);
+    }
+
+    let metadataJson: unknown;
+    try {
+        metadataJson = JSON.parse(metadataText);
+    } catch {
+        return err("invalidJson");
+    }
+
+    const metadataResult = ScreenshotMetadataSchema.safeParse(metadataJson);
+    if (!metadataResult.success) {
+        return err("invalidMetadata");
+    }
+
+    return ok(metadataResult.data);
+}
+
+function addPngInternationalTextChunk(png: Uint8Array, keyword: string, text: string): Uint8Array {
+    assertPngSignature(png);
+    validatePngTextKeyword(keyword);
+
+    const iendOffset = findChunkOffset(png, iendChunkType);
+    const chunk = createChunk(internationalTextChunkType, createInternationalTextChunkData(keyword, text));
+
+    const result = new Uint8Array(png.length + chunk.length);
+    result.set(png.subarray(0, iendOffset), 0);
+    result.set(chunk, iendOffset);
+    result.set(png.subarray(iendOffset), iendOffset + chunk.length);
+
+    return result;
+}
+
+function readPngInternationalTextChunk(png: Uint8Array, keyword: string): string | null {
+    assertPngSignature(png);
+
+    let offset = pngSignature.length;
+    while (offset < png.length) {
+        const chunkLength = readUint32(png, offset);
+        const chunkType = bytesToAscii(png.subarray(offset + 4, offset + 8));
+        const dataStart = offset + 8;
+        const dataEnd = dataStart + chunkLength;
+
+        if (dataEnd + 4 > png.length) {
+            throw new Error("Invalid PNG: chunk length exceeds file size");
+        }
+
+        if (chunkType === internationalTextChunkType) {
+            const text = readInternationalTextChunkData(png.subarray(dataStart, dataEnd), keyword);
+            if (text !== null) return text;
+        }
+
+        offset = dataEnd + 4;
+    }
+
+    return null;
+}
+
+export function dataUrlToBytes(dataUrl: string): Uint8Array {
+    const base64SeparatorIndex = dataUrl.indexOf(";base64,");
+    if (base64SeparatorIndex === -1) {
+        throw new Error("Screenshot data URL is not base64 encoded");
+    }
+
+    const base64 = dataUrl.slice(base64SeparatorIndex + ";base64,".length);
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+
+    return bytes;
+}
+
+export function bytesToDataUrl(bytes: Uint8Array, mimeType: string): string {
+    let binary = "";
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+    }
+
+    const base64 = btoa(binary);
+    return `data:${mimeType};base64,${base64}`;
+}
+
+export function downloadPng(png: Uint8Array, filename: string): void {
+    const bytes = new ArrayBuffer(png.byteLength);
+    new Uint8Array(bytes).set(png);
+
+    const blob = new Blob([bytes], { type: "image/png" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+
+    URL.revokeObjectURL(url);
+}
+
+function createInternationalTextChunkData(keyword: string, text: string): Uint8Array {
+    const keywordBytes = asciiToBytes(keyword);
+    const textBytes = new TextEncoder().encode(text);
+    const data = new Uint8Array(keywordBytes.length + 5 + textBytes.length);
+
+    data.set(keywordBytes, 0);
+    data[keywordBytes.length] = 0;
+    data[keywordBytes.length + 1] = 0;
+    data[keywordBytes.length + 2] = 0;
+    data[keywordBytes.length + 3] = 0;
+    data[keywordBytes.length + 4] = 0;
+    data.set(textBytes, keywordBytes.length + 5);
+
+    return data;
+}
+
+function readInternationalTextChunkData(data: Uint8Array, expectedKeyword: string): string | null {
+    const keywordEnd = data.indexOf(0);
+    if (keywordEnd === -1) return null;
+
+    const keyword = bytesToAscii(data.subarray(0, keywordEnd));
+    if (keyword !== expectedKeyword) return null;
+
+    const compressionFlag = data[keywordEnd + 1];
+    if (compressionFlag !== 0) return null;
+
+    const languageTagEnd = data.indexOf(0, keywordEnd + 3);
+    if (languageTagEnd === -1) return null;
+
+    const translatedKeywordEnd = data.indexOf(0, languageTagEnd + 1);
+    if (translatedKeywordEnd === -1) return null;
+
+    return new TextDecoder().decode(data.subarray(translatedKeywordEnd + 1));
+}
+
+function createChunk(type: string, data: Uint8Array): Uint8Array {
+    const typeBytes = asciiToBytes(type);
+    const chunk = new Uint8Array(12 + data.length);
+
+    writeUint32(chunk, 0, data.length);
+    chunk.set(typeBytes, 4);
+    chunk.set(data, 8);
+    writeUint32(chunk, 8 + data.length, crc32(chunk.subarray(4, 8 + data.length)));
+
+    return chunk;
+}
+
+function findChunkOffset(png: Uint8Array, chunkType: string): number {
+    let offset = pngSignature.length;
+    while (offset < png.length) {
+        const chunkLength = readUint32(png, offset);
+        const type = bytesToAscii(png.subarray(offset + 4, offset + 8));
+        const nextOffset = offset + 12 + chunkLength;
+
+        if (nextOffset > png.length) {
+            throw new Error("Invalid PNG: chunk length exceeds file size");
+        }
+
+        if (type === chunkType) return offset;
+
+        offset = nextOffset;
+    }
+
+    throw new Error(`Invalid PNG: ${chunkType} chunk not found`);
+}
+
+function assertPngSignature(png: Uint8Array): void {
+    if (png.length < pngSignature.length) {
+        throw new Error("Invalid PNG: file is too short");
+    }
+
+    for (let i = 0; i < pngSignature.length; i++) {
+        if (png[i] !== pngSignature[i]) {
+            throw new Error("Invalid PNG signature");
+        }
+    }
+}
+
+function validatePngTextKeyword(keyword: string): void {
+    if (keyword.length === 0 || keyword.length > 79) {
+        throw new Error("PNG text keyword must contain between 1 and 79 characters");
+    }
+
+    for (const character of keyword) {
+        const code = character.charCodeAt(0);
+        if (code < 32 || code > 126) {
+            throw new Error("PNG text keyword must contain printable ASCII characters only");
+        }
+    }
+}
+
+function asciiToBytes(text: string): Uint8Array {
+    const bytes = new Uint8Array(text.length);
+    for (let i = 0; i < text.length; i++) {
+        bytes[i] = text.charCodeAt(i);
+    }
+    return bytes;
+}
+
+function bytesToAscii(bytes: Uint8Array): string {
+    let text = "";
+    for (const byte of bytes) {
+        text += String.fromCharCode(byte);
+    }
+    return text;
+}
+
+function readUint32(bytes: Uint8Array, offset: number): number {
+    const byte0 = bytes[offset];
+    const byte1 = bytes[offset + 1];
+    const byte2 = bytes[offset + 2];
+    const byte3 = bytes[offset + 3];
+
+    if (byte0 === undefined || byte1 === undefined || byte2 === undefined || byte3 === undefined) {
+        throw new Error("Invalid PNG: unexpected end of file");
+    }
+
+    return ((byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3) >>> 0;
+}
+
+function writeUint32(bytes: Uint8Array, offset: number, value: number): void {
+    bytes[offset] = (value >>> 24) & 0xff;
+    bytes[offset + 1] = (value >>> 16) & 0xff;
+    bytes[offset + 2] = (value >>> 8) & 0xff;
+    bytes[offset + 3] = value & 0xff;
+}
+
+function crc32(bytes: Uint8Array): number {
+    let crc = 0xffffffff;
+
+    for (const byte of bytes) {
+        crc ^= byte;
+        for (let i = 0; i < 8; i++) {
+            crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+        }
+    }
+
+    return (crc ^ 0xffffffff) >>> 0;
+}


### PR DESCRIPTION
## Related Tickets

Fixes #653 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

To make cool locations easier to share, location data will be added to in-game screenshots automatically.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

## How to test

- Play the game
- Take a screenshot (from pause menu or P)
- Open the screenshot in some metadata viewer
- The coordinates should be present

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

Add an option in the starmap to locate a screenshot by pinpointing the coordinates

<!--
What should we do next to take advantage of this work?
-->
