### PR TITLE
Fix progress monitoring

### DIFF
--- a/packages/game/src/ts/frontend/assets/assets.ts
+++ b/packages/game/src/ts/frontend/assets/assets.ts
@@ -30,7 +30,7 @@ export type Assets = {
 export async function loadAssets(
     scene: Scene,
     audioEngine: AudioEngineV2,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Assets> {
     const audioAssetsPromise = loadAudioAssets(audioEngine, progressMonitor);
     const renderingAssetsPromise = loadRenderingAssets(scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/audio/index.ts
+++ b/packages/game/src/ts/frontend/assets/audio/index.ts
@@ -30,7 +30,7 @@ export type AudioAssets = {
 
 export async function loadAudioAssets(
     audioEngine: AudioEngineV2,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<AudioAssets> {
     const soundsPromise = loadSounds(audioEngine, progressMonitor);
     const musicsPromise = loadMusics(audioEngine, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/audio/musics.ts
+++ b/packages/game/src/ts/frontend/assets/audio/musics.ts
@@ -56,7 +56,7 @@ export type Musics = {
 
 export async function loadMusics(
     audioEngine: AudioEngineV2,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Musics> {
     const loadSoundAsync = async (
         name: string,
@@ -64,9 +64,9 @@ export async function loadMusics(
         audioEngine: AudioEngineV2,
         options?: Partial<IStreamingSoundOptions>,
     ) => {
-        progressMonitor?.startTask();
+        progressMonitor.startTask();
         const sound = await CreateStreamingSoundAsync(name, url, options, audioEngine);
-        progressMonitor?.completeTask();
+        progressMonitor.completeTask();
         return sound;
     };
 

--- a/packages/game/src/ts/frontend/assets/audio/sounds.ts
+++ b/packages/game/src/ts/frontend/assets/audio/sounds.ts
@@ -56,7 +56,7 @@ export type Sounds = {
 
 export async function loadSounds(
     audioEngine: AudioEngineV2,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Sounds> {
     const loadSoundAsync = async (
         name: string,
@@ -64,9 +64,9 @@ export async function loadSounds(
         engine: AudioEngineV2,
         options?: Partial<IStaticSoundOptions>,
     ) => {
-        progressMonitor?.startTask();
+        progressMonitor.startTask();
         const sound = await CreateSoundAsync(name, url, options, engine);
-        progressMonitor?.completeTask();
+        progressMonitor.completeTask();
         return sound;
     };
 

--- a/packages/game/src/ts/frontend/assets/audio/voiceLines.ts
+++ b/packages/game/src/ts/frontend/assets/audio/voiceLines.ts
@@ -58,7 +58,7 @@ export type SpeakerVoiceLines = {
 
 export async function loadVoiceLines(
     audioEngine: AudioEngineV2,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<SpeakerVoiceLines> {
     const loadSoundAsync = async (
         name: string,
@@ -66,9 +66,9 @@ export async function loadVoiceLines(
         audioEngine: AudioEngineV2,
         options?: Partial<IStaticSoundOptions>,
     ) => {
-        progressMonitor?.startTask();
+        progressMonitor.startTask();
         const sound = await CreateSoundAsync(name, url, options, audioEngine);
-        progressMonitor?.completeTask();
+        progressMonitor.completeTask();
         return sound;
     };
 

--- a/packages/game/src/ts/frontend/assets/loadingProgressMonitor.ts
+++ b/packages/game/src/ts/frontend/assets/loadingProgressMonitor.ts
@@ -18,6 +18,7 @@
 export interface ILoadingProgressMonitor {
     startTask(): void;
     completeTask(): void;
+    reset(): void;
     addProgressCallback(callback: (startedTaskCount: number, completedTaskCount: number) => void): void;
 }
 
@@ -41,6 +42,12 @@ export class LoadingProgressMonitor implements ILoadingProgressMonitor {
         this.notifyProgress();
     }
 
+    public reset(): void {
+        this.startedTaskCount = 0;
+        this.completedTaskCount = 0;
+        this.notifyProgress();
+    }
+
     private notifyProgress(): void {
         for (const callback of this.progressCallbacks) {
             callback(this.startedTaskCount, this.completedTaskCount);
@@ -54,6 +61,10 @@ export class LoadingProgressMonitorMock implements ILoadingProgressMonitor {
     }
 
     public completeTask(): void {
+        // No operation for mock
+    }
+
+    public reset(): void {
         // No operation for mock
     }
 

--- a/packages/game/src/ts/frontend/assets/objects/asteroids.ts
+++ b/packages/game/src/ts/frontend/assets/objects/asteroids.ts
@@ -30,10 +30,7 @@ import asteroid2Path from "@assets/asteroid/asteroid2.glb";
 
 export type Asteroid = { mesh: Mesh; physicsShape: PhysicsShape };
 
-export async function loadAsteroids(
-    scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
-): Promise<Array<Asteroid>> {
+export async function loadAsteroids(scene: Scene, progressMonitor: ILoadingProgressMonitor): Promise<Array<Asteroid>> {
     const assetContainers = await loadAsteroidModels(scene, progressMonitor);
     const scalings = [0.5, 0.7, 0.9, 1.1, 1.3, 1.5, 1.7, 1.9, 2.1] as const;
 
@@ -50,7 +47,7 @@ export async function loadAsteroids(
 
 export async function loadAsteroidModels(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<AssetContainer[]> {
     const asteroidPromises = [
         loadAssetInContainerAsync("Asteroid1", asteroidPath, scene, progressMonitor),

--- a/packages/game/src/ts/frontend/assets/objects/humanoids.ts
+++ b/packages/game/src/ts/frontend/assets/objects/humanoids.ts
@@ -68,7 +68,7 @@ export interface HumanoidPrefab {
 
 export async function loadHumanoidPrefabs(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<HumanoidPrefabs> {
     const defaultHumanoid = await loadAssetInContainerAsync(
         "DefaultHumanoid",

--- a/packages/game/src/ts/frontend/assets/objects/index.ts
+++ b/packages/game/src/ts/frontend/assets/objects/index.ts
@@ -59,7 +59,7 @@ export type Objects = {
 export async function loadObjects(
     materials: Materials,
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Objects> {
     // Start loading all mesh assets
     const wandererPromise = loadAssetInContainerAsync("Wanderer", wandererPath, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/objects/utils.ts
+++ b/packages/game/src/ts/frontend/assets/objects/utils.ts
@@ -25,10 +25,10 @@ export async function loadAssetInContainerAsync(
     name: string,
     url: string,
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<AssetContainer> {
-    progressMonitor?.startTask();
+    progressMonitor.startTask();
     const container = await LoadAssetContainerAsync(url, scene);
-    progressMonitor?.completeTask();
+    progressMonitor.completeTask();
     return container;
 }

--- a/packages/game/src/ts/frontend/assets/renderingAssets.ts
+++ b/packages/game/src/ts/frontend/assets/renderingAssets.ts
@@ -30,7 +30,7 @@ export type RenderingAssets = {
 
 export async function loadRenderingAssets(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<RenderingAssets> {
     const texturesPromise = loadTextures(scene, progressMonitor);
 

--- a/packages/game/src/ts/frontend/assets/textures/environment.ts
+++ b/packages/game/src/ts/frontend/assets/textures/environment.ts
@@ -29,7 +29,7 @@ export type EnvironmentTextures = {
 
 export async function loadEnvironmentTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<EnvironmentTextures> {
     const milkyWayPromise = loadCubeTextureAsync("SkyBox", milkyWay, scene, progressMonitor);
     const milkyWayTexture = await milkyWayPromise;

--- a/packages/game/src/ts/frontend/assets/textures/gasPlanet.ts
+++ b/packages/game/src/ts/frontend/assets/textures/gasPlanet.ts
@@ -35,7 +35,7 @@ export type GasPlanetTextures = {
 
 export async function loadGasPlanetTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<GasPlanetTextures> {
     const jupiterTexturePromise = loadTextureAsync("JupiterTexture", jupiterTexturePath, scene, progressMonitor);
     const saturnTexturePromise = loadTextureAsync("SaturnTexture", saturnTexturePath, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/index.ts
+++ b/packages/game/src/ts/frontend/assets/textures/index.ts
@@ -69,7 +69,7 @@ export type Textures = {
  * @param progressMonitor - The progress monitor to report loading progress
  * @returns A promise resolving to the Textures object
  */
-export async function loadTextures(scene: Scene, progressMonitor: ILoadingProgressMonitor | null): Promise<Textures> {
+export async function loadTextures(scene: Scene, progressMonitor: ILoadingProgressMonitor): Promise<Textures> {
     // Water textures
     const waterNormalMap1Promise = loadTextureAsync("WaterNormalMap1", waterNormal1, scene, progressMonitor);
     const waterNormalMap2Promise = loadTextureAsync("WaterNormalMap2", waterNormal2, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/materials/concrete.ts
+++ b/packages/game/src/ts/frontend/assets/textures/materials/concrete.ts
@@ -28,7 +28,7 @@ import concreteNormal from "@assets/degraded-concrete-ue/degraded-concrete_norma
 
 export async function loadConcreteTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<PBRTextures> {
     const albedo = loadTextureAsync("ConcreteAlbedo", concreteAlbedo, scene, progressMonitor);
     const normal = loadTextureAsync("ConcreteNormal", concreteNormal, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/materials/crate.ts
+++ b/packages/game/src/ts/frontend/assets/textures/materials/crate.ts
@@ -35,7 +35,7 @@ export type CrateTextures = {
 
 export async function loadCrateTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<CrateTextures> {
     const albedoPromise = loadTextureAsync("crateAlbedo", albedoPath, scene, progressMonitor);
     const normalHeightPromise = loadTextureAsync("crateNormalHeight", normalHeightPath, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/materials/index.ts
+++ b/packages/game/src/ts/frontend/assets/textures/materials/index.ts
@@ -56,7 +56,7 @@ export type AllMaterialTextures = {
 
 export async function loadMaterialTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<AllMaterialTextures> {
     // Space Station
     const spaceStationAlbedoPromise = loadTextureAsync(

--- a/packages/game/src/ts/frontend/assets/textures/materials/pvcTactileTiles.ts
+++ b/packages/game/src/ts/frontend/assets/textures/materials/pvcTactileTiles.ts
@@ -35,7 +35,7 @@ export type PvcTactileTilesTextures = {
 
 export async function loadPvcTactileTilesTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<PvcTactileTilesTextures> {
     const albedoPromise = loadTextureAsync("PvcTactileTilesAlbedo", albedoPath, scene, progressMonitor);
     const normalPromise = loadTextureAsync("PvcTactileTilesNormal", normalPath, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/materials/solarPanel.ts
+++ b/packages/game/src/ts/frontend/assets/textures/materials/solarPanel.ts
@@ -37,7 +37,7 @@ export type SolarPanelTextures = {
 
 export async function loadSolarPanelTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<SolarPanelTextures> {
     const albedoPromise = loadTextureAsync("SolarPanelAlbedo", solarPanelAlbedoPath, scene, progressMonitor);
     const normalPromise = loadTextureAsync("SolarPanelNormal", solarPanelNormalPath, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/materials/styrofoam.ts
+++ b/packages/game/src/ts/frontend/assets/textures/materials/styrofoam.ts
@@ -35,7 +35,7 @@ export type StyroFoamTextures = {
 
 export async function loadStyroFoamTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<StyroFoamTextures> {
     const albedoPromise = loadTextureAsync("StyroFoamAlbedo", albedoPath, scene, progressMonitor);
     const normalPromise = loadTextureAsync("StyroFoamNormal", normalPath, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/materials/tire.ts
+++ b/packages/game/src/ts/frontend/assets/textures/materials/tire.ts
@@ -33,10 +33,7 @@ export type TireTextures = {
     ambientOcclusion: Texture;
 };
 
-export async function loadTireTextures(
-    scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
-): Promise<TireTextures> {
+export async function loadTireTextures(scene: Scene, progressMonitor: ILoadingProgressMonitor): Promise<TireTextures> {
     const albedoPromise = loadTextureAsync("TireAlbedo", tireAlbedoPath, scene, progressMonitor);
     const normalHeightPromise = loadTextureAsync("TireNormalHeight", tireNormalHeightPath, scene, progressMonitor);
     const roughnessPromise = loadTextureAsync("TireRoughness", tireRoughnessPath, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/noises.ts
+++ b/packages/game/src/ts/frontend/assets/textures/noises.ts
@@ -29,7 +29,7 @@ export type NoiseTextures = {
 
 export async function loadNoiseTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<NoiseTextures> {
     const seamlessPerlin = loadTextureAsync("SeamlessPerlinNoise", seamlessPerlinPath, scene, progressMonitor);
 

--- a/packages/game/src/ts/frontend/assets/textures/particles.ts
+++ b/packages/game/src/ts/frontend/assets/textures/particles.ts
@@ -31,7 +31,7 @@ export type ParticleTextures = {
     butterfly: Texture;
 };
 
-export async function loadParticleTextures(scene: Scene, progressMonitor: ILoadingProgressMonitor | null) {
+export async function loadParticleTextures(scene: Scene, progressMonitor: ILoadingProgressMonitor) {
     const plumeParticlePromise = loadTextureAsync("PlumeParticle", plumeParticle, scene, progressMonitor);
     const flareTexturePromise = loadTextureAsync("FlareTexture", flareParticle, scene, progressMonitor);
     const butterflyPromise = loadTextureAsync("Butterfly", butterflyTexture, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/rings.ts
+++ b/packages/game/src/ts/frontend/assets/textures/rings.ts
@@ -31,7 +31,7 @@ export type RingsTextures = {
 
 export async function loadRingsTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<RingsTextures> {
     const saturnRingsTexturePromise = loadTextureAsync("SaturnRingsTexture", saturnRingsPath, scene, progressMonitor);
     const uranusRingsTexturePromise = loadTextureAsync("UranusRingsTexture", uranusRingsPath, scene, progressMonitor);

--- a/packages/game/src/ts/frontend/assets/textures/starMap.ts
+++ b/packages/game/src/ts/frontend/assets/textures/starMap.ts
@@ -31,7 +31,7 @@ export type StarMapTextures = {
 
 export async function loadStarMapTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<StarMapTextures> {
     const starSprite = loadTextureAsync("StarSprite", starTexturePath, scene, progressMonitor);
 

--- a/packages/game/src/ts/frontend/assets/textures/terrains.ts
+++ b/packages/game/src/ts/frontend/assets/textures/terrains.ts
@@ -44,7 +44,7 @@ export type AllTerrainTextures = {
 
 export async function loadTerrainTextures(
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<AllTerrainTextures> {
     const rockNormalAmbientOcclusionPromise = loadTextureAsync(
         "RockNormalAmbientOcclusionMap",

--- a/packages/game/src/ts/frontend/assets/textures/utils.ts
+++ b/packages/game/src/ts/frontend/assets/textures/utils.ts
@@ -25,9 +25,9 @@ export async function loadTextureAsync(
     name: string,
     url: string,
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Texture> {
-    progressMonitor?.startTask();
+    progressMonitor.startTask();
     const texture = await new Promise<Texture>((resolve) => {
         const texture = new Texture(url, scene, false, false, undefined, () => {
             resolve(texture);
@@ -35,7 +35,7 @@ export async function loadTextureAsync(
         texture.name = name;
     });
 
-    progressMonitor?.completeTask();
+    progressMonitor.completeTask();
     return texture;
 }
 
@@ -43,9 +43,9 @@ export async function loadCubeTextureAsync(
     name: string,
     url: string,
     scene: Scene,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<CubeTexture> {
-    progressMonitor?.startTask();
+    progressMonitor.startTask();
     const texture = await new Promise<CubeTexture>((resolve) => {
         const texture = CubeTexture.CreateFromPrefilteredData(url, scene);
         texture.onLoadObservable.add(() => {
@@ -54,6 +54,6 @@ export async function loadCubeTextureAsync(
         texture.name = name;
     });
 
-    progressMonitor?.completeTask();
+    progressMonitor.completeTask();
     return texture;
 }

--- a/packages/game/src/ts/frontend/cosmosJourneyer.ts
+++ b/packages/game/src/ts/frontend/cosmosJourneyer.ts
@@ -70,7 +70,7 @@ import type { DeepReadonly } from "@/utils/types";
 import i18n, { initI18n } from "@/i18n";
 import { Settings } from "@/settings";
 
-import { LoadingProgressMonitor } from "./assets/loadingProgressMonitor";
+import { LoadingProgressMonitor, type ILoadingProgressMonitor } from "./assets/loadingProgressMonitor";
 import { loadStarMapTextures } from "./assets/textures/starMap";
 import { lookAt } from "./helpers/transform";
 import { NotificationManager, type INotificationManager } from "./ui/notificationManager";
@@ -106,6 +106,7 @@ export class CosmosJourneyer {
     readonly soundPlayer: ISoundPlayer;
     readonly tts: Tts;
     readonly notificationManager: INotificationManager;
+    private readonly loadingProgressMonitor: ILoadingProgressMonitor;
 
     readonly mainMenu: MainMenu;
     readonly pauseMenu: PauseMenu;
@@ -148,6 +149,7 @@ export class CosmosJourneyer {
         soundPlayer: ISoundPlayer,
         tts: Tts,
         notificationManager: INotificationManager,
+        loadingProgressMonitor: ILoadingProgressMonitor,
     ) {
         this.engine = engine;
 
@@ -185,6 +187,7 @@ export class CosmosJourneyer {
         this.soundPlayer = soundPlayer;
         this.tts = tts;
         this.notificationManager = notificationManager;
+        this.loadingProgressMonitor = loadingProgressMonitor;
 
         this.starMap = starMapView;
         this.starMap.onTargetSetObservable.add((systemCoordinates: StarSystemCoordinates) => {
@@ -476,6 +479,7 @@ export class CosmosJourneyer {
             notificationManager,
             starSystemViewAssets.rendering,
             chunkForge,
+            loadingProgressMonitor,
         );
 
         const starMapView = new StarMapView(
@@ -507,6 +511,7 @@ export class CosmosJourneyer {
             soundPlayer,
             tts,
             notificationManager,
+            loadingProgressMonitor,
         );
     }
 
@@ -892,6 +897,7 @@ export class CosmosJourneyer {
         });
         await this.starSystemView.resetPlayer();
 
+        this.loadingProgressMonitor.reset();
         this.engine.loadingScreen.displayLoadingUI();
 
         await this.starSystemView.loadStarSystem(systemModel);

--- a/packages/game/src/ts/frontend/helpers/loadingScreen.ts
+++ b/packages/game/src/ts/frontend/helpers/loadingScreen.ts
@@ -117,8 +117,11 @@ export class LoadingScreen implements ILoadingScreen {
     }
 
     public setProgress(startedCount: number, completedCount: number) {
-        const percentage = (completedCount / startedCount) * 100;
-        this.loadingUIText = `${i18next.t("common:loading")} (${completedCount}/${startedCount})`;
+        const percentage = startedCount === 0 ? 0 : (completedCount / startedCount) * 100;
+        this.loadingUIText =
+            startedCount === 0
+                ? i18next.t("common:loading")
+                : `${i18next.t("common:loading")} (${completedCount}/${startedCount})`;
         this.progressBar?.style.setProperty("--progress", `${percentage}%`);
     }
 

--- a/packages/game/src/ts/frontend/starSystemView.ts
+++ b/packages/game/src/ts/frontend/starSystemView.ts
@@ -40,6 +40,7 @@ import { type EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/ency
 import { ItinerarySchema } from "@/backend/player/serializedPlayer";
 import { type UniverseBackend } from "@/backend/universe/universeBackend";
 
+import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { AudioMasks } from "@/frontend/audio/audioMasks";
 import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
@@ -235,6 +236,8 @@ export class StarSystemView implements View {
 
     private readonly assets: RenderingAssets;
 
+    private readonly progressMonitor: ILoadingProgressMonitor;
+
     private readonly depthRendererManager: DepthRendererManager;
 
     /**
@@ -251,6 +254,7 @@ export class StarSystemView implements View {
      * @param notificationManager The notification manager
      * @param assets The rendering assets
      * @param chunkForge The chunk forge used to generate surface chunks for telluric planets
+     * @param progressMonitor The loading progress monitor to report star system loading progress
      */
     constructor(
         scene: Scene,
@@ -264,6 +268,7 @@ export class StarSystemView implements View {
         notificationManager: INotificationManager,
         assets: RenderingAssets,
         chunkForge: ChunkForge,
+        progressMonitor: ILoadingProgressMonitor,
     ) {
         this.player = player;
         this.encyclopaedia = encyclopaedia;
@@ -283,6 +288,7 @@ export class StarSystemView implements View {
         this.notificationManager = notificationManager;
         this.assets = assets;
         this.chunkForge = chunkForge;
+        this.progressMonitor = progressMonitor;
 
         this.interactionSystem = new InteractionSystem(CollisionMask.INTERACTIVE, scene, [], async (interactions) => {
             if (interactions.length === 0) {
@@ -591,7 +597,13 @@ export class StarSystemView implements View {
             this.spaceStationLayer.reset();
         }
 
-        this.starSystem = await StarSystemController.CreateAsync(starSystemModel, this.loader, this.assets, this.scene);
+        this.starSystem = await StarSystemController.CreateAsync(
+            starSystemModel,
+            this.loader,
+            this.assets,
+            this.scene,
+            this.progressMonitor,
+        );
 
         const shipMesh = this.spaceshipControls?.getSpaceship();
         if (shipMesh !== undefined) {

--- a/packages/game/src/ts/frontend/universe/starSystemController.ts
+++ b/packages/game/src/ts/frontend/universe/starSystemController.ts
@@ -27,6 +27,7 @@ import {
 
 import { type UniverseBackend } from "@/backend/universe/universeBackend";
 
+import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 import { translate } from "@/frontend/helpers/transform";
@@ -174,8 +175,9 @@ export class StarSystemController {
         loader: StarSystemLoader,
         assets: RenderingAssets,
         scene: Scene,
+        progressMonitor: ILoadingProgressMonitor,
     ): Promise<StarSystemController> {
-        const result = await loader.load(model, assets, scene);
+        const result = await loader.load(model, assets, scene, progressMonitor);
         return new StarSystemController(model, result, assets, scene);
     }
 

--- a/packages/game/src/ts/frontend/universe/starSystemLoader.ts
+++ b/packages/game/src/ts/frontend/universe/starSystemLoader.ts
@@ -25,6 +25,7 @@ import {
     type StarSystemModel,
 } from "@cosmos-journeyer/universe-model";
 
+import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { GasPlanet } from "@/frontend/universe/planets/gasPlanet/gasPlanet";
 import { TelluricPlanet } from "@/frontend/universe/planets/telluricPlanet/telluricPlanet";
@@ -42,26 +43,21 @@ import { SpaceElevator } from "./orbitalFacility/spaceElevator";
 import { SpaceStation } from "./orbitalFacility/spaceStation";
 
 export class StarSystemLoader {
-    private loadingIndex: number;
-    private maxLoadingIndex: number;
+    private loadingIndex = 0;
 
     private readonly offset = 1e10;
     private readonly timeOut = 16 * 10;
-
-    constructor() {
-        this.loadingIndex = 0;
-        this.maxLoadingIndex = 1;
-    }
-
-    public getLoadingProgress(): number {
-        return this.loadingIndex / this.maxLoadingIndex;
-    }
 
     /**
      * Loads the star system from the underlying data model.
      * This instantiates all stars, planets, satellites, anomalies and space stations in the star system.
      */
-    public async load(systemModel: DeepReadonly<StarSystemModel>, assets: RenderingAssets, scene: Scene) {
+    public async load(
+        systemModel: DeepReadonly<StarSystemModel>,
+        assets: RenderingAssets,
+        scene: Scene,
+        progressMonitor: ILoadingProgressMonitor,
+    ) {
         const numberOfObjects =
             systemModel.stellarObjects.length +
             systemModel.planets.length +
@@ -70,15 +66,23 @@ export class StarSystemLoader {
             systemModel.orbitalFacilities.length;
 
         this.loadingIndex = 0;
-        this.maxLoadingIndex = numberOfObjects;
+
+        for (let index = 0; index < numberOfObjects; index++) {
+            progressMonitor.startTask();
+        }
 
         await wait(1000);
 
-        const stellarObjects = await this.loadStellarObjects(systemModel.stellarObjects, assets, scene);
-        const planets = await this.loadPlanets(systemModel.planets, assets, scene);
-        const satellites = await this.loadSatellites(systemModel.satellites, assets, scene);
-        const anomalies = await this.loadAnomalies(systemModel.anomalies, scene);
-        const orbitalFacilities = await this.loadOrbitalFacilities(systemModel, assets, scene);
+        const stellarObjects = await this.loadStellarObjects(
+            systemModel.stellarObjects,
+            assets,
+            scene,
+            progressMonitor,
+        );
+        const planets = await this.loadPlanets(systemModel.planets, assets, scene, progressMonitor);
+        const satellites = await this.loadSatellites(systemModel.satellites, assets, scene, progressMonitor);
+        const anomalies = await this.loadAnomalies(systemModel.anomalies, scene, progressMonitor);
+        const orbitalFacilities = await this.loadOrbitalFacilities(systemModel, assets, scene, progressMonitor);
 
         await wait(1000);
 
@@ -95,6 +99,7 @@ export class StarSystemLoader {
         stellarObjectModels: DeepReadonly<Array<StellarObjectModel>>,
         assets: RenderingAssets,
         scene: Scene,
+        progressMonitor: ILoadingProgressMonitor,
     ): Promise<Readonly<NonEmptyArray<StellarObject>>> {
         const stellarObjects: StellarObject[] = [];
         for (const stellarObjectModel of stellarObjectModels) {
@@ -116,6 +121,7 @@ export class StarSystemLoader {
             stellarObjects.push(stellarObject);
 
             stellarObject.getTransform().setAbsolutePosition(new Vector3(this.offset * ++this.loadingIndex, 0, 0));
+            progressMonitor.completeTask();
 
             await wait(this.timeOut);
         }
@@ -130,6 +136,7 @@ export class StarSystemLoader {
     private async loadAnomalies(
         anomalyModels: DeepReadonly<Array<AnomalyModel>>,
         scene: Scene,
+        progressMonitor: ILoadingProgressMonitor,
     ): Promise<ReadonlyArray<Anomaly>> {
         const anomalies: Anomaly[] = [];
         for (const anomalyModel of anomalyModels) {
@@ -160,6 +167,7 @@ export class StarSystemLoader {
             anomalies.push(anomaly);
 
             anomaly.getTransform().setAbsolutePosition(new Vector3(this.offset * ++this.loadingIndex, 0, 0));
+            progressMonitor.completeTask();
 
             await wait(this.timeOut);
         }
@@ -171,6 +179,7 @@ export class StarSystemLoader {
         systemModel: DeepReadonly<StarSystemModel>,
         assets: RenderingAssets,
         scene: Scene,
+        progressMonitor: ILoadingProgressMonitor,
     ): Promise<ReadonlyArray<OrbitalFacility>> {
         const orbitalFacilities: OrbitalFacility[] = [];
         for (const orbitalFacilityModel of systemModel.orbitalFacilities) {
@@ -187,6 +196,7 @@ export class StarSystemLoader {
             }
             orbitalFacilities.push(orbitalFacility);
             orbitalFacility.getTransform().setAbsolutePosition(new Vector3(this.offset * ++this.loadingIndex, 0, 0));
+            progressMonitor.completeTask();
 
             await wait(this.timeOut);
         }
@@ -198,6 +208,7 @@ export class StarSystemLoader {
         planetModels: DeepReadonly<Array<PlanetModel>>,
         assets: RenderingAssets,
         scene: Scene,
+        progressMonitor: ILoadingProgressMonitor,
     ): Promise<ReadonlyArray<Planet>> {
         const planets: Planet[] = [];
         for (const planetModel of planetModels) {
@@ -216,8 +227,8 @@ export class StarSystemLoader {
             }
 
             planet.getTransform().setAbsolutePosition(new Vector3(this.offset * ++this.loadingIndex, 0, 0));
-
             planets.push(planet);
+            progressMonitor.completeTask();
 
             await wait(this.timeOut);
         }
@@ -229,6 +240,7 @@ export class StarSystemLoader {
         satelliteModels: DeepReadonly<Array<TelluricSatelliteModel>>,
         assets: RenderingAssets,
         scene: Scene,
+        progressMonitor: ILoadingProgressMonitor,
     ): Promise<ReadonlyArray<TelluricPlanet>> {
         const satellites: TelluricPlanet[] = [];
         for (const satelliteModel of satelliteModels) {
@@ -236,6 +248,7 @@ export class StarSystemLoader {
             const satellite = new TelluricPlanet(satelliteModel, assets, scene);
             satellite.getTransform().setAbsolutePosition(new Vector3(this.offset * ++this.loadingIndex, 0, 0));
             satellites.push(satellite);
+            progressMonitor.completeTask();
 
             await wait(this.timeOut);
         }

--- a/packages/game/src/ts/playgrounds/anomalies/juliaSet.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/juliaSet.ts
@@ -27,7 +27,7 @@ import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";
 export function createJuliaSetScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/anomalies/mandelbox.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/mandelbox.ts
@@ -27,7 +27,7 @@ import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";
 export function createMandelboxScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/anomalies/mandelbulb.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/mandelbulb.ts
@@ -27,7 +27,7 @@ import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";
 export function createMandelbulbScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/anomalies/mengerSponge.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/mengerSponge.ts
@@ -27,7 +27,7 @@ import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";
 export function createMengerSpongeScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/anomalies/sierpinski.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/sierpinski.ts
@@ -27,7 +27,7 @@ import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";
 export function createSierpinskiScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/asteroidField.ts
+++ b/packages/game/src/ts/playgrounds/asteroidField.ts
@@ -37,7 +37,7 @@ import { enablePhysics } from "./utils";
 
 export async function createAsteroidFieldScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/atmosphericScattering.ts
+++ b/packages/game/src/ts/playgrounds/atmosphericScattering.ts
@@ -29,7 +29,7 @@ import { AtmosphericScatteringPostProcess } from "@/frontend/postProcesses/atmos
 export function createAtmosphericScatteringScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/automaticLanding.ts
+++ b/packages/game/src/ts/playgrounds/automaticLanding.ts
@@ -44,7 +44,7 @@ import { createSky, enablePhysics, enablePointerLock, enableShadows } from "./ut
 
 export async function createAutomaticLandingScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/butterfly.ts
+++ b/packages/game/src/ts/playgrounds/butterfly.ts
@@ -30,7 +30,7 @@ import { createSky } from "./utils";
 
 export async function createButterflyScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/character.ts
+++ b/packages/game/src/ts/playgrounds/character.ts
@@ -43,7 +43,7 @@ import { createSky, enablePhysics, enablePointerLock, enableShadows } from "./ut
 
 export async function createCharacterDemoScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/darkKnight.ts
+++ b/packages/game/src/ts/playgrounds/darkKnight.ts
@@ -28,7 +28,7 @@ import { StarFieldBox } from "@/frontend/universe/starFieldBox";
 
 export async function createDarkKnightScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/debugAssets.ts
+++ b/packages/game/src/ts/playgrounds/debugAssets.ts
@@ -28,7 +28,7 @@ import { enablePhysics } from "./utils";
 
 export async function createDebugAssetsScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/default.ts
+++ b/packages/game/src/ts/playgrounds/default.ts
@@ -24,7 +24,7 @@ import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressM
 export function createDefaultScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
 

--- a/packages/game/src/ts/playgrounds/flightDemo.ts
+++ b/packages/game/src/ts/playgrounds/flightDemo.ts
@@ -34,7 +34,7 @@ import { enablePhysics, enableShadows } from "./utils";
 
 export async function createFlightDemoScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/forest.ts
+++ b/packages/game/src/ts/playgrounds/forest.ts
@@ -36,7 +36,7 @@ import { enablePhysics } from "./utils";
 
 export async function createForestScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/gasPlanet.ts
+++ b/packages/game/src/ts/playgrounds/gasPlanet.ts
@@ -38,7 +38,7 @@ import { enablePhysics } from "./utils";
 
 export async function createGasPlanetScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/grass.ts
+++ b/packages/game/src/ts/playgrounds/grass.ts
@@ -38,7 +38,7 @@ import { createSky } from "./utils";
 
 export async function createGrassScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/gravitySystem.ts
+++ b/packages/game/src/ts/playgrounds/gravitySystem.ts
@@ -38,7 +38,7 @@ import { enablePhysics, enableShadows } from "./utils";
 export async function createGravitySystemScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/hyperspaceTunnel.ts
+++ b/packages/game/src/ts/playgrounds/hyperspaceTunnel.ts
@@ -26,10 +26,7 @@ import { HyperSpaceTunnel } from "@/frontend/assets/procedural/hyperSpaceTunnel"
 import { loadNoiseTextures } from "@/frontend/assets/textures/noises";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 
-export async function createHyperspaceTunnelDemo(
-    engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
-) {
+export async function createHyperspaceTunnelDemo(engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor) {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;
 

--- a/packages/game/src/ts/playgrounds/interaction.ts
+++ b/packages/game/src/ts/playgrounds/interaction.ts
@@ -51,7 +51,7 @@ import { createSky, enablePhysics, enablePointerLock, enableShadows } from "./ut
 
 export async function createInteractionDemo(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/landingPad.ts
+++ b/packages/game/src/ts/playgrounds/landingPad.ts
@@ -42,7 +42,7 @@ import { enablePhysics } from "./utils";
 
 export async function createLandingPadScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.clearColor.set(0.1, 0.1, 0.1, 1);

--- a/packages/game/src/ts/playgrounds/lensFlareOcclusion.ts
+++ b/packages/game/src/ts/playgrounds/lensFlareOcclusion.ts
@@ -40,7 +40,7 @@ const OCCLUDER_POSITIONS = {
 export function createLensFlareOcclusionScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/onFoot.ts
+++ b/packages/game/src/ts/playgrounds/onFoot.ts
@@ -63,7 +63,7 @@ import { createSky, enablePhysics } from "./utils";
 
 export async function createOnFootScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/orbitalDemo.ts
+++ b/packages/game/src/ts/playgrounds/orbitalDemo.ts
@@ -35,7 +35,7 @@ import { OrbitRenderer } from "@/frontend/universe/orbitRenderer";
 export function createOrbitalDemoScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/playgroundRegistry.ts
+++ b/packages/game/src/ts/playgrounds/playgroundRegistry.ts
@@ -72,7 +72,7 @@ import { createXrScene } from "./xr";
 export class PlaygroundRegistry {
     private readonly map: Map<
         string,
-        (engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor | null) => Promise<Scene>
+        (engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor) => Promise<Scene>
     > = new Map([
         ["orbitalDemo", createOrbitalDemoScene],
         ["tunnel", createHyperspaceTunnelDemo],
@@ -126,12 +126,12 @@ export class PlaygroundRegistry {
 
     register(
         name: string,
-        createScene: (engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor | null) => Promise<Scene>,
+        createScene: (engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor) => Promise<Scene>,
     ) {
         this.map.set(name, createScene);
     }
 
-    get(name: string): (engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor | null) => Promise<Scene> {
+    get(name: string): (engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor) => Promise<Scene> {
         return this.map.get(name) ?? createDefaultScene;
     }
 }

--- a/packages/game/src/ts/playgrounds/rings.ts
+++ b/packages/game/src/ts/playgrounds/rings.ts
@@ -33,7 +33,7 @@ import { ItemPool } from "@/utils/itemPool";
 export async function createRingsScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/rover.ts
+++ b/packages/game/src/ts/playgrounds/rover.ts
@@ -55,7 +55,7 @@ import { createSky, enablePhysics, enableShadows } from "./utils";
 
 export async function createRoverScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/saveLoadingPanelContent.ts
+++ b/packages/game/src/ts/playgrounds/saveLoadingPanelContent.ts
@@ -35,7 +35,7 @@ import { initI18n } from "@/i18n";
 export async function createSaveLoadingPanelContentScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
 

--- a/packages/game/src/ts/playgrounds/sol/jupiter.ts
+++ b/packages/game/src/ts/playgrounds/sol/jupiter.ts
@@ -34,7 +34,7 @@ import { enablePhysics } from "../utils";
 
 export async function createJupiterScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/sol/saturn.ts
+++ b/packages/game/src/ts/playgrounds/sol/saturn.ts
@@ -37,7 +37,7 @@ import { enablePhysics } from "../utils";
 
 export async function createSaturnScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/sol/sol.ts
+++ b/packages/game/src/ts/playgrounds/sol/sol.ts
@@ -35,10 +35,7 @@ import { Settings } from "@/settings";
 
 import { enablePhysics } from "../utils";
 
-export async function createSolScene(
-    engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
-): Promise<Scene> {
+export async function createSolScene(engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;
     scene.clearColor.set(0, 0, 0, 1);

--- a/packages/game/src/ts/playgrounds/sol/sol.ts
+++ b/packages/game/src/ts/playgrounds/sol/sol.ts
@@ -69,6 +69,7 @@ export async function createSolScene(engine: AbstractEngine, progressMonitor: IL
         starSystemLoader,
         assets,
         scene,
+        progressMonitor,
     );
     starSystemController.initPositions(2, chunkForge, Date.now() / 1000);
 

--- a/packages/game/src/ts/playgrounds/sol/sun.ts
+++ b/packages/game/src/ts/playgrounds/sol/sun.ts
@@ -31,10 +31,7 @@ import { Star } from "@/frontend/universe/stellarObjects/star/star";
 
 import { enablePhysics } from "../utils";
 
-export async function createSunScene(
-    engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
-): Promise<Scene> {
+export async function createSunScene(engine: AbstractEngine, progressMonitor: ILoadingProgressMonitor): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;
     scene.clearColor.set(0, 0, 0, 1);

--- a/packages/game/src/ts/playgrounds/spaceDots.ts
+++ b/packages/game/src/ts/playgrounds/spaceDots.ts
@@ -30,7 +30,7 @@ const DEFAULT_ROLL = 0;
 export function createSpaceDotsScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/spaceElevator.ts
+++ b/packages/game/src/ts/playgrounds/spaceElevator.ts
@@ -40,7 +40,7 @@ import { enablePhysics } from "./utils";
 
 export async function createSpaceElevatorScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, {
         useFloatingOrigin: true,

--- a/packages/game/src/ts/playgrounds/spaceStation.ts
+++ b/packages/game/src/ts/playgrounds/spaceStation.ts
@@ -37,7 +37,7 @@ import { enablePhysics } from "./utils";
 
 export async function createSpaceStationScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, {
         useFloatingOrigin: true,

--- a/packages/game/src/ts/playgrounds/spaceStationUI.ts
+++ b/packages/game/src/ts/playgrounds/spaceStationUI.ts
@@ -38,7 +38,7 @@ import { enablePhysics } from "./utils";
 
 export async function createSpaceStationUIScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/sphericalHeightFieldTerrain.ts
+++ b/packages/game/src/ts/playgrounds/sphericalHeightFieldTerrain.ts
@@ -34,7 +34,7 @@ import { enablePhysics } from "./utils";
 export async function createSphericalHeightFieldTerrainScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/spotLights.ts
+++ b/packages/game/src/ts/playgrounds/spotLights.ts
@@ -28,7 +28,7 @@ import {
 export function createSpotLightsScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/starMap.ts
+++ b/packages/game/src/ts/playgrounds/starMap.ts
@@ -28,7 +28,7 @@ import { StarMap } from "@/frontend/starmap/starMap";
 
 export async function createStarMapScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/starMapView.ts
+++ b/packages/game/src/ts/playgrounds/starMapView.ts
@@ -36,7 +36,7 @@ import { initI18n } from "@/i18n";
 
 export async function createStarMapViewScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     await initI18n();
 

--- a/packages/game/src/ts/playgrounds/starSystemView.ts
+++ b/packages/game/src/ts/playgrounds/starSystemView.ts
@@ -39,7 +39,7 @@ import { enablePhysics } from "./utils";
 
 export async function createStarSystemViewScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     await initI18n();
 

--- a/packages/game/src/ts/playgrounds/starSystemView.ts
+++ b/packages/game/src/ts/playgrounds/starSystemView.ts
@@ -79,6 +79,7 @@ export async function createStarSystemViewScene(
         notificationManager,
         assets,
         chunkForge,
+        progressMonitor,
     );
 
     await starSystemView.resetPlayer();

--- a/packages/game/src/ts/playgrounds/stationLanding.ts
+++ b/packages/game/src/ts/playgrounds/stationLanding.ts
@@ -41,7 +41,7 @@ import { enablePhysics } from "./utils";
 
 export async function createStationLandingScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, {
         useFloatingOrigin: true,

--- a/packages/game/src/ts/playgrounds/stellarObjects/blackHole.ts
+++ b/packages/game/src/ts/playgrounds/stellarObjects/blackHole.ts
@@ -34,7 +34,7 @@ import { enablePointerLock } from "../utils";
 
 export async function createBlackHoleScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/stellarObjects/neutronStar.ts
+++ b/packages/game/src/ts/playgrounds/stellarObjects/neutronStar.ts
@@ -38,7 +38,7 @@ import { enablePhysics } from "../utils";
 
 export async function createNeutronStarScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/swimming.ts
+++ b/packages/game/src/ts/playgrounds/swimming.ts
@@ -42,7 +42,7 @@ import { createSky, enablePhysics, enablePointerLock, enableShadows } from "./ut
 
 export async function CreateSwimmingScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/telluricPlanet.ts
+++ b/packages/game/src/ts/playgrounds/telluricPlanet.ts
@@ -43,7 +43,7 @@ import { addToWindow, enablePhysics } from "./utils";
 
 export async function createTelluricPlanetScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/thrusterExhaust.ts
+++ b/packages/game/src/ts/playgrounds/thrusterExhaust.ts
@@ -118,7 +118,7 @@ function createControlPanel(exhaust: ThrusterExhaust): HTMLDivElement {
 export function createThrusterExhaustScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/triPlanarNormal.ts
+++ b/packages/game/src/ts/playgrounds/triPlanarNormal.ts
@@ -53,7 +53,7 @@ import normalMapPath from "@assets/testNormal.webp";
 
 export async function createTriPlanarNormalScene(
     engine: AbstractEngine,
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/src/ts/playgrounds/tutorial.ts
+++ b/packages/game/src/ts/playgrounds/tutorial.ts
@@ -32,7 +32,7 @@ import { initI18n } from "@/i18n";
 export async function createTutorialScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
 

--- a/packages/game/src/ts/playgrounds/xr.ts
+++ b/packages/game/src/ts/playgrounds/xr.ts
@@ -39,7 +39,7 @@ import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";
 export async function createXrScene(
     engine: AbstractEngine,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    progressMonitor: ILoadingProgressMonitor | null,
+    progressMonitor: ILoadingProgressMonitor,
 ): Promise<Scene> {
     const scene = new Scene(engine);
     scene.useRightHandedSystem = true;

--- a/packages/game/tests/e2e/asteroidField.spec.ts
+++ b/packages/game/tests/e2e/asteroidField.spec.ts
@@ -7,7 +7,7 @@ test("The asteroid field playground renders correctly", async ({ page }) => {
         scene: "asteroidField",
         shotName: "baseline",
         flagToWait: "frozen",
-        urlParams: { freeze: 3 },
+        urlParams: { freeze: 5 },
     });
 });
 


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

When loading a save, progress bar would stay empty, which is not great for the player.

Now it will fill up with the progress of loading the star system

Also progress monitor is now mandatory in the API, making the code more straightforward

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

Load a game

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

None

<!--
What should we do next to take advantage of this work?
-->
