### PR TITLE
Upgrade to pnpm 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ If you want the cutting edge version, follow these steps:
 1. Install prerequisites:
 
 - [Git](https://git-scm.com/) (install with your package manager or from https://git-scm.com/downloads)
-- [Node.js](https://nodejs.org/) (version 20 or higher)
-- [Pnpm](https://pnpm.io/) (install with `npm install -g pnpm`)
+- [Node.js](https://nodejs.org/) (version 24 or higher)
+- [Pnpm](https://pnpm.io/) (use the version pinned in `package.json`, for example with `corepack enable`)
 
 2. Clone the repo with `git clone https://github.com/BarthPaleologue/CosmosJourneyer.git`
 3. Install the dependencies with `pnpm install`
@@ -162,14 +162,14 @@ Cosmos Journeyer is built using the following technologies:
 
 ### Setup
 
-1. Install [Node.js](https://nodejs.org/)
-2. Install [Pnpm](https://pnpm.io/installation)
+1. Install [Node.js](https://nodejs.org/) 24 or higher
+2. Enable [Corepack](https://nodejs.org/api/corepack.html) with `corepack enable` so Node uses the pnpm version pinned in `package.json`
 3. Clone the repository with `git clone https://github.com/BarthPaleologue/CosmosJourneyer.git`
 4. Navigate to the project directory with `cd CosmosJourneyer`
 5. Install the dependencies with `pnpm install`
    (this also sets up Git hooks for formatting changed files before commit.
-   For pnpm 10 and later, hooks are installed because Husky is listed in
-   `onlyBuiltDependencies`.)
+   For pnpm 11 and later, hooks are installed because Husky is listed in
+   `allowBuilds`.)
 
 ### Repository layout
 

--- a/package.json
+++ b/package.json
@@ -73,12 +73,5 @@
     "engines": {
         "node": ">=24.0.0"
     },
-    "packageManager": "pnpm@10.18.0",
-    "pnpm": {
-        "onlyBuiltDependencies": [
-            "electron",
-            "electron-winstaller",
-            "husky"
-        ]
-    }
+    "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,15 @@
 packages:
     - packages/*
 
+allowBuilds:
+    "@parcel/watcher": true
+    electron: true
+    electron-winstaller: true
+    esbuild: true
+    husky: true
+    sharp: true
+    unrs-resolver: true
+
 catalog:
     "@eslint/js": ^10.0.1
     "@next/eslint-plugin-next": ^16.2.3


### PR DESCRIPTION
## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Description

In this day and age of supply chain attacks, pnpm 11 adds nice defaults to disable exotic transitive deps and add a delay before installing the newest version of a package.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Unexpected difficulties

None

<!--
Did you encounter unexpected difficulties while making this PR?
Tell us about it, and what you did to overcome them!
-->

## How to test

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Follow-up

Keep watching the supply chain attack news

<!--
What should we do next to take advantage of this work?
-->
