### PR TITLE
Remove non-landable bodies from havok physics

### DIFF
--- a/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
+++ b/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
@@ -18,13 +18,10 @@
 import { type Camera } from "@babylonjs/core/Cameras/camera";
 import type { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { type Material } from "@babylonjs/core/Materials/material";
-import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Quaternion } from "@babylonjs/core/Maths/math.vector";
 import { type TransformNode } from "@babylonjs/core/Meshes";
 import { type Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { PhysicsShapeSphere } from "@babylonjs/core/Physics/v2/physicsShape";
 import { type Scene } from "@babylonjs/core/scene";
 import { EarthRadius } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
@@ -56,8 +53,6 @@ export class GasPlanet implements CelestialBodyBase<"gasPlanet">, Cullable {
     private readonly mesh: Mesh;
     readonly material: GasPlanetProceduralMaterial | Material;
 
-    readonly aggregate: PhysicsAggregate;
-
     readonly atmosphereUniforms: AtmosphereUniforms;
 
     readonly ringsUniforms: RingsUniforms | null;
@@ -87,20 +82,6 @@ export class GasPlanet implements CelestialBodyBase<"gasPlanet">, Cullable {
             scene,
         );
         this.mesh.rotationQuaternion = Quaternion.Identity();
-
-        this.aggregate = new PhysicsAggregate(
-            this.getTransform(),
-            PhysicsShapeType.CONTAINER,
-            {
-                mass: 0,
-                restitution: 0.2,
-            },
-            scene,
-        );
-        this.aggregate.body.setMassProperties({ inertia: Vector3.Zero(), mass: 0 });
-        this.aggregate.body.disablePreStep = false;
-        const physicsShape = new PhysicsShapeSphere(Vector3.Zero(), this.model.radius, scene);
-        this.aggregate.shape.addChildFromParent(this.getTransform(), physicsShape, this.mesh);
 
         if (this.model.colorPalette.type === "procedural") {
             this.material = new GasPlanetProceduralMaterial(
@@ -164,7 +145,6 @@ export class GasPlanet implements CelestialBodyBase<"gasPlanet">, Cullable {
 
     public dispose(ringsLutPool: ItemPool<RingsProceduralPatternLut>): void {
         this.mesh.dispose();
-        this.aggregate.dispose();
         this.material.dispose();
         this.asteroidField?.dispose();
         this.ringsUniforms?.dispose(ringsLutPool);

--- a/packages/game/src/ts/frontend/universe/stellarObjects/neutronStar/neutronStar.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/neutronStar/neutronStar.ts
@@ -17,13 +17,10 @@
 
 import { type Camera } from "@babylonjs/core/Cameras/camera";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
-import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Quaternion } from "@babylonjs/core/Maths/math.vector";
 import { type TransformNode } from "@babylonjs/core/Meshes";
 import { type Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { PhysicsShapeSphere } from "@babylonjs/core/Physics/v2/physicsShape";
 import { type Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import { type NeutronStarModel } from "@cosmos-journeyer/universe-model";
@@ -58,8 +55,6 @@ export class NeutronStar implements CelestialBodyBase<"neutronStar">, Cullable, 
 
     private readonly material: StarMaterial;
 
-    readonly aggregate: PhysicsAggregate;
-
     readonly volumetricLightUniforms = new VolumetricLightUniforms();
 
     readonly ringsUniforms: RingsUniforms | null;
@@ -85,20 +80,6 @@ export class NeutronStar implements CelestialBodyBase<"neutronStar">, Cullable, 
             scene,
         );
         this.mesh.rotationQuaternion = Quaternion.Identity();
-
-        this.aggregate = new PhysicsAggregate(
-            this.getTransform(),
-            PhysicsShapeType.CONTAINER,
-            {
-                mass: 0,
-                restitution: 0.2,
-            },
-            scene,
-        );
-        this.aggregate.body.setMassProperties({ inertia: Vector3.Zero(), mass: 0 });
-        this.aggregate.body.disablePreStep = false;
-        const physicsShape = new PhysicsShapeSphere(Vector3.Zero(), this.model.radius, scene);
-        this.aggregate.shape.addChildFromParent(this.getTransform(), physicsShape, this.mesh);
 
         const starColor = getRgbFromTemperature(this.model.blackBodyTemperature);
         this.emissiveColor = new Color3(starColor.r, starColor.g, starColor.b);
@@ -158,7 +139,6 @@ export class NeutronStar implements CelestialBodyBase<"neutronStar">, Cullable, 
     }
 
     public dispose(ringsLutPool: ItemPool<RingsProceduralPatternLut>): void {
-        this.aggregate.dispose();
         this.mesh.dispose();
         this.material.dispose();
         this.asteroidField?.dispose();

--- a/packages/game/src/ts/frontend/universe/stellarObjects/star/star.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/star/star.ts
@@ -17,12 +17,10 @@
 
 import { type Camera } from "@babylonjs/core/Cameras/camera";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
-import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Quaternion } from "@babylonjs/core/Maths/math.vector";
 import { type TransformNode } from "@babylonjs/core/Meshes";
 import { type Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { type Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import { type StarModel } from "@cosmos-journeyer/universe-model";
@@ -53,8 +51,6 @@ export class Star implements CelestialBodyBase<"star">, Cullable, LightEmitter {
 
     private readonly emissiveColor: Color3;
 
-    readonly aggregate: PhysicsAggregate;
-
     readonly volumetricLightUniforms = new VolumetricLightUniforms();
 
     readonly ringsUniforms: RingsUniforms | null;
@@ -84,18 +80,6 @@ export class Star implements CelestialBodyBase<"star">, Cullable, LightEmitter {
             scene,
         );
         this.mesh.rotationQuaternion = Quaternion.Identity();
-
-        this.aggregate = new PhysicsAggregate(
-            this.getTransform(),
-            PhysicsShapeType.SPHERE,
-            {
-                mass: 0,
-                restitution: 0.2,
-            },
-            scene,
-        );
-        this.aggregate.body.setMassProperties({ inertia: Vector3.Zero(), mass: 0 });
-        this.aggregate.body.disablePreStep = false;
 
         const starColor = getRgbFromTemperature(this.model.blackBodyTemperature);
         this.emissiveColor = new Color3(starColor.r, starColor.g, starColor.b);
@@ -155,7 +139,6 @@ export class Star implements CelestialBodyBase<"star">, Cullable, LightEmitter {
     }
 
     public dispose(ringsLutPool: ItemPool<RingsProceduralPatternLut>): void {
-        this.aggregate.dispose();
         this.material.dispose();
         this.asteroidField?.dispose();
         this.ringsUniforms?.dispose(ringsLutPool);


### PR DESCRIPTION
## What does this do?

As lens-flare occlusion no longer relies on physics raycasts, we no longer need physics bodies for stars and gas planets.

Moreover, those extra bodies allowed for ship landing, which lead to funny situations where landing on a neutron star and driving around its surface were absolutely possible.

Having less bodies means havok will consume less cpu time so that should improve performance a little bit.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## How to test?

Try to land on a neutron star, won't work!

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Interesting findings / surprises / setbacks

None

<!--
Did you encounter unexpected difficulties while making this PR?
Was there something that surprised you?
Tell us about it, and what you did to overcome them!
-->

## AI Usage

### Tooling and model

Codex gpt 5.6 sol medium

<!--
What AI tooling did you use? Example: Codex, Claude Code, GitHub Copilot, OpenCode...
What model did you use the tool with? Example: GPT5.5 high, Claude Opus 4.8 xhigh...
-->

### Usage

Review

<!--
Describe your usage of said tool. Example: code review, investigation, refactoring, line completion...
-->

## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What's next?

Thermal management will prevent players from getting to close to a neutron star surface in the first place.

<!--
What should we do next to take advantage of this work?
-->
