### PR TITLE
Fix TKL keyboards not being able to use camera presets

### DIFF
--- a/packages/game/src/ts/frontend/spaceship/spaceShipControlsInputs.ts
+++ b/packages/game/src/ts/frontend/spaceship/spaceShipControlsInputs.ts
@@ -97,43 +97,43 @@ const nextMissionInteraction = new PressInteraction(
 
 const resetCameraInteraction = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad0")],
+        bindings: [keyboard.getControl("Numpad0"), keyboard.getControl("Digit0")],
     }),
 );
 
 const switchToCameraPreset1 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad1")],
+        bindings: [keyboard.getControl("Numpad1"), keyboard.getControl("Digit1")],
     }),
 );
 
 const switchToCameraPreset2 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad2")],
+        bindings: [keyboard.getControl("Numpad2"), keyboard.getControl("Digit2")],
     }),
 );
 
 const switchToCameraPreset3 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad3")],
+        bindings: [keyboard.getControl("Numpad3"), keyboard.getControl("Digit3")],
     }),
 );
 
 const switchToCameraPreset4 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad4")],
+        bindings: [keyboard.getControl("Numpad4"), keyboard.getControl("Digit4")],
     }),
 );
 
 const switchToCameraPreset5 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad5")],
+        bindings: [keyboard.getControl("Numpad5"), keyboard.getControl("Digit5")],
     }),
 );
 
 const switchToCameraPreset6 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad6")],
+        bindings: [keyboard.getControl("Numpad6"), keyboard.getControl("Digit6")],
     }),
 );
 

--- a/packages/game/src/ts/frontend/vehicle/vehicleControlsInputs.ts
+++ b/packages/game/src/ts/frontend/vehicle/vehicleControlsInputs.ts
@@ -59,30 +59,30 @@ const toggleDoorsAction = new Action({
 });
 
 const resetCameraAction = new Action({
-    bindings: [keyboard.getControl("Numpad0")],
+    bindings: [keyboard.getControl("Numpad0"), keyboard.getControl("Digit0")],
 });
 
 const switchToCameraPreset1 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad1")],
+        bindings: [keyboard.getControl("Numpad1"), keyboard.getControl("Digit1")],
     }),
 );
 
 const switchToCameraPreset2 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad2")],
+        bindings: [keyboard.getControl("Numpad2"), keyboard.getControl("Digit2")],
     }),
 );
 
 const switchToCameraPreset3 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad3")],
+        bindings: [keyboard.getControl("Numpad3"), keyboard.getControl("Digit3")],
     }),
 );
 
 const switchToCameraPreset4 = new PressInteraction(
     new Action({
-        bindings: [keyboard.getControl("Numpad4")],
+        bindings: [keyboard.getControl("Numpad4"), keyboard.getControl("Digit4")],
     }),
 );
 


### PR DESCRIPTION
## What does this do?

TKL can't use camera presets bound to numpad keys.

Until bindings are remappable, also use the digit row for camera presets


<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## How to test?

- control spaceship, rover
- press top row keys
- should cycle between camera presets

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Interesting findings / surprises / setbacks

None

<!--
Did you encounter unexpected difficulties while making this PR?
Was there something that surprised you?
Tell us about it, and what you did to overcome them!
-->

## AI Usage

### Tooling and model

Codex GPT 5.6 Sol medium

<!--
What AI tooling did you use? Example: Codex, Claude Code, GitHub Copilot, OpenCode...
What model did you use the tool with? Example: GPT5.5 high, Claude Opus 4.8 xhigh...
-->

### Usage

All code editing

<!--
Describe your usage of said tool. Example: code review, investigation, refactoring, line completion...
-->

## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What's next?

#521 

<!--
What should we do next to take advantage of this work?
-->
