### PR TITLE
Bump release version to 1.11.1

### DIFF
--- a/.github/workflows/deploy-game-release.yml
+++ b/.github/workflows/deploy-game-release.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
         inputs:
             version:
-                description: "Release version, e.g. 1.11.0"
+                description: "Release version, e.g. 1.11.1"
                 required: true
                 type: string
             dry_run:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cosmos-journeyer",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "private": true,
     "description": "Cosmos Journeyer is a space exploration game featuring fully explorable planets, across millions of star systems. It is built using Babylon.JS, and a lot of passion.",
     "keywords": [

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/desktop-electron",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "private": true,
     "description": "Electron desktop shell for Cosmos Journeyer.",
     "homepage": "https://cosmosjourneyer.com",

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/game",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "private": true,
     "description": "Cosmos Journeyer is a space exploration game featuring fully explorable planets, across millions of star systems. It is built using Babylon.JS, and a lot of passion.",
     "keywords": [

--- a/packages/physics/package.json
+++ b/packages/physics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/physics",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "private": true,
     "description": "Pure physics formulas, constants, and unit conversions shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/typescript",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "private": true,
     "description": "Generic TypeScript helper types and functions shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/universe-generation/package.json
+++ b/packages/universe-generation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/universe-generation",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "private": true,
     "description": "Pure procedural universe model generators shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/universe-model/package.json
+++ b/packages/universe-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/universe-model",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "private": true,
     "description": "Universe data models, schemas, and canonical derived accessors shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/website/src/siteConfig.ts
+++ b/packages/website/src/siteConfig.ts
@@ -1,6 +1,6 @@
 const repositoryUrl = "https://github.com/BarthPaleologue/CosmosJourneyer";
 const contactEmail = "barth.paleologue@cosmosjourneyer.com";
-const desktopReleaseVersion = "1.11.0";
+const desktopReleaseVersion = "1.11.1";
 const desktopReleaseUrl = `${repositoryUrl}/releases/download/v${desktopReleaseVersion}`;
 
 export const siteConfig = {


### PR DESCRIPTION
### Motivation

- Prepare a patch release by advancing the project and release-aligned workspace packages from `1.11.0` to `1.11.1` so website downloads and release tooling target the new artifacts. 
- Keep release metadata consistent across manifests and the website so CI and the release workflow validate and publish the correct version.

### Description

- Updated the `version` field from `1.11.0` to `1.11.1` in the root `package.json` and workspace packages: `@cosmos-journeyer/game`, `@cosmos-journeyer/desktop-electron`, `@cosmos-journeyer/physics`, `@cosmos-journeyer/typescript`, `@cosmos-journeyer/universe-generation`, and `@cosmos-journeyer/universe-model`.
- Updated the website desktop release target by changing `desktopReleaseVersion` to `1.11.1` in `packages/website/src/siteConfig.ts`, which updates the generated desktop download URLs.
- Updated the example release-version text in the release workflow `/.github/workflows/deploy-game-release.yml` to reference `1.11.1`.
- Note: `packages/terrain-generation` remains at its independent version (`1.8.0`) and there are third-party occurrences of `1.11.0` in lockfiles that do not represent this repo's release version.

### Testing

- Ran `pnpm install --frozen-lockfile` and `pnpm format:check` successfully to validate installs and formatting.
- Ran `pnpm test:unit` and package unit tests completed successfully across the workspace (`vitest` and Rust unit tests for `terrain-generation` passed).
- Ran `pnpm lint` which completed with warnings only (no lint errors) and `pnpm format:check` passed.
- Validated manifests and website config with a small script that confirmed all edited JSON/TS release references use `1.11.1`, however `pnpm build` and `pnpm test:e2e` could not complete in this environment because `wasm-pack` is not available and a checked-in WASM placeholder cannot be rebuilt here, causing the full build/E2E steps to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68552afe708328870cde67e01140e4)