### PR TITLE
Fix desktop auto-updater & bump packages to v1.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cosmos-journeyer",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "private": true,
     "description": "Cosmos Journeyer is a space exploration game featuring fully explorable planets, across millions of star systems. It is built using Babylon.JS, and a lot of passion.",
     "keywords": [

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/desktop-electron",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "private": true,
     "description": "Electron desktop shell for Cosmos Journeyer.",
     "homepage": "https://cosmosjourneyer.com",
@@ -50,7 +50,7 @@
         "appId": "com.cosmosjourneyer",
         "productName": "Cosmos Journeyer",
         "executableName": "cosmos-journeyer",
-        "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+        "artifactName": "Cosmos-Journeyer-${version}-${os}-${arch}.${ext}",
         "publish": {
             "provider": "github",
             "owner": "BarthPaleologue",

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/game",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "private": true,
     "description": "Cosmos Journeyer is a space exploration game featuring fully explorable planets, across millions of star systems. It is built using Babylon.JS, and a lot of passion.",
     "keywords": [

--- a/packages/physics/package.json
+++ b/packages/physics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/physics",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "private": true,
     "description": "Pure physics formulas, constants, and unit conversions shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/typescript",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "private": true,
     "description": "Generic TypeScript helper types and functions shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/universe-generation/package.json
+++ b/packages/universe-generation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/universe-generation",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "private": true,
     "description": "Pure procedural universe model generators shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/universe-model/package.json
+++ b/packages/universe-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/universe-model",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "private": true,
     "description": "Universe data models, schemas, and canonical derived accessors shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/website/src/siteConfig.ts
+++ b/packages/website/src/siteConfig.ts
@@ -1,6 +1,6 @@
 const repositoryUrl = "https://github.com/BarthPaleologue/CosmosJourneyer";
 const contactEmail = "barth.paleologue@cosmosjourneyer.com";
-const desktopReleaseVersion = "1.11.1";
+const desktopReleaseVersion = "1.11.2";
 const desktopReleaseUrl = `${repositoryUrl}/releases/download/v${desktopReleaseVersion}`;
 
 export const siteConfig = {
@@ -25,22 +25,22 @@ export const siteConfig = {
             {
                 platform: "Windows",
                 detail: "x64 · .exe",
-                url: `${desktopReleaseUrl}/Cosmos.Journeyer-${desktopReleaseVersion}-win-x64.exe`,
+                url: `${desktopReleaseUrl}/Cosmos-Journeyer-${desktopReleaseVersion}-win-x64.exe`,
             },
             {
                 platform: "macOS",
                 detail: "Apple Silicon · .dmg",
-                url: `${desktopReleaseUrl}/Cosmos.Journeyer-${desktopReleaseVersion}-mac-arm64.dmg`,
+                url: `${desktopReleaseUrl}/Cosmos-Journeyer-${desktopReleaseVersion}-mac-arm64.dmg`,
             },
             {
                 platform: "Debian / Ubuntu",
                 detail: "amd64 · .deb",
-                url: `${desktopReleaseUrl}/Cosmos.Journeyer-${desktopReleaseVersion}-linux-amd64.deb`,
+                url: `${desktopReleaseUrl}/Cosmos-Journeyer-${desktopReleaseVersion}-linux-amd64.deb`,
             },
             {
                 platform: "Other Linux",
                 detail: "x86_64 · AppImage",
-                url: `${desktopReleaseUrl}/Cosmos.Journeyer-${desktopReleaseVersion}-linux-x86_64.AppImage`,
+                url: `${desktopReleaseUrl}/Cosmos-Journeyer-${desktopReleaseVersion}-linux-x86_64.AppImage`,
             },
         ],
     },


### PR DESCRIPTION
### Motivation
- Prepare a new patch release by bumping package versions to `1.11.2` across the monorepo.
- Ensure the desktop release artifact name is consistent and predictable for published assets.
- Keep the website download links and displayed release version in sync with the packaged artifact naming.

### Description
- Incremented the version from `1.11.1` to `1.11.2` in `package.json` files for the root project and packages (`@cosmos-journeyer/desktop-electron`, `@cosmos-journeyer/game`, `@cosmos-journeyer/physics`, `@cosmos-journeyer/typescript`, `@cosmos-journeyer/universe-generation`, and `@cosmos-journeyer/universe-model`).
- Changed the `artifactName` in `packages/desktop-electron/package.json` from `${productName}-${version}-${os}-${arch}.${ext}` to `Cosmos-Journeyer-${version}-${os}-${arch}.${ext}` to produce release files with a stable filename prefix.
- Updated `packages/website/src/siteConfig.ts` to set `desktopReleaseVersion` to `1.11.2` and adjusted the desktop download URLs to match the new artifact naming format.

### Testing
- Ran workspace type checking with `pnpm -w -r typecheck`, which completed successfully.
- Executed unit tests where available with `pnpm -w -r test:unit` (`vitest`), and the tests passed.
- Built the desktop package with the repository build script (`pnpm --filter @cosmos-journeyer/desktop-electron build`) to validate the packaging changes, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a687fabb718832895b853a2a95e5f17)