### PR TITLE
Configure weekly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+
+  - package-ecosystem: "cargo"
+    directory: "/packages/terrain-generation"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       time: "06:00"
       timezone: "Europe/Paris"
 
+  - package-ecosystem: "uv"
+    directory: "/packages/gaia-explorer"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+
   - package-ecosystem: "cargo"
     directory: "/packages/terrain-generation"
     schedule:


### PR DESCRIPTION
## What changed

- add a weekly Dependabot schedule for the pnpm/npm workspace at the repository root
- add a weekly Dependabot schedule for the Gaia Explorer uv project in `packages/gaia-explorer`
- add a weekly Dependabot schedule for the Rust crate in `packages/terrain-generation`
- add a weekly Dependabot schedule for GitHub Actions
- run updates every Monday at 06:00 in the `Europe/Paris` timezone

## Notes

The repository currently declares `pnpm@11.1.2`. GitHub's documented Dependabot support currently lists pnpm through version 10, so the npm ecosystem job should be monitored after merge for compatibility with pnpm 11 and pnpm catalogs.

Gaia Explorer contains both `pyproject.toml` and `uv.lock`, and GitHub supports uv through `package-ecosystem: "uv"`.

## Validation

- configuration follows Dependabot version update schema v2
- target directories match the repository's npm/pnpm, uv, Cargo, and GitHub Actions dependency files