### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,8 +74,6 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Paris"
-    cooldown:
-      semver-major-days: 14
     groups:
       minor-patch:
         applies-to: "version-updates"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,29 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Paris"
+    cooldown:
+      semver-major-days: 14
+    groups:
+      babylonjs:
+        applies-to: "version-updates"
+        patterns:
+          - "@babylonjs/*"
+        exclude-patterns:
+          - "@babylonjs/havok"
+
+      production-minor-patch:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+
+      development-minor-patch:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "uv"
     directory: "/packages/gaia-explorer"
@@ -15,6 +38,16 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Paris"
+    cooldown:
+      semver-major-days: 14
+    groups:
+      minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "cargo"
     directory: "/packages/terrain-generation"
@@ -23,6 +56,16 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Paris"
+    cooldown:
+      semver-major-days: 14
+    groups:
+      minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -31,3 +74,13 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Paris"
+    cooldown:
+      semver-major-days: 14
+    groups:
+      minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- group BabylonJS version updates while keeping `@babylonjs/havok` separate
- group npm minor and patch updates by production versus development dependency type
- group minor and patch updates for uv, Cargo, and GitHub Actions
- add a 14-day cooldown for major version updates

## Why

The current configuration opens many independent dependency PRs, including separate PRs for tightly coupled BabylonJS packages. This change reduces PR and CI noise while preserving isolated review of unrelated major upgrades.

Security updates remain unaffected by version-update groups and cooldowns.

## Validation

- parsed the resulting file as YAML
- confirmed the branch is one commit ahead of `main`
- confirmed `.github/dependabot.yml` is the only changed file
