### PR TITLE
Fix atomic save snapshot

### DIFF
--- a/packages/game/src/ts/frontend/cosmosJourneyer.spec.ts
+++ b/packages/game/src/ts/frontend/cosmosJourneyer.spec.ts
@@ -1,0 +1,90 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
+import { UniverseBackend } from "@/backend/universe/universeBackend";
+
+import { makeScreenshotPng } from "@/frontend/helpers/screenshot";
+import { Player } from "@/frontend/player/player";
+
+import { CosmosJourneyer } from "./cosmosJourneyer";
+
+vi.mock("@/frontend/helpers/screenshot", () => ({
+    bytesToDataUrl: vi.fn(() => "data:image/png;base64,thumbnail"),
+    downloadPng: vi.fn(),
+    makeScreenshotPng: vi.fn(),
+}));
+
+describe("CosmosJourneyer", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("snapshots the player before awaiting thumbnail creation", async () => {
+        const systemModel = getLoneStarSystem();
+        const universeBackend = new UniverseBackend(systemModel);
+        const player = Player.Default(universeBackend);
+        const serializedSpaceship = player.serializedSpaceships[0];
+        const stellarObject = systemModel.stellarObjects[0];
+        if (serializedSpaceship === undefined) {
+            throw new Error("Default player has no spaceship");
+        }
+
+        let resolveScreenshot: ((value: Uint8Array) => void) | undefined;
+        const screenshotPromise = new Promise<Uint8Array>((resolve) => {
+            resolveScreenshot = resolve;
+        });
+        vi.mocked(makeScreenshotPng).mockReturnValue(screenshotPromise);
+
+        const spaceship = {
+            id: serializedSpaceship.id,
+            isLandedAtFacility: () => false,
+        };
+        const context = {
+            activeView: {
+                getMainScene: () => ({ activeCamera: {} }),
+            },
+            engine: {},
+            getCurrentUniverseCoordinates: () => ({
+                type: "relative",
+                universeObjectId: {
+                    systemCoordinates: systemModel.coordinates,
+                    idInSystem: stellarObject.id,
+                },
+                position: { x: 0, y: 0, z: 0 },
+                rotation: { x: 0, y: 0, z: 0, w: 1 },
+            }),
+            player,
+            starSystemView: {
+                getSpaceshipControls: () => ({
+                    getSpaceship: () => spaceship,
+                    getTransform: () => ({}),
+                }),
+            },
+        } as unknown as CosmosJourneyer;
+
+        const savePromise = CosmosJourneyer.prototype.generateSaveData.call(context);
+
+        player.serializedSpaceships.length = 0;
+        resolveScreenshot?.(new Uint8Array());
+
+        const save = await savePromise;
+        expect(save.player.spaceShips).toEqual([serializedSpaceship]);
+    });
+});

--- a/packages/game/src/ts/frontend/cosmosJourneyer.ts
+++ b/packages/game/src/ts/frontend/cosmosJourneyer.ts
@@ -494,7 +494,7 @@ export class CosmosJourneyer {
             notificationManager,
         );
 
-        await starSystemView.resetPlayer();
+        await starSystemView.resetPlayer(player);
 
         const keyboardLayoutMap = await getGlobalKeyboardLayoutMap();
 
@@ -806,19 +806,7 @@ export class CosmosJourneyer {
               }
             : shipUniverseCoordinates;
 
-        const camera = this.activeView.getMainScene().activeCamera;
-        let thumbnailDataUrl: string | undefined = undefined;
-        if (camera !== null) {
-            const thumbnailBytes = await makeScreenshotPng(this.engine, camera, {
-                size: {
-                    width: 256,
-                    height: 144,
-                },
-            });
-            thumbnailDataUrl = bytesToDataUrl(thumbnailBytes, "image/png");
-        }
-
-        return {
+        const saveData: Save = {
             uuid: crypto.randomUUID(),
             timestamp: Date.now(),
             player: Player.Serialize(this.player),
@@ -829,8 +817,22 @@ export class CosmosJourneyer {
             shipLocations: {
                 [spaceship.id]: shipLocation,
             },
-            thumbnail: thumbnailDataUrl,
         };
+
+        const camera = this.activeView.getMainScene().activeCamera;
+        if (camera === null) {
+            return saveData;
+        }
+
+        const thumbnailBytes = await makeScreenshotPng(this.engine, camera, {
+            size: {
+                width: 256,
+                height: 144,
+            },
+        });
+
+        saveData.thumbnail = bytesToDataUrl(thumbnailBytes, "image/png");
+        return saveData;
     }
 
     public async createManualSave(): Promise<boolean> {
@@ -948,8 +950,7 @@ export class CosmosJourneyer {
         this.loadingProgressMonitor.reset();
         this.engine.loadingScreen.displayLoadingUI();
 
-        this.player.copyFrom(Player.Default(this.backend.universe), this.backend.universe);
-        await this.starSystemView.resetPlayer();
+        await this.starSystemView.resetPlayer(Player.Default(this.backend.universe));
         this.starSystemView.setUIEnabled(false);
         await this.mainMenu.init();
         this.starSystemView.initStarSystem(Date.now() / 1000);
@@ -1000,11 +1001,10 @@ export class CosmosJourneyer {
         }
 
         const newPlayer = Player.Deserialize(saveData.player, this.backend.universe);
-        this.player.copyFrom(newPlayer, this.backend.universe);
+        await this.starSystemView.resetPlayer(newPlayer);
         this.player.discoveries.uploaded.forEach(async (discovery) => {
             await this.backend.encyclopaedia.contributeDiscoveryIfNew(discovery);
         });
-        await this.starSystemView.resetPlayer();
 
         this.loadingProgressMonitor.reset();
         this.engine.loadingScreen.displayLoadingUI();

--- a/packages/game/src/ts/frontend/starSystemView.spec.ts
+++ b/packages/game/src/ts/frontend/starSystemView.spec.ts
@@ -1,0 +1,132 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
+import { UniverseBackend } from "@/backend/universe/universeBackend";
+
+import { Player } from "@/frontend/player/player";
+import { Spaceship } from "@/frontend/spaceship/spaceship";
+
+import { StarSystemView } from "./starSystemView";
+
+describe("StarSystemView", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("atomically replaces the player and spaceship controls after instantiation", async () => {
+        const universeBackend = new UniverseBackend(getLoneStarSystem());
+        const player = Player.Default(universeBackend);
+        const nextPlayer = Player.Default(universeBackend);
+        const currentPlayerUuid = player.uuid;
+        const currentSpaceshipSerialized = player.serializedSpaceships[0];
+        const nextSpaceshipSerialized = nextPlayer.serializedSpaceships[0];
+        if (currentSpaceshipSerialized === undefined || nextSpaceshipSerialized === undefined) {
+            throw new Error("Default player has no spaceship");
+        }
+
+        const spaceship = { aggregate: {} } as unknown as Spaceship;
+        let resolveDeserialization: ((spaceship: Spaceship) => void) | undefined;
+        vi.spyOn(Spaceship, "Deserialize").mockReturnValue(
+            new Promise<Spaceship>((resolve) => {
+                resolveDeserialization = resolve;
+            }),
+        );
+
+        const oldSpaceship = { dispose: vi.fn() };
+        const spaceshipControls = {
+            getCameras: () => [],
+            getSpaceship: () => oldSpaceship,
+            reset: vi.fn(),
+            setSpaceship: vi.fn(),
+        };
+        const context = {
+            assets: {},
+            characterControls: {},
+            defaultControls: { getCameras: () => [] },
+            interactionSystem: { register: vi.fn() },
+            physicsEngine: {},
+            player,
+            postProcessManager: { reset: vi.fn() },
+            scene: {},
+            setActiveControls: vi.fn(),
+            soundPlayer: {},
+            spaceshipControls,
+            targetCursorLayer: { addObjects: vi.fn() },
+            universeBackend,
+            vehicleControls: { getCameras: () => [] },
+        } as unknown as StarSystemView;
+
+        const resetPromise = StarSystemView.prototype.resetPlayer.call(context, nextPlayer);
+
+        expect(player.uuid).toBe(currentPlayerUuid);
+        expect(player.serializedSpaceships).toEqual([currentSpaceshipSerialized]);
+        expect(spaceshipControls.getSpaceship()).toBe(oldSpaceship);
+
+        resolveDeserialization?.(spaceship);
+        await resetPromise;
+
+        expect(player.uuid).toBe(nextPlayer.uuid);
+        expect(player.serializedSpaceships).toEqual([]);
+        expect(player.instancedSpaceships).toEqual([spaceship]);
+        expect(nextPlayer.serializedSpaceships).toEqual([nextSpaceshipSerialized]);
+        expect(spaceshipControls.setSpaceship).toHaveBeenCalledWith(spaceship);
+        expect(oldSpaceship.dispose).toHaveBeenCalled();
+    });
+
+    it("keeps the current player when the replacement spaceship cannot be instantiated", async () => {
+        const universeBackend = new UniverseBackend(getLoneStarSystem());
+        const player = Player.Default(universeBackend);
+        const nextPlayer = Player.Default(universeBackend);
+        const currentSpaceshipSerialized = player.serializedSpaceships[0];
+        const nextSpaceshipSerialized = nextPlayer.serializedSpaceships[0];
+        if (currentSpaceshipSerialized === undefined || nextSpaceshipSerialized === undefined) {
+            throw new Error("Default player has no spaceship");
+        }
+
+        let rejectDeserialization: ((reason: Error) => void) | undefined;
+        const deserializationPromise = new Promise<Spaceship>((_resolve, reject) => {
+            rejectDeserialization = reject;
+        });
+        vi.spyOn(Spaceship, "Deserialize").mockReturnValue(deserializationPromise);
+
+        const context = {
+            assets: {},
+            physicsEngine: {},
+            player,
+            scene: {},
+            soundPlayer: {},
+            universeBackend,
+        } as unknown as StarSystemView;
+
+        const resetPromise = StarSystemView.prototype.resetPlayer.call(context, nextPlayer);
+
+        expect(player.serializedSpaceships).toEqual([currentSpaceshipSerialized]);
+        expect(nextPlayer.serializedSpaceships).toEqual([nextSpaceshipSerialized]);
+
+        const expectedError = new Error("Spaceship deserialization failed");
+        const rejectionExpectation = expect(resetPromise).rejects.toBe(expectedError);
+        rejectDeserialization?.(expectedError);
+        await rejectionExpectation;
+
+        expect(player.serializedSpaceships).toEqual([currentSpaceshipSerialized]);
+        expect(player.instancedSpaceships).toEqual([]);
+        expect(nextPlayer.serializedSpaceships).toEqual([nextSpaceshipSerialized]);
+    });
+});

--- a/packages/game/src/ts/frontend/starSystemView.ts
+++ b/packages/game/src/ts/frontend/starSystemView.ts
@@ -660,10 +660,21 @@ export class StarSystemView implements View {
     }
 
     /**
-     * Call this when the player object is changed when loading a save.
-     * It will remove the current controls and recreate them based on the player object.
+     * Instantiates the incoming player's spaceship before atomically replacing the current player and controls.
      */
-    public async resetPlayer() {
+    public async resetPlayer(nextPlayer: Player) {
+        const spaceshipSerialized = nextPlayer.serializedSpaceships[0];
+        if (spaceshipSerialized === undefined) throw new Error("No spaceship serialized in player");
+
+        const spaceship = await Spaceship.Deserialize(
+            spaceshipSerialized,
+            nextPlayer.spareSpaceshipComponents,
+            this.scene,
+            this.assets,
+            this.soundPlayer,
+            this.physicsEngine,
+        );
+
         this.postProcessManager.reset();
 
         const maxZ = Settings.EARTH_RADIUS * 1e5;
@@ -676,17 +687,11 @@ export class StarSystemView implements View {
 
         this.vehicleControls.getCameras().forEach((camera) => (camera.maxZ = maxZ));
 
-        const spaceshipSerialized = this.player.serializedSpaceships.shift();
-        if (spaceshipSerialized === undefined) throw new Error("No spaceship serialized in player");
+        if (nextPlayer !== this.player) {
+            this.player.copyFrom(nextPlayer, this.universeBackend);
+        }
 
-        const spaceship = await Spaceship.Deserialize(
-            spaceshipSerialized,
-            this.player.spareSpaceshipComponents,
-            this.scene,
-            this.assets,
-            this.soundPlayer,
-            this.physicsEngine,
-        );
+        this.player.serializedSpaceships.shift();
         this.player.instancedSpaceships.push(spaceship);
 
         this.targetCursorLayer.addObjects([spaceship]);

--- a/packages/game/src/ts/playgrounds/customSystem.ts
+++ b/packages/game/src/ts/playgrounds/customSystem.ts
@@ -100,7 +100,7 @@ export async function createCustomSystemScene(
         progressMonitor,
     );
 
-    await starSystemView.resetPlayer();
+    await starSystemView.resetPlayer(player);
 
     await starSystemView.switchToSpaceshipControls();
 

--- a/packages/game/src/ts/playgrounds/starSystemView.ts
+++ b/packages/game/src/ts/playgrounds/starSystemView.ts
@@ -82,7 +82,7 @@ export async function createStarSystemViewScene(
         progressMonitor,
     );
 
-    await starSystemView.resetPlayer();
+    await starSystemView.resetPlayer(player);
 
     await starSystemView.switchToSpaceshipControls();
 


### PR DESCRIPTION
## What does this do?

Fix for #785 

The PR closes the window of opportunity for the spaceship array to be empty at save time.

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## How to test?

- Create a save on an existing commander
- Edit the save to empty the spaceship array
- Load the broken save
- The game should still be able to load

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Interesting findings / surprises / setbacks

`await` thingies should happen either at the begining or end of a serialization process, but not in the middle!

<!--
Did you encounter unexpected difficulties while making this PR?
Was there something that surprised you?
Tell us about it, and what you did to overcome them!
-->

## AI Usage

### Tooling and model

Codex with GPT 5.6 Sol medium

<!--
What AI tooling did you use? Example: Codex, Claude Code, GitHub Copilot, OpenCode...
What model did you use the tool with? Example: GPT5.5 high, Claude Opus 4.8 xhigh...
-->

### Usage

Investigation, fix implementation

<!--
Describe your usage of said tool. Example: code review, investigation, refactoring, line completion...
-->

## Related Tickets

Fixes #785 

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->
