### PR TITLE
Align save thumbnails in loading panel

### DIFF
--- a/packages/game/src/styles/saveLoadingPanelContent.css
+++ b/packages/game/src/styles/saveLoadingPanelContent.css
@@ -66,10 +66,12 @@
                 background: linear-gradient(90deg, var(--cmdr-color) 10px, rgba(0, 0, 0, 0.5) 10px);
                 padding: 20px;
                 display: flex;
-                justify-content: space-between;
+                column-gap: 40px;
 
                 .saveText {
                     display: flex;
+                    flex: 1 1 0;
+                    min-width: 0;
                     flex-direction: column;
                     justify-content: center;
                     row-gap: 10px;


### PR DESCRIPTION
## What changed

- replace `justify-content: space-between` with a fixed `column-gap`
- let `.saveText` absorb the remaining horizontal space using `flex: 1 1 0`
- add `min-width: 0` so long save text does not push thumbnails out of alignment

## Why

Save rows contain text, a thumbnail, and action buttons. Because the text width varies between saves, `space-between` gives each row different spacing and shifts thumbnails horizontally.

The text column now owns the flexible space, keeping thumbnails and action buttons aligned across rows.

Before:

<img width="1214" height="626" alt="image" src="https://github.com/user-attachments/assets/057a75ce-1159-4036-9667-fc892b102cdb" />

After:

<img width="1204" height="629" alt="image" src="https://github.com/user-attachments/assets/f1d499cb-e63e-463c-9598-40d700268a1c" />

## Validation

- visually tested in the save loading panel
- branch diff contains only `packages/game/src/styles/saveLoadingPanelContent.css`