### PR TITLE
chore: bump workspace version to 1.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cosmos-journeyer",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "private": true,
     "description": "Cosmos Journeyer is a space exploration game featuring fully explorable planets, across millions of star systems. It is built using Babylon.JS, and a lot of passion.",
     "keywords": [

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/desktop-electron",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "private": true,
     "description": "Electron desktop shell for Cosmos Journeyer.",
     "homepage": "https://cosmosjourneyer.com",

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/game",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "private": true,
     "description": "Cosmos Journeyer is a space exploration game featuring fully explorable planets, across millions of star systems. It is built using Babylon.JS, and a lot of passion.",
     "keywords": [

--- a/packages/physics/package.json
+++ b/packages/physics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/physics",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "private": true,
     "description": "Pure physics formulas, constants, and unit conversions shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/typescript",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "private": true,
     "description": "Generic TypeScript helper types and functions shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/universe-generation/package.json
+++ b/packages/universe-generation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/universe-generation",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "private": true,
     "description": "Pure procedural universe model generators shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/universe-model/package.json
+++ b/packages/universe-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cosmos-journeyer/universe-model",
-    "version": "1.11.2",
+    "version": "1.11.3",
     "private": true,
     "description": "Universe data models, schemas, and canonical derived accessors shared across Cosmos Journeyer packages.",
     "license": "AGPL-3.0-only",

--- a/packages/website/src/siteConfig.ts
+++ b/packages/website/src/siteConfig.ts
@@ -1,6 +1,6 @@
 const repositoryUrl = "https://github.com/BarthPaleologue/CosmosJourneyer";
 const contactEmail = "barth.paleologue@cosmosjourneyer.com";
-const desktopReleaseVersion = "1.11.2";
+const desktopReleaseVersion = "1.11.3";
 const desktopReleaseUrl = `${repositoryUrl}/releases/download/v${desktopReleaseVersion}`;
 
 export const siteConfig = {


### PR DESCRIPTION
### Motivation

- Prepare and publish the next patch release by updating the workspace and release-aligned packages to `1.11.3` so consumers and the website point to the new desktop release.

### Description

- Bumped the workspace `version` to `1.11.3` in the root `package.json` and in the package manifests for `@cosmos-journeyer/desktop-electron`, `@cosmos-journeyer/game`, `@cosmos-journeyer/physics`, `@cosmos-journeyer/typescript`, `@cosmos-journeyer/universe-generation`, and `@cosmos-journeyer/universe-model`.
- Updated the website configuration `packages/website/src/siteConfig.ts` by setting `desktopReleaseVersion` to `"1.11.3"` so download URLs target the `v1.11.3` release.
- Ensured formatting consistency with `oxfmt` on the changed files.

### Testing

- Ran `pnpm -r test:unit` and observed unit tests complete successfully across the workspace.
- Ran `pnpm -r lint` which completed with warnings but no errors (lint passed overall).
- Ran `pnpm exec oxfmt --check` on the changed files and confirmed formatting is correct.
- Attempted `pnpm -r build` which failed in this environment due to a missing `wasm-pack` dependency required by the `terrain-generation` package, unrelated to the version bumps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a746fc0ba848328a9354fb0531eec27)