### PR TITLE
Detach tutorial state from save snapshots

### DIFF
--- a/packages/game/src/ts/frontend/cosmosJourneyer.spec.ts
+++ b/packages/game/src/ts/frontend/cosmosJourneyer.spec.ts
@@ -82,9 +82,11 @@ describe("CosmosJourneyer", () => {
         const savePromise = CosmosJourneyer.prototype.generateSaveData.call(context);
 
         player.serializedSpaceships.length = 0;
+        player.tutorials.flightCompleted = true;
         resolveScreenshot?.(new Uint8Array());
 
         const save = await savePromise;
         expect(save.player.spaceShips).toEqual([serializedSpaceship]);
+        expect(save.player.tutorials.flightCompleted).toBe(false);
     });
 });

--- a/packages/game/src/ts/frontend/player/player.ts
+++ b/packages/game/src/ts/frontend/player/player.ts
@@ -1,6 +1,6 @@
 //  This file is part of Cosmos Journeyer
 //
-//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//  Copyright (C) 2024 Barthémy Paléologue <barth.paleologue@cosmosjourneyer.com>
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Affero General Public License as published by
@@ -110,20 +110,10 @@ export class Player {
         this.tutorials = serializedPlayer.tutorials;
     }
 
-    /**
-     * Returns true if the player has visited the given object, false otherwise.
-     * @param objectId The object to check if the player has visited it.
-     * @returns True if the player has visited the object, false otherwise.
-     */
     hasVisitedObject(objectId: UniverseObjectId): boolean {
         return this.visitedObjects.has(serializeUniverseObjectId(objectId));
     }
 
-    /**
-     * Adds the given object to the list of visited objects if it is not already in the list.
-     * @param objectId The object to add to the list of visited objects.
-     * @returns True if the object was added, false if it was already in the list.
-     */
     addVisitedObjectIfNew(objectId: UniverseObjectId) {
         if (this.hasVisitedObject(objectId)) {
             return false;
@@ -198,14 +188,10 @@ export class Player {
                 player.instancedSpaceships.map((spaceship) => spaceship.serialize()),
             ),
             spareSpaceshipComponents: Array.from(player.spareSpaceshipComponents),
-            tutorials: player.tutorials,
+            tutorials: structuredClone(player.tutorials),
         };
     }
 
-    /**
-     * Performs a deep copy of the player
-     * @param player the player to copy from
-     */
     public copyFrom(player: Player, universeBackend: UniverseBackend) {
         this.uuid = player.uuid;
         this.setName(player.getName());

--- a/packages/game/src/ts/frontend/player/player.ts
+++ b/packages/game/src/ts/frontend/player/player.ts
@@ -1,6 +1,6 @@
 //  This file is part of Cosmos Journeyer
 //
-//  Copyright (C) 2024 Barthémy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Affero General Public License as published by
@@ -110,10 +110,20 @@ export class Player {
         this.tutorials = serializedPlayer.tutorials;
     }
 
+    /**
+     * Returns true if the player has visited the given object, false otherwise.
+     * @param objectId The object to check if the player has visited it.
+     * @returns True if the object is visited, false if it is not.
+     */
     hasVisitedObject(objectId: UniverseObjectId): boolean {
         return this.visitedObjects.has(serializeUniverseObjectId(objectId));
     }
 
+    /**
+     * Adds the given object to the list of visited objects if it is not already in the list.
+     * @param objectId The object to add to the list of visited objects.
+     * @returns True if the object was added, false if it was already in the list.
+     */
     addVisitedObjectIfNew(objectId: UniverseObjectId) {
         if (this.hasVisitedObject(objectId)) {
             return false;
@@ -192,6 +202,10 @@ export class Player {
         };
     }
 
+    /**
+     * Performs a deep copy of the player
+     * @param player the player to copy from
+     */
     public copyFrom(player: Player, universeBackend: UniverseBackend) {
         this.uuid = player.uuid;
         this.setName(player.getName());


### PR DESCRIPTION
## What changed

- Deep-clone tutorial completion state when serializing a player.
- Extend the delayed-thumbnail save regression test to mutate a tutorial flag while screenshot generation is pending.

## Why

`generateSaveData()` captures player state before awaiting thumbnail generation, but `Player.Serialize()` previously retained the live `tutorials` object by reference. A tutorial completion callback during screenshot generation could therefore mutate the captured save after its timestamp and other fields had been recorded.

## Impact

Save snapshots now remain detached from subsequent tutorial-state mutations, matching the atomic behavior already covered for serialized spaceships.

## Validation

- Added a regression assertion to `cosmosJourneyer.spec.ts`.
- Type compatibility is covered by the project's existing `structuredClone` usage and DOM/WebWorker TypeScript libraries.

Full local test execution was unavailable in this environment because the GitHub CLI and a network-accessible checkout were not available.