### PR TITLE
Reuse Git LFS cache for desktop packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         timeout-minutes: 40
         outputs:
             desktop-packaging-changed: ${{ steps.desktop-packaging-changes.outputs.desktop-packaging }}
+            git-lfs-cache-key: ${{ steps.git-lfs-cache-key.outputs.key }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
@@ -48,8 +49,9 @@ jobs:
               uses: actions/cache@v6
               with:
                   path: .git/lfs
-                  key: git-lfs-${{ runner.os }}-${{ steps.git-lfs-cache-key.outputs.key }}
-                  restore-keys: git-lfs-${{ runner.os }}-
+                  key: git-lfs-${{ steps.git-lfs-cache-key.outputs.key }}
+                  restore-keys: git-lfs-
+                  enableCrossOsArchive: true
 
             - name: Pull Git LFS assets
               run: git lfs pull
@@ -130,7 +132,18 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v7
               with:
-                  lfs: true
+                  lfs: false
+
+            - name: Restore Git LFS objects
+              uses: actions/cache/restore@v6
+              with:
+                  path: .git/lfs
+                  key: git-lfs-${{ needs.checks.outputs.git-lfs-cache-key }}
+                  restore-keys: git-lfs-
+                  enableCrossOsArchive: true
+
+            - name: Pull missing Git LFS assets
+              run: git lfs pull
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v6


### PR DESCRIPTION
## What changed

- expose the Git LFS cache key from the `checks` job
- make the LFS cache key OS-independent and enable cross-OS archives
- change desktop packaging checkouts to `lfs: false`
- restore the cache produced by `checks` in each desktop packaging runner
- run `git lfs pull` afterwards so only missing objects are downloaded

## Why

`package-desktop` previously used `actions/checkout` with `lfs: true` on macOS, Ubuntu, and Windows. Each runner therefore fetched the LFS objects directly from GitHub before any cache could be restored, consuming LFS bandwidth multiple times for the same workflow run.

The `checks` job already downloads and caches the complete `.git/lfs` object store. Reusing that cache allows the three desktop jobs to consume the cached copy instead of downloading the same objects again.

## Impact

For the current ~101 MiB LFS object set, a desktop CI run should generally reduce GitHub LFS downloads from roughly four copies (checks + three packaging jobs) to roughly one copy on a cold cache, and close to zero when the shared cache is already warm. `git lfs pull` remains as a fallback for any missing objects.

## Validation

- diff is limited to `.github/workflows/ci.yml`
- branch is one commit ahead of `main`
- uses `actions/cache` cross-OS archive support for the Windows packaging runner
