### PR TITLE
Cache Git LFS assets across GitHub Actions

### DIFF
--- a/.github/actions/setup-lfs/action.yml
+++ b/.github/actions/setup-lfs/action.yml
@@ -1,0 +1,29 @@
+name: Setup Git LFS cache
+description: Restore cached Git LFS objects and download only missing assets.
+
+outputs:
+    cache-key:
+        description: Cache key derived from the Git LFS object IDs in the checkout.
+        value: ${{ steps.git-lfs-cache-key.outputs.key }}
+
+runs:
+    using: composite
+    steps:
+        - name: Compute Git LFS cache key
+          id: git-lfs-cache-key
+          shell: bash
+          run: |
+              key="$(git lfs ls-files --long | LC_ALL=C sort | git hash-object --stdin)"
+              echo "key=$key" >> "$GITHUB_OUTPUT"
+
+        - name: Cache Git LFS objects
+          uses: actions/cache@v6
+          with:
+              path: .git/lfs
+              key: git-lfs-${{ steps.git-lfs-cache-key.outputs.key }}
+              restore-keys: git-lfs-
+              enableCrossOsArchive: true
+
+        - name: Pull missing Git LFS assets
+          shell: bash
+          run: git lfs pull

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         timeout-minutes: 40
         outputs:
             desktop-packaging-changed: ${{ steps.desktop-packaging-changes.outputs.desktop-packaging }}
-            git-lfs-cache-key: ${{ steps.git-lfs-cache-key.outputs.key }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
@@ -33,28 +32,15 @@ jobs:
               with:
                   filters: |
                       desktop-packaging:
+                          - ".github/actions/setup-lfs/**"
                           - ".github/workflows/ci.yml"
                           - "package.json"
                           - "pnpm-lock.yaml"
                           - "pnpm-workspace.yaml"
                           - "packages/desktop-electron/**"
 
-            - name: Compute Git LFS cache key
-              id: git-lfs-cache-key
-              run: |
-                  git lfs ls-files --long | sort | sha256sum | cut -d " " -f 1 > /tmp/git-lfs-cache-key
-                  echo "key=$(cat /tmp/git-lfs-cache-key)" >> "$GITHUB_OUTPUT"
-
-            - name: Cache Git LFS objects
-              uses: actions/cache@v6
-              with:
-                  path: .git/lfs
-                  key: git-lfs-${{ steps.git-lfs-cache-key.outputs.key }}
-                  restore-keys: git-lfs-
-                  enableCrossOsArchive: true
-
-            - name: Pull Git LFS assets
-              run: git lfs pull
+            - name: Setup Git LFS assets
+              uses: ./.github/actions/setup-lfs
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v6
@@ -134,16 +120,8 @@ jobs:
               with:
                   lfs: false
 
-            - name: Restore Git LFS objects
-              uses: actions/cache/restore@v6
-              with:
-                  path: .git/lfs
-                  key: git-lfs-${{ needs.checks.outputs.git-lfs-cache-key }}
-                  restore-keys: git-lfs-
-                  enableCrossOsArchive: true
-
-            - name: Pull missing Git LFS assets
-              run: git lfs pull
+            - name: Setup Git LFS assets
+              uses: ./.github/actions/setup-lfs
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v6

--- a/.github/workflows/deploy-game-release.yml
+++ b/.github/workflows/deploy-game-release.yml
@@ -30,7 +30,10 @@ jobs:
               uses: actions/checkout@v7
               with:
                   ref: ${{ github.sha }}
-                  lfs: true
+                  lfs: false
+
+            - name: Setup Git LFS assets
+              uses: ./.github/actions/setup-lfs
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v6
@@ -103,7 +106,10 @@ jobs:
               uses: actions/checkout@v7
               with:
                   ref: ${{ github.sha }}
-                  lfs: true
+                  lfs: false
+
+            - name: Setup Git LFS assets
+              uses: ./.github/actions/setup-lfs
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v6

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,7 +28,10 @@ jobs:
               uses: actions/checkout@v7
               with:
                   ref: ${{ github.sha }}
-                  lfs: true
+                  lfs: false
+
+            - name: Setup Git LFS assets
+              uses: ./.github/actions/setup-lfs
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v6

--- a/.github/workflows/main-preview-game.yml
+++ b/.github/workflows/main-preview-game.yml
@@ -18,9 +18,13 @@ jobs:
         timeout-minutes: 10
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v7
+            - name: Checkout repository
+              uses: actions/checkout@v7
               with:
-                  lfs: true
+                  lfs: false
+
+            - name: Setup Git LFS assets
+              uses: ./.github/actions/setup-lfs
 
             - name: Setup Node.js with pnpm
               uses: pnpm/action-setup@v6


### PR DESCRIPTION
## What does this do?

This PR centralizes Git LFS setup in a reusable composite action and uses it across CI, main preview, website deployment, and game release workflows.

The shared action:
- computes a deterministic cache key from the LFS object IDs referenced by the checkout;
- restores `.git/lfs` through `actions/cache` with cross-OS support;
- falls back to older `git-lfs-` caches when the exact asset set changed;
- runs `git lfs pull` so only missing LFS objects are downloaded from GitHub LFS.

`main-preview-game.yml` now seeds the canonical cache on `main`, allowing pull requests and deployment workflows to reuse it. The existing inline CI cache logic is replaced by the same shared action to keep behavior consistent everywhere.

The desktop packaging path filter also includes `.github/actions/setup-lfs/**`, so changes to the shared action exercise Ubuntu, macOS, and Windows packaging in CI.

## How to test?

1. Let the PR CI complete and verify the `checks` job successfully restores/pulls Git LFS assets.
2. Verify desktop packaging runs on Ubuntu, macOS, and Windows for this PR.
3. After merge, verify the main preview run creates a `git-lfs-*` cache under `refs/heads/main`.
4. Open or rerun a subsequent PR without LFS changes and verify the LFS cache restores before `git lfs pull`, avoiding a full Git LFS download.
5. For deployment workflows, run a dry-run deployment and confirm the same cache path is restored before building.

## Interesting findings / surprises / setbacks

The existing CI cache key used `sha256sum`, which is not portable to the default macOS runner. The shared action instead hashes the sorted LFS object list with `git hash-object --stdin`, keeping the key deterministic while working anywhere Git is available.

The release workflow previously used `lfs: true` independently in the game build and each Electron matrix job, which could cause repeated LFS downloads when no reusable cache was available.

## AI Usage

### Tooling and model

ChatGPT, GPT-5.6 Sol.

### Usage

Repository inspection, GitHub Actions design, implementation, and PR preparation.

## What's next?

A follow-up PR can reduce the amount of work further by filtering LFS paths per product and narrowing build scope where appropriate. Those semantic optimizations are intentionally kept separate from this infrastructure-only change.