### PR TITLE
Enable no-implicit-coercion ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,6 +109,8 @@ const typeScriptWorkspaceRules = {
         // enforce braces around control flow statements
         curly: "error",
 
+        "no-implicit-coercion": "error",
+
         "@typescript-eslint/switch-exhaustiveness-check": "error",
         "@typescript-eslint/no-inferrable-types": "error",
         "@typescript-eslint/require-array-sort-compare": "error",

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingBay/landingBay.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingBay/landingBay.ts
@@ -263,7 +263,7 @@ export class LandingBay {
                         color: new Color3(1, 1, 0.8),
                         upDirection: landingPadUp,
                         range: 50 * landingPad.getPadSize(),
-                        lampSize: 1 * landingPad.getPadSize(),
+                        lampSize: landingPad.getPadSize(),
                         postHeight: 10 * landingPad.getPadSize(),
                         postDiameter: 0.4 * landingPad.getPadSize(),
                     });

--- a/packages/physics/src/gasGiants.spec.ts
+++ b/packages/physics/src/gasGiants.spec.ts
@@ -43,7 +43,7 @@ describe("getCoolGasGiantRadiusFromMass", () => {
     it("increases from sub-saturn masses up to about jovian masses", () => {
         const r01 = getCoolGasGiantRadiusFromMass(0.1 * JupiterMass);
         const r03 = getCoolGasGiantRadiusFromMass(0.3 * JupiterMass);
-        const r1 = getCoolGasGiantRadiusFromMass(1 * JupiterMass);
+        const r1 = getCoolGasGiantRadiusFromMass(JupiterMass);
 
         expect(r03).toBeGreaterThan(r01);
         expect(r1).toBeGreaterThan(r03);


### PR DESCRIPTION
## Summary
- enable ESLint's `no-implicit-coercion` rule for package JavaScript/TypeScript sources
- keep the change scoped to the existing `typeScriptWorkspaceRules` configuration

## Rationale
This prevents shorthand implicit conversions such as `!!value`, `+value`, and `"" + value`, favoring explicit conversions instead.