### PR TITLE
Render translated Markdown safely in UI and add markdown utility

### DIFF
--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -64,6 +64,7 @@
         "fast-simplex-noise": "^4.0.0",
         "fflate": "^0.8.3",
         "i18next": "^26.4.0",
+        "markdown-it": "^15.0.0",
         "qrcode": "^1.5.4",
         "squirrel-noise": "^1.0.0",
         "terrain-generation": "workspace:^",

--- a/packages/game/src/locales/en-US/common.json
+++ b/packages/game/src/locales/en-US/common.json
@@ -9,5 +9,5 @@
     "cancel": "Cancel",
     "confirm": "Confirm",
     "ok": "OK",
-    "unofficialOriginNotice": "This is not the official stable version of Cosmos Journeyer. Play the latest stable version at <a href=\"https://cosmosjourneyer.com\">cosmosjourneyer.com</a>."
+    "unofficialOriginNotice": "This is not the official stable version of Cosmos Journeyer. Play the latest stable version at [cosmosjourneyer.com](https://cosmosjourneyer.com)."
 }

--- a/packages/game/src/locales/en-US/sidePanel.json
+++ b/packages/game/src/locales/en-US/sidePanel.json
@@ -1,7 +1,7 @@
 {
     "loadSave": "Load a save",
     "dropASaveFileHere": "Drop a save file or Commander archive here",
-    "saveMigrationNotice": "Missing your Commanders? Saves are not synchronized automatically between websites. Check both <a href=\"https://cosmosjourneyer.com/game\">cosmosjourneyer.com</a> and the <a href=\"https://barthpaleologue.github.io/CosmosJourneyer/\">development version</a>. Download a Commander archive there, then import it here.",
+    "saveMigrationNotice": "Missing your Commanders? Saves are not synchronized automatically between websites. Check both [cosmosjourneyer.com](https://cosmosjourneyer.com/game) and the [development version](https://barthpaleologue.github.io/CosmosJourneyer/). Download a Commander archive there, then import it here.",
     "continueCommander": "Continue from this Commander's latest save",
     "shareCommander": "Copy a link to this Commander's latest save",
     "downloadCommanderArchive": "Download all saves for this Commander",
@@ -22,13 +22,13 @@
     "tutorialsWarning": "If this is your first time playing, you can simply start a new game: the tutorials will be naturally presented during the game!",
     "contribute": "Contribute",
     "bugReports": "Bug Reports",
-    "bugReportsText": "If you experience any bug during your exploration, please add it to the <a href=\"https://github.com/BarthPaleologue/CosmosJourneyer/issues\">issue tracker</a>. You can also send an email at <a href=\"mailto:barth.paleologue@cosmosjourneyer.com\">barth.paleologue@cosmosjourneyer.com</a>. Sending screenshots and save files can help enormously with the debugging process.",
+    "bugReportsText": "If you experience any bug during your exploration, please add it to the [issue tracker](https://github.com/BarthPaleologue/CosmosJourneyer/issues). You can also send an email at [barth.paleologue@cosmosjourneyer.com](mailto:barth.paleologue@cosmosjourneyer.com). Sending screenshots and save files can help enormously with the debugging process.",
     "translation": "Translation",
-    "translationText": "Translating Cosmos Journeyer makes it accessible to more people around the world! You don't need any coding skills, only proficiency in a language not currently supported or that can be enhanced. You can access the translation guide <a href=\"https://github.com/BarthPaleologue/CosmosJourneyer/blob/main/CONTRIBUTING.md#translation\">here</a>.",
+    "translationText": "Translating Cosmos Journeyer makes it accessible to more people around the world! You don't need any coding skills, only proficiency in a language not currently supported or that can be enhanced. You can access the translation guide [here](https://github.com/BarthPaleologue/CosmosJourneyer/blob/main/CONTRIBUTING.md#translation).",
     "knowHowToCode": "Know how to code?",
-    "knowHowToCodeText": "Cosmos Journeyer is an open-source project which means anyone can help build it! Why not you?\n You can check out <a target=\"_blank\" href=\"https://github.com/BarthPaleologue/CosmosJourneyer\">the repository of the project</a> for more details. Please take a look at the contributing guidelines before starting to contribute to Cosmos Journeyer.",
+    "knowHowToCodeText": "Cosmos Journeyer is an open-source project which means anyone can help build it! Why not you?\n You can check out [the repository of the project](https://github.com/BarthPaleologue/CosmosJourneyer) for more details. Please take a look at the contributing guidelines before starting to contribute to Cosmos Journeyer.",
     "supportFinancially": "Support financially",
-    "supportFinanciallyText": "Building Cosmos Journeyer takes a lot of time and effort while being free for everyone. Please consider sponsoring the project on <a target=\"_blank\" href=\"https://www.patreon.com/barthpaleologue\">Patreon</a> or <a target=\"_blank\" href=\"https://ko-fi.com/cosmosjourneyer\">Ko-fi</a>. Your support will help me dedicate more time to the project and make it even better!",
+    "supportFinanciallyText": "Building Cosmos Journeyer takes a lot of time and effort while being free for everyone. Please consider sponsoring the project on [Patreon](https://www.patreon.com/barthpaleologue) or [Ko-fi](https://ko-fi.com/cosmosjourneyer). Your support will help me dedicate more time to the project and make it even better!",
     "credits": "Credits",
     "contributors": "Contributors",
     "programming": "Programming",
@@ -43,5 +43,5 @@
     "specialThanks": "Special Thanks",
     "about": "About",
     "aboutText": "Hello fellow explorer!\nI am the creator of Cosmos Journeyer, and I am glad you're interested in this project. It was years in the making you see: back in 2016 already, when I was working on my 3D planetarium, I dreamed about making the planets fully explorable. But then I was limited by how little I knew about computer graphics.\n\nI only started Cosmos Journeyer years later as a way to escape from the stress of my studies in French \"classes préparatoires\". At first, it was only a small procedural planet generator, which was called PlanetEngine. But as ideas kept on coming, I continued working on it for years and the project grew way beyond what I had imagined at first.\n\nAs I understand now that such projects cannot be achieved alone, I decided to open-source Cosmos Journeyer so that anyone can freely use and modify it to their liking and even contribute to the project.\n\nI hope you will enjoy CosmosJourneyer as much as I enjoy making it!",
-    "emailContact": "If you have any question about Cosmos Journeyer, feel free to contact me at <a href=\"mailto:barth.paleologue@cosmosjourneyer.com\">barth.paleologue@cosmosjourneyer.com</a>"
+    "emailContact": "If you have any question about Cosmos Journeyer, feel free to contact me at [barth.paleologue@cosmosjourneyer.com](mailto:barth.paleologue@cosmosjourneyer.com)"
 }

--- a/packages/game/src/locales/en-US/tutorials/common.json
+++ b/packages/game/src/locales/en-US/tutorials/common.json
@@ -1,10 +1,10 @@
 {
     "moreWillComeSoon": "More tutorials will come in the future!",
-    "navigationInfo": "<p>To move forward in the tutorial, simply press {{nextKeys}}. You can go back to the previous panel by pressing {{previousKeys}}.</p>",
+    "navigationInfo": "To move forward in the tutorial, simply press {{nextKeys}}. You can go back to the previous panel by pressing {{previousKeys}}.",
     "quit": "Quit",
     "next": "Next",
     "previous": "Previous",
-    "tutorialEnding": "<p>This tutorial and others are available at any time from the main menu and the pause menu.</p><p>Press {{keyQuit}} to leave the tutorial.</p>",
+    "tutorialEnding": "This tutorial and others are available at any time from the main menu and the pause menu.\n\nPress {{keyQuit}} to leave the tutorial.",
     "loadTutorialWillLeaveGame": "Loading this tutorial will leave your current game. An autosave has just been made. Continue loading the tutorial?",
     "quitConfirm": "You are about to quit the tutorial. Are you sure?",
     "returnToMainMenuAfterTutorial": "You are currently in a tutorial save. No progress will be saved. Return to the main menu?"

--- a/packages/game/src/locales/en-US/tutorials/starMap.json
+++ b/packages/game/src/locales/en-US/tutorials/starMap.json
@@ -3,9 +3,9 @@
     "description": "Master interstellar travel with the star map.",
     "welcome": "This tutorial will teach you how to use the star map to master interstellar travel.",
     "open1": "Finding your way among the stars is not trivial without a map.",
-    "open2": "To open the star map, press <strong>{{keys}}</strong>.",
+    "open2": "To open the star map, press **{{keys}}**.",
     "open3": "Pressing the same key again will close the star map.",
-    "controls1": "You can drag the camera around the center of the view with the mouse. To translate the center of the view, use <strong>{{keys}}</strong>.",
+    "controls1": "You can drag the camera around the center of the view with the mouse. To translate the center of the view, use **{{keys}}**.",
     "controls2": "You can zoom with the mouse wheel, and nearby stars can be selected by clicking on them.",
     "missions1": "If you have ongoing missions, you can find your destinations thanks to the orange icons on the map.",
     "missions2": "You can click on the icon to target the system",
@@ -13,7 +13,7 @@
     "system2": "You can add it to your bookmarks by clicking the \"Bookmark\" button.",
     "system3": "To plot an itinerary, click on the \"Plot itinerary\" button. This will create a sequence of interstellar jumps for you to follow",
     "travel1": "To follow your itinerary, close the star map and align your ship with your target.",
-    "travel2": "Once aligned, press <strong>{{keys}}</strong> to warp to the system.",
+    "travel2": "Once aligned, press **{{keys}}** to warp to the system.",
     "travel3": "You can repeat this process until you reach your destination.",
     "congratulations": "Congratulations! You now know how to use the star map. I hope you will find it useful in your interstellar adventures!"
 }

--- a/packages/game/src/locales/fr-FR/common.json
+++ b/packages/game/src/locales/fr-FR/common.json
@@ -9,5 +9,5 @@
     "cancel": "Annuler",
     "confirm": "Confirmer",
     "ok": "OK",
-    "unofficialOriginNotice": "Ceci n'est pas la version stable officielle de Cosmos Journeyer. Jouez à la dernière version stable sur <a href=\"https://cosmosjourneyer.com\">cosmosjourneyer.com</a>."
+    "unofficialOriginNotice": "Ceci n'est pas la version stable officielle de Cosmos Journeyer. Jouez à la dernière version stable sur [cosmosjourneyer.com](https://cosmosjourneyer.com)."
 }

--- a/packages/game/src/locales/fr-FR/sidePanel.json
+++ b/packages/game/src/locales/fr-FR/sidePanel.json
@@ -1,7 +1,7 @@
 {
     "loadSave": "Charger une sauvegarde",
     "dropASaveFileHere": "Déposez une sauvegarde ou une archive de Commandant ici",
-    "saveMigrationNotice": "Vos Commandants sont introuvables ? Les sauvegardes ne sont pas synchronisées automatiquement entre les sites. Vérifiez à la fois <a href=\"https://cosmosjourneyer.com/game\">cosmosjourneyer.com</a> et <a href=\"https://barthpaleologue.github.io/CosmosJourneyer/\">la version de développement</a>. Téléchargez-y l'archive d'un Commandant, puis importez-la ici.",
+    "saveMigrationNotice": "Vos Commandants sont introuvables ? Les sauvegardes ne sont pas synchronisées automatiquement entre les sites. Vérifiez à la fois [cosmosjourneyer.com](https://cosmosjourneyer.com/game) et [la version de développement](https://barthpaleologue.github.io/CosmosJourneyer/). Téléchargez-y l'archive d'un Commandant, puis importez-la ici.",
     "continueCommander": "Continuer depuis la dernière sauvegarde de ce Commandant",
     "shareCommander": "Copier un lien vers la dernière sauvegarde de ce Commandant",
     "downloadCommanderArchive": "Télécharger toutes les sauvegardes de ce Commandant",
@@ -22,13 +22,13 @@
     "settings": "Paramètres",
     "contribute": "Contribuer",
     "bugReports": "Signaler un bug",
-    "bugReportsText": "Si vous rencontrez un bug lors de votre exploration, merci de l'ajouter au <a href=\"https://github.com/BarthPaleologue/CosmosJourneyer/issues\">tracker de bugs</a>. Vous pouvez aussi envoyer un email à <a href=\"mailto:barth.paleologue@cosmosjourneyer.com\">barth.paleologue@cosmosjourneyer.com</a>. Envoyer des captures d'écran et des fichiers de sauvegarde peut grandement aider le processus de débogage.",
+    "bugReportsText": "Si vous rencontrez un bug lors de votre exploration, merci de l'ajouter au [tracker de bugs](https://github.com/BarthPaleologue/CosmosJourneyer/issues). Vous pouvez aussi envoyer un email à [barth.paleologue@cosmosjourneyer.com](mailto:barth.paleologue@cosmosjourneyer.com). Envoyer des captures d'écran et des fichiers de sauvegarde peut grandement aider le processus de débogage.",
     "translation": "Traduction",
-    "translationText": "Traduire Cosmos Journeyer le rend accessible à plus de personnes à travers le monde ! Vous n'avez pas besoin de compétences en programmation, seulement d'une maîtrise d'une langue non supportée ou qui peut être améliorée. Vous pouvez accéder au guide de traduction <a href=\"https://github.com/BarthPaleologue/CosmosJourneyer/CONTRIBUTING.md#translation\">ici</a>.",
+    "translationText": "Traduire Cosmos Journeyer le rend accessible à plus de personnes à travers le monde ! Vous n'avez pas besoin de compétences en programmation, seulement d'une maîtrise d'une langue non supportée ou qui peut être améliorée. Vous pouvez accéder au guide de traduction [ici](https://github.com/BarthPaleologue/CosmosJourneyer/CONTRIBUTING.md#translation).",
     "knowHowToCode": "Vous savez coder ?",
-    "knowHowToCodeText": "Cosmos Journeyer est un projet open-source, ce qui signifie que n'importe qui peut aider à le construire ! Pourquoi pas vous ?\n Vous pouvez consulter <a target=\"_blank\" href=\"https://github.com/BarthPaleologue/CosmosJourneyer\">le dépôt du projet</a> pour plus de détails. Merci de lire les directives de contribution avant de commencer à contribuer à Cosmos Journeyer.",
+    "knowHowToCodeText": "Cosmos Journeyer est un projet open-source, ce qui signifie que n'importe qui peut aider à le construire ! Pourquoi pas vous ?\n Vous pouvez consulter [le dépôt du projet](https://github.com/BarthPaleologue/CosmosJourneyer) pour plus de détails. Merci de lire les directives de contribution avant de commencer à contribuer à Cosmos Journeyer.",
     "supportFinancially": "Soutenir financièrement",
-    "supportFinanciallyText": "Construire Cosmos Journeyer demande beaucoup de temps et d'efforts tout en étant gratuit pour tout le monde. Si le coeur vous en dit, vous pouvez sponsoriser le projet via <a target=\"_blank\" href=\"https://www.patreon.com/barthpaleologue\">Patreon</a> ou <a target=\"_blank\" href=\"https://ko-fi.com/cosmosjourneyer\">Ko-fi</a>. Votre soutien m'aidera à consacrer plus de temps au projet et à le rendre encore meilleur !",
+    "supportFinanciallyText": "Construire Cosmos Journeyer demande beaucoup de temps et d'efforts tout en étant gratuit pour tout le monde. Si le coeur vous en dit, vous pouvez sponsoriser le projet via [Patreon](https://www.patreon.com/barthpaleologue) ou [Ko-fi](https://ko-fi.com/cosmosjourneyer). Votre soutien m'aidera à consacrer plus de temps au projet et à le rendre encore meilleur !",
     "credits": "Crédits",
     "contributors": "Contributeurs",
     "programming": "Programmation",
@@ -41,5 +41,5 @@
     "specialThanks": "Remerciements",
     "about": "À propos",
     "aboutText": "Bienvenue cher explorateur !\nJe suis le créateur de Cosmos Journeyer, et je suis ravi que vous soyez intéressé. Longtemps, j'ai rêvé de faire ce project. En 2016 déjà lorsque je travaillais sur mon Planétarium en 3D, j'imaginais rendre les planètes entièrement explorables. Mais mes connaissances en informatique graphique étaient alors trop limitées.\n\nJ'ai commencé Cosmos Journeyer bien des années plus tard, comme une façon d'échapper au stress des concours des classes préparatoires. Cela a commencé par un petit générateur de planètes, que j'appelais PlanetEngine (\"moteur à planète\"). Mais plus je travaillais dessus, et plus j'avais des nouvelles idées. Après plus de 3 années de travail, je peux dire que le projet est allé bien au delà de ce que j'imaginais pouvoir faire au début.\n\nIl serait illusoire de penser que je puisse seul terminer Cosmos Journeyer un jour. C'est pourquoi j'ai décidé de rendre le projet open-source, afin que chacun puisse l'utiliser et le modifier à sa guise, et même contribuer au projet dans les années à venir.\n\nJ'espère que vous aimerez Cosmos Journeyer autant que j'aime le créer !",
-    "emailContact": "Si vous avez des questions sur Cosmos Journeyer, n'hésitez pas à me contacter à <a href=\"mailto:barth.paleologue@cosmosjourneyer.com\">barth.paleologue@cosmosjourneyer.com</a>"
+    "emailContact": "Si vous avez des questions sur Cosmos Journeyer, n'hésitez pas à me contacter à [barth.paleologue@cosmosjourneyer.com](mailto:barth.paleologue@cosmosjourneyer.com)"
 }

--- a/packages/game/src/locales/fr-FR/tutorials/common.json
+++ b/packages/game/src/locales/fr-FR/tutorials/common.json
@@ -1,10 +1,10 @@
 {
     "moreWillComeSoon": "Plus de tutoriels dans le futur !",
-    "navigationInfo": "<p>Pour avancer dans le tutoriel, appuyez sur {{nextKeys}}. Vous pouvez revenir aux étapes précédentes avec {{previousKeys}}.</p>",
+    "navigationInfo": "Pour avancer dans le tutoriel, appuyez sur {{nextKeys}}. Vous pouvez revenir aux étapes précédentes avec {{previousKeys}}.",
     "quit": "Quitter",
     "next": "Suivant",
     "previous": "Précédent",
-    "tutorialEnding": "<p>Ce tutoriel et d'autres sont disponibles à tout moment depuis le menu principal et le menu de pause.</p><p>Appuyez sur {{keyQuit}} pour quitter le tutoriel.</p>",
+    "tutorialEnding": "Ce tutoriel et d'autres sont disponibles à tout moment depuis le menu principal et le menu de pause.\n\nAppuyez sur {{keyQuit}} pour quitter le tutoriel.",
     "loadTutorialWillLeaveGame": "Charger ce tutoriel quittera votre partie actuelle. Une sauvegarde automatique vient d'être effectuée. Continuer de charger le tutoriel ?",
     "quitConfirm": "Vous êtes sur le point de quitter le tutoriel. Êtes-vous sûr ?",
     "returnToMainMenuAfterTutorial": "Vous êtes actuellement dans une sauvegarde de tutoriel. Aucune progression ne sera enregistrée. Revenir au menu principal ?"

--- a/packages/game/src/locales/fr-FR/tutorials/starMap.json
+++ b/packages/game/src/locales/fr-FR/tutorials/starMap.json
@@ -3,9 +3,9 @@
     "description": "Maîtrisez le voyage interstellaire avec la carte stellaire.",
     "welcome": "Ce tutoriel va vous apprendre comment utiliser la carte stellaire pour maîtriser le voyage interstellaire.",
     "open1": "Trouver son chemin parmi les étoiles peut se révéler délicat sans une carte.",
-    "open2": "Pour ouvrir la carte stellaire, appuyez sur <strong>{{keys}}</strong>.",
+    "open2": "Pour ouvrir la carte stellaire, appuyez sur **{{keys}}**.",
     "open3": "Appuyer à nouveau sur la même touche fermera la carte stellaire.",
-    "controls1": "Vous pouvez déplacer la caméra autour du centre de la vue avec la souris. Pour déplacer le centre de la vue, utilisez <strong>{{keys}}</strong>.",
+    "controls1": "Vous pouvez déplacer la caméra autour du centre de la vue avec la souris. Pour déplacer le centre de la vue, utilisez **{{keys}}**.",
     "controls2": "Vous pouvez zoomer avec la molette de la souris, et les étoiles proches peuvent être sélectionnées en cliquant dessus.",
     "missions1": "Si vous avez des missions en cours, vous pouvez trouver vos destinations grâce aux icônes oranges sur la carte.",
     "missions2": "Vous pouvez cliquer sur l'icône pour cibler le système",
@@ -13,7 +13,7 @@
     "system2": "Vous pouvez l'ajouter à vos favoris en cliquant sur le bouton \"Favoris\".",
     "system3": "Pour tracer un itinéraire, cliquez sur le bouton \"Tracer itinéraire\". Cela créera une séquence de sauts interstellaires à suivre",
     "travel1": "Pour suivre votre itinéraire, fermez la carte stellaire et alignez votre vaisseau avec votre cible.",
-    "travel2": "Une fois aligné, appuyez sur <strong>{{keys}}</strong> pour voyager vers le système.",
+    "travel2": "Une fois aligné, appuyez sur **{{keys}}** pour voyager vers le système.",
     "travel3": "Vous pouvez répéter ce processus jusqu'à ce que vous atteigniez votre destination.",
     "congratulations": "Félicitations ! Vous savez maintenant comment utiliser la carte stellaire. J'espère que vous la trouverez utile dans vos aventures spatiales !"
 }

--- a/packages/game/src/ts/frontend/ui/officialOriginNotice.spec.ts
+++ b/packages/game/src/ts/frontend/ui/officialOriginNotice.spec.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { isOfficialGameLocation } from "./officialOriginNotice";
+import { createOfficialOriginNotice, isOfficialGameLocation } from "./officialOriginNotice";
+
+vi.mock("@/i18n", () => ({
+    default: {
+        t: (): string => "Play at [cosmosjourneyer.com](https://cosmosjourneyer.com).",
+    },
+}));
 
 describe("isOfficialGameLocation", () => {
     it.each([
@@ -14,5 +20,14 @@ describe("isOfficialGameLocation", () => {
 
     it("rejects a third-party web origin", () => {
         expect(isOfficialGameLocation({ protocol: "https:", hostname: "barthpaleologue.github.io" })).toBe(false);
+    });
+
+    it("renders the translated Markdown link safely", () => {
+        const notice = createOfficialOriginNotice({ protocol: "https:", hostname: "example.com" });
+        const link = notice?.querySelector("a");
+
+        expect(link?.href).toBe("https://cosmosjourneyer.com/");
+        expect(link?.target).toBe("_blank");
+        expect(link?.rel).toBe("noopener");
     });
 });

--- a/packages/game/src/ts/frontend/ui/officialOriginNotice.ts
+++ b/packages/game/src/ts/frontend/ui/officialOriginNotice.ts
@@ -15,6 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { renderMarkdownInline } from "@/utils/markdown";
+
 import i18n from "@/i18n";
 
 export function isOfficialGameLocation(location: Pick<Location, "hostname" | "protocol">): boolean {
@@ -36,6 +38,6 @@ export function createOfficialOriginNotice(
 
     const notice = document.createElement("aside");
     notice.classList.add("officialOriginNotice");
-    notice.innerHTML = i18n.t("common:unofficialOriginNotice");
+    notice.innerHTML = renderMarkdownInline(i18n.t("common:unofficialOriginNotice"));
     return notice;
 }

--- a/packages/game/src/ts/frontend/ui/panels/aboutPanel.ts
+++ b/packages/game/src/ts/frontend/ui/panels/aboutPanel.ts
@@ -15,6 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { renderMarkdownInline } from "@/utils/markdown";
+
 import i18n from "@/i18n";
 
 export class AboutPanel {
@@ -50,7 +52,7 @@ export class AboutPanel {
         const emailText = document.createElement("p");
         emailText.className = "aboutText";
         emailText.style.whiteSpace = "pre-line"; // necessary to display \n in the text
-        emailText.innerHTML = i18n.t("sidePanel:emailContact");
+        emailText.innerHTML = renderMarkdownInline(i18n.t("sidePanel:emailContact"));
         panel.appendChild(emailText);
 
         // Special thanks section

--- a/packages/game/src/ts/frontend/ui/panels/contributePanel.ts
+++ b/packages/game/src/ts/frontend/ui/panels/contributePanel.ts
@@ -15,6 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { renderMarkdownInline } from "@/utils/markdown";
+
 import i18n from "@/i18n";
 
 export class ContributePanel {
@@ -39,7 +41,7 @@ export class ContributePanel {
         panel.appendChild(bugReportsHeader);
 
         const bugReportsText = document.createElement("p");
-        bugReportsText.innerHTML = i18n.t("sidePanel:bugReportsText");
+        bugReportsText.innerHTML = renderMarkdownInline(i18n.t("sidePanel:bugReportsText"));
         panel.appendChild(bugReportsText);
 
         // Translation section
@@ -48,7 +50,7 @@ export class ContributePanel {
         panel.appendChild(translationHeader);
 
         const translationText = document.createElement("p");
-        translationText.innerHTML = i18n.t("sidePanel:translationText");
+        translationText.innerHTML = renderMarkdownInline(i18n.t("sidePanel:translationText"));
         panel.appendChild(translationText);
 
         // Know how to code section
@@ -57,7 +59,7 @@ export class ContributePanel {
         panel.appendChild(codeHeader);
 
         const codeText = document.createElement("p");
-        codeText.innerHTML = i18n.t("sidePanel:knowHowToCodeText");
+        codeText.innerHTML = renderMarkdownInline(i18n.t("sidePanel:knowHowToCodeText"));
         panel.appendChild(codeText);
 
         // Support financially section
@@ -66,7 +68,7 @@ export class ContributePanel {
         panel.appendChild(supportHeader);
 
         const supportText = document.createElement("p");
-        supportText.innerHTML = i18n.t("sidePanel:supportFinanciallyText");
+        supportText.innerHTML = renderMarkdownInline(i18n.t("sidePanel:supportFinanciallyText"));
         panel.appendChild(supportText);
 
         return panel;

--- a/packages/game/src/ts/frontend/ui/saveLoadingPanelContent.ts
+++ b/packages/game/src/ts/frontend/ui/saveLoadingPanelContent.ts
@@ -13,6 +13,7 @@ import { alertModal, promptModalBoolean } from "@/frontend/ui/dialogModal";
 
 import { downloadBlob } from "@/utils/downloadBlob";
 import { downloadCommanderArchive } from "@/utils/downloadCommanderArchive";
+import { renderMarkdownInline } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
@@ -53,7 +54,7 @@ export class SaveLoadingPanelContent {
 
         const migrationNotice = document.createElement("p");
         migrationNotice.classList.add("saveMigrationNotice");
-        migrationNotice.innerHTML = i18n.t("sidePanel:saveMigrationNotice");
+        migrationNotice.innerHTML = renderMarkdownInline(i18n.t("sidePanel:saveMigrationNotice"));
         this.htmlRoot.appendChild(migrationNotice);
 
         const dropFileZone = document.createElement("div");

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/flightTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/flightTutorial.ts
@@ -27,6 +27,7 @@ import { SpaceShipControlsInputs } from "@/frontend//spaceship/spaceShipControls
 import { axisCompositeToString, pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
+import { renderMarkdownBlock } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
@@ -62,14 +63,17 @@ export class FlightTutorial implements Tutorial {
         <div class="tutorialContent">
             <img src="${welcomeImageSrc}" alt="Welcome to Cosmos Journeyer">
             <p>${i18n.t("tutorials:flightTutorial:welcome")}</p>
-            ${i18n.t("tutorials:common:navigationInfo", {
-                nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keybordLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-                previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keybordLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:navigationInfo", {
+                    nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keybordLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                    previousKeys: pressInteractionToStrings(
+                        TutorialControlsInputs.map.prevPanel,
+                        keybordLayoutMap,
+                    ).join(` ${i18n.t("common:or")} `),
+                }),
+            )}
         </div>`;
 
         const rotationPanelHtml = `
@@ -125,11 +129,13 @@ export class FlightTutorial implements Tutorial {
             <img src="${congratsImageSrc}" alt="Congratulations!">
             <p>${i18n.t("tutorials:flightTutorial:congratulationsText1")}</p>
             
-            ${i18n.t("tutorials:common:tutorialEnding", {
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keybordLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:tutorialEnding", {
+                    keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keybordLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                }),
+            )}
         </div>`;
 
         return [

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/fuelScoopTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/fuelScoopTutorial.ts
@@ -24,6 +24,7 @@ import { type UniverseBackend } from "@/backend/universe/universeBackend";
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
+import { renderMarkdownBlock } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
@@ -57,15 +58,18 @@ export class FuelScoopTutorial implements Tutorial {
             
             <p>${i18n.t("tutorials:fuelScooping:whatIsFuel")}</p>
             
-            ${i18n.t("tutorials:common:navigationInfo", {
-                // This displays a small internationalized text to explain the keys to navigate the tutorial
-                nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-                previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:navigationInfo", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                    previousKeys: pressInteractionToStrings(
+                        TutorialControlsInputs.map.prevPanel,
+                        keyboardLayoutMap,
+                    ).join(` ${i18n.t("common:or")} `),
+                }),
+            )}
         </div>`;
 
         const fuelManagement = `
@@ -81,13 +85,14 @@ export class FuelScoopTutorial implements Tutorial {
             
             <p>${i18n.t("tutorials:fuelScooping:howToFuelScoop")}</p>
             
-            <p>${i18n.t("tutorials:common:tutorialEnding", {
-                // This displays a small internationalized text to explain the keys to end the tutorial
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
-                </p>
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:tutorialEnding", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                }),
+            )}
         </div>`;
 
         return [presentationPanelHtml, fuelManagement, howToFuelScoopPanel];

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/planetaryLandingTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/planetaryLandingTutorial.ts
@@ -27,6 +27,7 @@ import { StarSystemInputs } from "@/frontend/inputs/starSystemInputs";
 import { SpaceShipControlsInputs } from "@/frontend/spaceship/spaceShipControlsInputs";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
+import { renderMarkdownBlock } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
@@ -72,15 +73,18 @@ export class PlanetaryLandingTutorial implements Tutorial {
             <img src="${welcomeImageSrc}" alt="Planetary landing welcome image">
             <p>${i18n.t("tutorials:planetaryLanding:welcome")}</p>
             
-            ${i18n.t("tutorials:common:navigationInfo", {
-                // This displays a small internationalized text to explain the keys to navigate the tutorial
-                nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-                previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:navigationInfo", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                    previousKeys: pressInteractionToStrings(
+                        TutorialControlsInputs.map.prevPanel,
+                        keyboardLayoutMap,
+                    ).join(` ${i18n.t("common:or")} `),
+                }),
+            )}
         </div>`;
 
         const gettingCloseToSurfacePanel = `
@@ -106,13 +110,14 @@ export class PlanetaryLandingTutorial implements Tutorial {
 
             <p>${i18n.t("tutorials:planetaryLanding:howToLiftoff", { keyLiftoff: spaceshipUpKeys })}</p>
             
-            <p>${i18n.t("tutorials:common:tutorialEnding", {
-                // This displays a small internationalized text to explain the keys to end the tutorial
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
-                </p>
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:tutorialEnding", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                }),
+            )}
         </div>`;
 
         return [presentationPanelHtml, gettingCloseToSurfacePanel, howToLandPanel];

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/starMapTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/starMapTutorial.ts
@@ -33,6 +33,7 @@ import { StarSystemInputs } from "@/frontend/inputs/starSystemInputs";
 import { StarMapInputs } from "@/frontend/starmap/starMapInputs";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
+import { escapeMarkdown, renderMarkdownBlock, renderMarkdownInline } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
@@ -69,15 +70,18 @@ export class StarMapTutorial implements Tutorial {
             <img src="${coverImgSrc}" alt="Welcome to Cosmos Journeyer">
             <p>${i18n.t("tutorials:starMap:welcome")}</p>
             
-            ${i18n.t("tutorials:common:navigationInfo", {
-                // This displays a small internationalized text to explain the keys to navigate the tutorial
-                nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-                previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:navigationInfo", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                    previousKeys: pressInteractionToStrings(
+                        TutorialControlsInputs.map.prevPanel,
+                        keyboardLayoutMap,
+                    ).join(` ${i18n.t("common:or")} `),
+                }),
+            )}
         </div>`;
 
         const toggleStarMapKeys = pressInteractionToStrings(GeneralInputs.map.toggleStarMap, keyboardLayoutMap).join(
@@ -86,8 +90,8 @@ export class StarMapTutorial implements Tutorial {
 
         const howToOpenPanelHtml = `
         <div class="tutorialContent">
-            <p>${i18n.t("tutorials:starMap:open1")}</p> 
-            <p>${i18n.t("tutorials:starMap:open2", { keys: toggleStarMapKeys })}</p> 
+            <p>${i18n.t("tutorials:starMap:open1")}</p>
+            <p>${renderMarkdownInline(i18n.t("tutorials:starMap:open2", { keys: escapeMarkdown(toggleStarMapKeys) }))}</p>
             <img src="${openImgSrc}" alt="Star map opening" class="tutorialImage">
             <p>${i18n.t("tutorials:starMap:open3")}</p>
         </div>`;
@@ -106,7 +110,7 @@ export class StarMapTutorial implements Tutorial {
 
         const howToUseStarMapPanelHtml = `
         <div class="tutorialContent">
-            <p>${i18n.t("tutorials:starMap:controls1", { keys })}</p>
+            <p>${renderMarkdownInline(i18n.t("tutorials:starMap:controls1", { keys: escapeMarkdown(keys) }))}</p>
             <img src="${controlsImgSrc}" alt="Star map controls" class="tutorialImage">
             <p>${i18n.t("tutorials:starMap:controls2")}</p>
         </div>`;
@@ -133,7 +137,7 @@ export class StarMapTutorial implements Tutorial {
         const howToInterstellarTravelPanelHtml = `
         <div class="tutorialContent">
             <p>${i18n.t("tutorials:starMap:travel1")}</p>
-            <p>${i18n.t("tutorials:starMap:travel2", { keys: jumpKeys })}</p>
+            <p>${renderMarkdownInline(i18n.t("tutorials:starMap:travel2", { keys: escapeMarkdown(jumpKeys) }))}</p>
             <img src="${jumpImgSrc}" alt="Interstellar jump" class="tutorialImage">
             <p>${i18n.t("tutorials:starMap:travel3")}</p>
         </div>`;
@@ -142,12 +146,16 @@ export class StarMapTutorial implements Tutorial {
         <div class="tutorialContent">
             <img src="${coverImgSrc}" alt="Welcome to Cosmos Journeyer">
             <p>${i18n.t("tutorials:starMap:congratulations")}</p>
-            ${i18n.t("tutorials:common:tutorialEnding", {
-                // This displays a small internationalized text to explain the keys to end the tutorial
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:tutorialEnding", {
+                    // Key labels come from the controlled input binding display API; escape them before Markdown interpolation.
+                    keyQuit: escapeMarkdown(
+                        pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                            ` ${i18n.t("common:or")} `,
+                        ),
+                    ),
+                }),
+            )}
         </div>`;
 
         return [

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/stationLandingTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/stationLandingTutorial.ts
@@ -26,6 +26,7 @@ import { SpaceShipControlsInputs } from "@/frontend/spaceship/spaceShipControlsI
 import { TutorialControlsInputs } from "@/frontend/ui/tutorial/tutorialLayerInputs";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
+import { renderMarkdownBlock } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
@@ -61,15 +62,18 @@ export class StationLandingTutorial implements Tutorial {
             
             <p>${i18n.t("tutorials:stationLanding:whatAreStations")}</p>
             
-            ${i18n.t("tutorials:common:navigationInfo", {
-                // This displays a small internationalized text to explain the keys to navigate the tutorial
-                nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-                previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:navigationInfo", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                    previousKeys: pressInteractionToStrings(
+                        TutorialControlsInputs.map.prevPanel,
+                        keyboardLayoutMap,
+                    ).join(` ${i18n.t("common:or")} `),
+                }),
+            )}
         </div>`;
 
         const landingRequestPanelHtml = `
@@ -104,13 +108,14 @@ export class StationLandingTutorial implements Tutorial {
             
             <p>${i18n.t("tutorials:stationLanding:services2")}</p>
             
-            <p>${i18n.t("tutorials:common:tutorialEnding", {
-                // This displays a small internationalized text to explain the keys to end the tutorial
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
-                </p>
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:tutorialEnding", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                }),
+            )}
         </div>`;
 
         return [presentationPanelHtml, landingRequestPanelHtml, landingPanelHtml, stationServicesPanelHtml];

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/templateTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/templateTutorial.ts
@@ -24,6 +24,7 @@ import { type UniverseBackend } from "@/backend/universe/universeBackend";
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
+import { renderMarkdownBlock } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
@@ -55,25 +56,30 @@ export class TemplateTutorial implements Tutorial {
             <img src="${welcomeImageSrc}" alt="Welcome to Cosmos Journeyer">
             <p>Welcome, Commander! This is a tutorial about tutorials! Now this is meta.</p>
             
-            ${i18n.t("tutorials:common:navigationInfo", {
-                // This displays a small internationalized text to explain the keys to navigate the tutorial
-                nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-                previousKeys: pressInteractionToStrings(TutorialControlsInputs.map.prevPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:navigationInfo", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    nextKeys: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                    previousKeys: pressInteractionToStrings(
+                        TutorialControlsInputs.map.prevPanel,
+                        keyboardLayoutMap,
+                    ).join(` ${i18n.t("common:or")} `),
+                }),
+            )}
         </div>`;
 
         const endPanelHtml = `
         <div class="tutorialContent">
-            ${i18n.t("tutorials:common:tutorialEnding", {
-                // This displays a small internationalized text to explain the keys to end the tutorial
-                keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
-                    ` ${i18n.t("common:or")} `,
-                ),
-            })}
+            ${renderMarkdownBlock(
+                i18n.t("tutorials:common:tutorialEnding", {
+                    // Interpolations are controlled display labels produced by the input binding API.
+                    keyQuit: pressInteractionToStrings(TutorialControlsInputs.map.nextPanel, keyboardLayoutMap).join(
+                        ` ${i18n.t("common:or")} `,
+                    ),
+                }),
+            )}
         </div>`;
 
         return [welcomePanelHtml, endPanelHtml];

--- a/packages/game/src/ts/i18n.ts
+++ b/packages/game/src/ts/i18n.ts
@@ -18,6 +18,8 @@
 import i18next, { init, t, type Resource, type ResourceKey, type ResourceLanguage } from "i18next";
 import { z } from "zod";
 
+import { renderMarkdownInline } from "./utils/markdown";
+
 /**
  * Load all the resources from the locales folder and return them in the i18next format.
  * This takes place at build time, so the resources are bundled with the application.
@@ -88,9 +90,7 @@ export async function initI18n(): Promise<void> {
             throw new Error("data-i18n attribute is null");
         }
 
-        // this should be safe as we are not doing any interpolation
-        // (as long as the translation are reviewed before being merged of course)
-        element.innerHTML = t(key);
+        element.innerHTML = renderMarkdownInline(t(key));
     });
 }
 

--- a/packages/game/src/ts/utils/markdown.spec.ts
+++ b/packages/game/src/ts/utils/markdown.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { renderMarkdownBlock, renderMarkdownInline } from "./markdown";
+
+describe("Markdown renderer", () => {
+    it("renders inline emphasis without a wrapping paragraph", () => {
+        expect(renderMarkdownInline("This is **important**.")).toBe("This is <strong>important</strong>.");
+    });
+
+    it("renders multiple block paragraphs", () => {
+        expect(renderMarkdownBlock("First paragraph.\n\nSecond paragraph.")).toBe(
+            "<p>First paragraph.</p>\n<p>Second paragraph.</p>\n",
+        );
+    });
+
+    it("does not interpret raw HTML", () => {
+        expect(renderMarkdownInline("<strong>unsafe</strong>")).toBe("&lt;strong&gt;unsafe&lt;/strong&gt;");
+    });
+
+    it("opens links in a new tab without suppressing the referrer", () => {
+        expect(renderMarkdownInline("[Cosmos Journeyer](https://cosmosjourneyer.com)")).toBe(
+            '<a href="https://cosmosjourneyer.com" target="_blank" rel="noopener">Cosmos Journeyer</a>',
+        );
+    });
+
+    it("does not emit dangerous link targets", () => {
+        expect(renderMarkdownInline("[unsafe](javascript:alert(1))")).not.toContain('href="javascript:');
+    });
+
+    it("does not render images", () => {
+        expect(renderMarkdownInline("![tracking pixel](https://example.com/pixel.png)")).not.toContain("<img");
+    });
+});

--- a/packages/game/src/ts/utils/markdown.ts
+++ b/packages/game/src/ts/utils/markdown.ts
@@ -1,0 +1,31 @@
+import MarkdownItRenderer from "markdown-it";
+
+const markdownRenderer = new MarkdownItRenderer({
+    html: false,
+    linkify: false,
+    typographer: false,
+    breaks: false,
+});
+
+markdownRenderer.disable("image");
+
+const defaultLinkOpen = markdownRenderer.renderer.rules["link_open"];
+markdownRenderer.renderer.rules["link_open"] = (tokens, index, options, environment, self): string => {
+    tokens[index]?.attrSet("target", "_blank");
+    tokens[index]?.attrSet("rel", "noopener");
+
+    return defaultLinkOpen?.(tokens, index, options, environment, self) ?? self.renderToken(tokens, index, options);
+};
+
+export function renderMarkdownInline(markdown: string): string {
+    return markdownRenderer.renderInline(markdown);
+}
+
+export function renderMarkdownBlock(markdown: string): string {
+    return markdownRenderer.render(markdown);
+}
+
+/** Escape Markdown punctuation in values before interpolating them into translated Markdown. */
+export function escapeMarkdown(value: string): string {
+    return value.replace(/[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g, "\\$&");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       i18next:
         specifier: ^26.4.0
         version: 26.4.0(typescript@6.0.3)
+      markdown-it:
+        specifier: ^15.0.0
+        version: 15.0.0
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -2232,6 +2235,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  argparse@3.0.0:
+    resolution: {integrity: sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==}
+
   asn1js@3.0.10:
     resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
     engines: {node: '>=12.0.0'}
@@ -3300,6 +3306,9 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
+  linkify-it@6.1.0:
+    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
+
   lint-staged@17.3.0:
     resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
@@ -3346,6 +3355,10 @@ packages:
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
+  markdown-it@15.0.0:
+    resolution: {integrity: sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==}
     hasBin: true
 
   matcher@3.0.0:
@@ -4062,6 +4075,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uc.micro@3.0.0:
+    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -6708,6 +6724,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  argparse@3.0.0: {}
+
   asn1js@3.0.10:
     dependencies:
       pvtsutils: 1.3.6
@@ -7858,6 +7876,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  linkify-it@6.1.0:
+    dependencies:
+      uc.micro: 3.0.0
+
   lint-staged@17.3.0:
     dependencies:
       picomatch: 4.0.5
@@ -7904,6 +7926,15 @@ snapshots:
       mdurl: 2.1.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  markdown-it@15.0.0:
+    dependencies:
+      argparse: 3.0.0
+      entities: 8.0.0
+      linkify-it: 6.1.0
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 3.0.0
 
   matcher@3.0.0:
     dependencies:
@@ -8610,6 +8641,8 @@ snapshots:
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
+
+  uc.micro@3.0.0: {}
 
   undici-types@7.18.2: {}
 


### PR DESCRIPTION
### Motivation
- Allow translators to use Markdown (links, emphasis, paragraphs) in locale strings instead of raw HTML while preventing injection of unsafe HTML or malicious links. 
- Ensure translated links open in a new tab with safe attributes (`target="_blank" rel="noopener"`) and avoid rendering images or javascript: links. 
- Make tutorial and UI text rendering consistent and safe when interpolating runtime key labels into translated Markdown. 

### Description
- Added `markdown-it` dependency and a new utility `src/ts/utils/markdown.ts` exposing `renderMarkdownInline`, `renderMarkdownBlock`, and `escapeMarkdown` with HTML disabled, images disabled, and link rendering adjusted to set `target="_blank" rel="noopener"`. 
- Replaced direct `innerHTML` usages and raw translation rendering with `renderMarkdownInline` / `renderMarkdownBlock` across UI modules including `aboutPanel.ts`, `contributePanel.ts`, `saveLoadingPanelContent.ts`, `officialOriginNotice.ts`, tutorial implementations (`*Tutorial.ts`), and the i18n static translation pass in `i18n.ts`. 
- Updated locale JSON files to use Markdown-style links instead of HTML anchors and adjusted tutorial copy to use Markdown-friendly strings. 
- Escaped runtime interpolations where necessary using `escapeMarkdown` before inserting key labels into translated Markdown to avoid accidental Markdown interpretation. 
- Added unit tests in `utils/markdown.spec.ts` and updated `officialOriginNotice.spec.ts` to cover safe link rendering and inline/block behavior. 
- Updated `package.json` and `pnpm-lock.yaml` to include the new `markdown-it` dependency. 

### Testing
- Ran unit tests with `vitest`, including the new `utils/markdown.spec.ts` and the updated `officialOriginNotice.spec.ts`, and they passed. 
- Exercised the translation rendering path by performing the static translation pass (`initI18n`) in dev builds and verified rendered output uses the Markdown renderer without raw HTML injection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eace347a48328a86529a5b296fd12)