### PR TITLE
Enable linkify in Markdown renderer, add email/URL tests, and simplify locale contact links

### DIFF
--- a/packages/game/src/locales/en-US/common.json
+++ b/packages/game/src/locales/en-US/common.json
@@ -9,5 +9,5 @@
     "cancel": "Cancel",
     "confirm": "Confirm",
     "ok": "OK",
-    "unofficialOriginNotice": "This is not the official stable version of Cosmos Journeyer. Play the latest stable version at [cosmosjourneyer.com](https://cosmosjourneyer.com)."
+    "unofficialOriginNotice": "This is not the official stable version of Cosmos Journeyer. Play the latest stable version at https://cosmosjourneyer.com."
 }

--- a/packages/game/src/locales/en-US/sidePanel.json
+++ b/packages/game/src/locales/en-US/sidePanel.json
@@ -22,7 +22,7 @@
     "tutorialsWarning": "If this is your first time playing, you can simply start a new game: the tutorials will be naturally presented during the game!",
     "contribute": "Contribute",
     "bugReports": "Bug Reports",
-    "bugReportsText": "If you experience any bug during your exploration, please add it to the [issue tracker](https://github.com/BarthPaleologue/CosmosJourneyer/issues). You can also send an email at [barth.paleologue@cosmosjourneyer.com](mailto:barth.paleologue@cosmosjourneyer.com). Sending screenshots and save files can help enormously with the debugging process.",
+    "bugReportsText": "If you experience any bug during your exploration, please add it to the [issue tracker](https://github.com/BarthPaleologue/CosmosJourneyer/issues). You can also send an email at barth.paleologue@cosmosjourneyer.com. Sending screenshots and save files can help enormously with the debugging process.",
     "translation": "Translation",
     "translationText": "Translating Cosmos Journeyer makes it accessible to more people around the world! You don't need any coding skills, only proficiency in a language not currently supported or that can be enhanced. You can access the translation guide [here](https://github.com/BarthPaleologue/CosmosJourneyer/blob/main/CONTRIBUTING.md#translation).",
     "knowHowToCode": "Know how to code?",
@@ -43,5 +43,5 @@
     "specialThanks": "Special Thanks",
     "about": "About",
     "aboutText": "Hello fellow explorer!\nI am the creator of Cosmos Journeyer, and I am glad you're interested in this project. It was years in the making you see: back in 2016 already, when I was working on my 3D planetarium, I dreamed about making the planets fully explorable. But then I was limited by how little I knew about computer graphics.\n\nI only started Cosmos Journeyer years later as a way to escape from the stress of my studies in French \"classes préparatoires\". At first, it was only a small procedural planet generator, which was called PlanetEngine. But as ideas kept on coming, I continued working on it for years and the project grew way beyond what I had imagined at first.\n\nAs I understand now that such projects cannot be achieved alone, I decided to open-source Cosmos Journeyer so that anyone can freely use and modify it to their liking and even contribute to the project.\n\nI hope you will enjoy CosmosJourneyer as much as I enjoy making it!",
-    "emailContact": "If you have any question about Cosmos Journeyer, feel free to contact me at [barth.paleologue@cosmosjourneyer.com](mailto:barth.paleologue@cosmosjourneyer.com)"
+    "emailContact": "If you have any question about Cosmos Journeyer, feel free to contact me at barth.paleologue@cosmosjourneyer.com"
 }

--- a/packages/game/src/locales/fr-FR/common.json
+++ b/packages/game/src/locales/fr-FR/common.json
@@ -9,5 +9,5 @@
     "cancel": "Annuler",
     "confirm": "Confirmer",
     "ok": "OK",
-    "unofficialOriginNotice": "Ceci n'est pas la version stable officielle de Cosmos Journeyer. Jouez à la dernière version stable sur [cosmosjourneyer.com](https://cosmosjourneyer.com)."
+    "unofficialOriginNotice": "Ceci n'est pas la version stable officielle de Cosmos Journeyer. Jouez à la dernière version stable sur https://cosmosjourneyer.com."
 }

--- a/packages/game/src/locales/fr-FR/sidePanel.json
+++ b/packages/game/src/locales/fr-FR/sidePanel.json
@@ -22,7 +22,7 @@
     "settings": "Paramètres",
     "contribute": "Contribuer",
     "bugReports": "Signaler un bug",
-    "bugReportsText": "Si vous rencontrez un bug lors de votre exploration, merci de l'ajouter au [tracker de bugs](https://github.com/BarthPaleologue/CosmosJourneyer/issues). Vous pouvez aussi envoyer un email à [barth.paleologue@cosmosjourneyer.com](mailto:barth.paleologue@cosmosjourneyer.com). Envoyer des captures d'écran et des fichiers de sauvegarde peut grandement aider le processus de débogage.",
+    "bugReportsText": "Si vous rencontrez un bug lors de votre exploration, merci de l'ajouter au [tracker de bugs](https://github.com/BarthPaleologue/CosmosJourneyer/issues). Vous pouvez aussi envoyer un email à barth.paleologue@cosmosjourneyer.com. Envoyer des captures d'écran et des fichiers de sauvegarde peut grandement aider le processus de débogage.",
     "translation": "Traduction",
     "translationText": "Traduire Cosmos Journeyer le rend accessible à plus de personnes à travers le monde ! Vous n'avez pas besoin de compétences en programmation, seulement d'une maîtrise d'une langue non supportée ou qui peut être améliorée. Vous pouvez accéder au guide de traduction [ici](https://github.com/BarthPaleologue/CosmosJourneyer/CONTRIBUTING.md#translation).",
     "knowHowToCode": "Vous savez coder ?",
@@ -41,5 +41,5 @@
     "specialThanks": "Remerciements",
     "about": "À propos",
     "aboutText": "Bienvenue cher explorateur !\nJe suis le créateur de Cosmos Journeyer, et je suis ravi que vous soyez intéressé. Longtemps, j'ai rêvé de faire ce project. En 2016 déjà lorsque je travaillais sur mon Planétarium en 3D, j'imaginais rendre les planètes entièrement explorables. Mais mes connaissances en informatique graphique étaient alors trop limitées.\n\nJ'ai commencé Cosmos Journeyer bien des années plus tard, comme une façon d'échapper au stress des concours des classes préparatoires. Cela a commencé par un petit générateur de planètes, que j'appelais PlanetEngine (\"moteur à planète\"). Mais plus je travaillais dessus, et plus j'avais des nouvelles idées. Après plus de 3 années de travail, je peux dire que le projet est allé bien au delà de ce que j'imaginais pouvoir faire au début.\n\nIl serait illusoire de penser que je puisse seul terminer Cosmos Journeyer un jour. C'est pourquoi j'ai décidé de rendre le projet open-source, afin que chacun puisse l'utiliser et le modifier à sa guise, et même contribuer au projet dans les années à venir.\n\nJ'espère que vous aimerez Cosmos Journeyer autant que j'aime le créer !",
-    "emailContact": "Si vous avez des questions sur Cosmos Journeyer, n'hésitez pas à me contacter à [barth.paleologue@cosmosjourneyer.com](mailto:barth.paleologue@cosmosjourneyer.com)"
+    "emailContact": "Si vous avez des questions sur Cosmos Journeyer, n'hésitez pas à me contacter à barth.paleologue@cosmosjourneyer.com"
 }

--- a/packages/game/src/ts/utils/markdown.spec.ts
+++ b/packages/game/src/ts/utils/markdown.spec.ts
@@ -17,13 +17,30 @@ describe("Markdown renderer", () => {
         expect(renderMarkdownInline("<strong>unsafe</strong>")).toBe("&lt;strong&gt;unsafe&lt;/strong&gt;");
     });
 
-    it("opens links in a new tab without suppressing the referrer", () => {
-        expect(renderMarkdownInline("[Cosmos Journeyer](https://cosmosjourneyer.com)")).toBe(
-            '<a href="https://cosmosjourneyer.com" target="_blank" rel="noopener">Cosmos Journeyer</a>',
+    it("linkifies URLs and opens them in a new tab without suppressing the referrer", () => {
+        expect(renderMarkdownInline("Visit https://cosmosjourneyer.com")).toBe(
+            'Visit <a href="https://cosmosjourneyer.com" target="_blank" rel="noopener">https://cosmosjourneyer.com</a>',
+        );
+    });
+
+    it("linkifies email addresses", () => {
+        expect(renderMarkdownInline("Contact test@example.com")).toBe(
+            'Contact <a href="mailto:test@example.com" target="_blank" rel="noopener">test@example.com</a>',
+        );
+    });
+
+    it("does not linkify domains without a protocol", () => {
+        expect(renderMarkdownInline("Visit cosmosjourneyer.com")).toBe("Visit cosmosjourneyer.com");
+    });
+
+    it("preserves explicit Markdown links", () => {
+        expect(renderMarkdownInline("[documentation](https://example.com/docs)")).toBe(
+            '<a href="https://example.com/docs" target="_blank" rel="noopener">documentation</a>',
         );
     });
 
     it("does not emit dangerous link targets", () => {
+        expect(renderMarkdownInline("javascript:alert(1)")).not.toContain("<a");
         expect(renderMarkdownInline("[unsafe](javascript:alert(1))")).not.toContain('href="javascript:');
     });
 

--- a/packages/game/src/ts/utils/markdown.ts
+++ b/packages/game/src/ts/utils/markdown.ts
@@ -2,9 +2,14 @@ import MarkdownItRenderer from "markdown-it";
 
 const markdownRenderer = new MarkdownItRenderer({
     html: false,
-    linkify: false,
+    linkify: true,
     typographer: false,
     breaks: false,
+});
+
+markdownRenderer.linkify.set({
+    fuzzyLink: false,
+    fuzzyEmail: true,
 });
 
 markdownRenderer.disable("image");


### PR DESCRIPTION
### Motivation

- Enable automatic detection of URLs and email addresses in rendered Markdown while avoiding accidental linkification of bare domains.
- Ensure links open in a new tab without suppressing the referrer and prevent dangerous link targets.
- Simplify localized contact strings to plain URLs/emails so they render consistently with the updated renderer.

### Description

- Turn on linkification by setting `linkify: true` and configure it with `linkify.set({ fuzzyLink: false, fuzzyEmail: true })` in the Markdown renderer.
- Ensure all links produced by the renderer include `target="_blank"` and `rel="noopener"` by overriding the `link_open` rule.
- Add and update unit tests in `packages/game/src/ts/utils/markdown.spec.ts` to cover URL linkification, email linkification, preserving explicit Markdown links, avoiding linkification of bare domains, and rejecting `javascript:` links; keep images disabled.
- Replace Markdown-style mailto and linked domain strings in localization files with plain `https://...` URLs and plain email addresses in `en-US` and `fr-FR` locale JSONs.

### Testing

- Ran the `vitest` unit tests for the markdown utilities (`packages/game/src/ts/utils/markdown.spec.ts`) and the updated test suite passed.
- No automated tests were required for the locale JSON edits beyond the unit tests above which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f0b752f888328b61dcfcb1f167f95)