### PR TITLE
fix(game): reduce terrain worker initialization time

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,7 +74,8 @@ const typeScriptWorkspaceRules = {
     },
     rules: {
         "import-x/no-cycle": "error",
-        "import-x/no-duplicates": ["error", { "prefer-inline": true }],
+        "import-x/consistent-type-specifier-style": ["error", "prefer-top-level"],
+        "import-x/no-duplicates": "error",
         "import-x/no-extraneous-dependencies": "error",
         "import-x/no-mutable-exports": "error",
         "import-x/no-relative-packages": "error",
@@ -116,7 +117,7 @@ const typeScriptWorkspaceRules = {
         "@typescript-eslint/require-array-sort-compare": "error",
         "@typescript-eslint/strict-boolean-expressions": "error",
 
-        "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
+        "@typescript-eslint/consistent-type-imports": "error",
 
         "@typescript-eslint/consistent-type-exports": "error",
 

--- a/packages/babylonjs-shading-language/src/index.ts
+++ b/packages/babylonjs-shading-language/src/index.ts
@@ -84,9 +84,10 @@ import { NodeMaterialBlockConnectionPointTypes } from "@babylonjs/core/Materials
 import { NodeMaterialBlockTargets } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialBlockTargets";
 import { NodeMaterialSystemValues } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialSystemValues";
 import type { NodeMaterialConnectionPoint } from "@babylonjs/core/Materials/Node/nodeMaterialBlockConnectionPoint";
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import type { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
-import { Vector2, type Vector3, type Vector4 } from "@babylonjs/core/Maths/math.vector";
+import { Vector2 } from "@babylonjs/core/Maths/math.vector";
+import type { Vector3, Vector4 } from "@babylonjs/core/Maths/math.vector";
 
 export const Target = {
     VERT: NodeMaterialBlockTargets.Vertex,

--- a/packages/channel-packer/src/main.ts
+++ b/packages/channel-packer/src/main.ts
@@ -10,7 +10,8 @@ import {
     getAssignedInputCount,
     releaseFileKeyIfUnused,
 } from "./app/state";
-import { createUi, setHoveredDropTarget, syncUi, type UiRefs } from "./app/ui";
+import { createUi, setHoveredDropTarget, syncUi } from "./app/ui";
+import type { UiRefs } from "./app/ui";
 import { ImageCache, generatePreview, savePackedPng, synchronizeCache } from "./packer";
 import type { AppState, ColorChannel } from "./types";
 

--- a/packages/channel-packer/src/packer.spec.ts
+++ b/packages/channel-packer/src/packer.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createPackerEngine, ImageCache, type DecodedImage, type FileSignature } from "./packerCore";
+import { createPackerEngine, ImageCache } from "./packerCore";
+import type { DecodedImage, FileSignature } from "./packerCore";
 import type { ChannelAssignment, ColorChannel, PackRequest, PackedTexture } from "./types";
 
 interface TestInput {

--- a/packages/channel-packer/src/packer.ts
+++ b/packages/channel-packer/src/packer.ts
@@ -1,4 +1,5 @@
-import { createPackerEngine, ImageCache, PackerError, type DecodedImage, type FileSignature } from "./packerCore";
+import { createPackerEngine, ImageCache, PackerError } from "./packerCore";
+import type { DecodedImage, FileSignature } from "./packerCore";
 import type { PackRequest, PackedTexture, PreviewResponse } from "./types";
 
 export { ImageCache, PackerError };

--- a/packages/desktop-electron/src/autoUpdate.spec.ts
+++ b/packages/desktop-electron/src/autoUpdate.spec.ts
@@ -4,7 +4,7 @@ import type { CancellationToken, ProgressInfo, UpdateInfo } from "electron-updat
 import { describe, expect, it, vi } from "vitest";
 
 import { DesktopAutoUpdateService } from "./autoUpdate.js";
-import { type DesktopUpdateState } from "./updateContract.js";
+import type { DesktopUpdateState } from "./updateContract.js";
 
 class MockUpdater extends EventEmitter {
     public autoDownload = true;

--- a/packages/desktop-electron/src/autoUpdate.ts
+++ b/packages/desktop-electron/src/autoUpdate.ts
@@ -1,6 +1,7 @@
-import { autoUpdater, CancellationToken, type ProgressInfo, type UpdateInfo } from "electron-updater";
+import { autoUpdater, CancellationToken } from "electron-updater";
+import type { ProgressInfo, UpdateInfo } from "electron-updater";
 
-import { type DesktopUpdateState } from "./updateContract.js";
+import type { DesktopUpdateState } from "./updateContract.js";
 
 const updateCheckIntervalMs = 4 * 60 * 60 * 1_000;
 

--- a/packages/desktop-electron/src/devWatcher.ts
+++ b/packages/desktop-electron/src/devWatcher.ts
@@ -1,4 +1,5 @@
-import { watch, type FSWatcher } from "node:fs";
+import { watch } from "node:fs";
+import type { FSWatcher } from "node:fs";
 
 import type * as ElectronModule from "electron";
 

--- a/packages/desktop-electron/src/main.ts
+++ b/packages/desktop-electron/src/main.ts
@@ -4,8 +4,10 @@ import { fileURLToPath } from "node:url";
 
 import type * as ElectronModule from "electron";
 
-import { createDesktopAutoUpdateService, type DesktopAutoUpdateService } from "./autoUpdate.js";
-import { createDevWatcher, type DevWatcher } from "./devWatcher.js";
+import { createDesktopAutoUpdateService } from "./autoUpdate.js";
+import type { DesktopAutoUpdateService } from "./autoUpdate.js";
+import { createDevWatcher } from "./devWatcher.js";
+import type { DevWatcher } from "./devWatcher.js";
 import { createDevelopmentAutoUpdater } from "./mockAutoUpdater.js";
 import { appHost, appScheme, createHandleAppProtocol } from "./protocol.js";
 import { updateIpcChannels } from "./updateContract.js";

--- a/packages/desktop-electron/src/mockAutoUpdater.ts
+++ b/packages/desktop-electron/src/mockAutoUpdater.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from "node:events";
 
-import { type App } from "electron";
-import { type CancellationToken, type ProgressInfo, type UpdateInfo } from "electron-updater";
+import type { App } from "electron";
+import type { CancellationToken, ProgressInfo, UpdateInfo } from "electron-updater";
 
-import { type AutoUpdaterClient } from "./autoUpdate.js";
+import type { AutoUpdaterClient } from "./autoUpdate.js";
 
 const mockDownloadStepIntervalMs = 250;
 const mockDownloadStepCount = 20;

--- a/packages/game/src/ts/backend/backendLocal.ts
+++ b/packages/game/src/ts/backend/backendLocal.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 import { generateDarkKnightModel } from "@cosmos-journeyer/universe-generation";
 
 import { hashArray } from "@/utils/hash";

--- a/packages/game/src/ts/backend/encyclopaedia/encyclopaediaGalactica.ts
+++ b/packages/game/src/ts/backend/encyclopaedia/encyclopaediaGalactica.ts
@@ -16,7 +16,8 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Result } from "@cosmos-journeyer/typescript";
-import { UniverseObjectIdSchema, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import { UniverseObjectIdSchema } from "@cosmos-journeyer/universe-model";
+import type { UniverseObjectId } from "@cosmos-journeyer/universe-model";
 import { z } from "zod";
 
 export const SpaceDiscoveryDataSchema = z.object({

--- a/packages/game/src/ts/backend/encyclopaedia/encyclopaediaGalacticaLocal.ts
+++ b/packages/game/src/ts/backend/encyclopaedia/encyclopaediaGalacticaLocal.ts
@@ -1,15 +1,16 @@
-import { assertUnreachable, err, ok, type DeepReadonly, type Result } from "@cosmos-journeyer/typescript";
-import {
-    type GasPlanetModel,
-    type TelluricPlanetModel,
-    type TelluricSatelliteModel,
-    type UniverseObjectId,
-    serializeUniverseObjectId,
+import { assertUnreachable, err, ok } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly, Result } from "@cosmos-journeyer/typescript";
+import { serializeUniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type {
+    GasPlanetModel,
+    TelluricPlanetModel,
+    TelluricSatelliteModel,
+    UniverseObjectId,
 } from "@cosmos-journeyer/universe-model";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type EncyclopaediaGalactica, type SpaceDiscoveryData } from "./encyclopaediaGalactica";
+import type { EncyclopaediaGalactica, SpaceDiscoveryData } from "./encyclopaediaGalactica";
 
 export class EncyclopaediaGalacticaLocal implements EncyclopaediaGalactica {
     /**

--- a/packages/game/src/ts/backend/encyclopaedia/encyclopaediaGalacticaManager.ts
+++ b/packages/game/src/ts/backend/encyclopaedia/encyclopaediaGalacticaManager.ts
@@ -1,7 +1,8 @@
-import { ok, type Result } from "@cosmos-journeyer/typescript";
-import { type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import { ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
+import type { UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type EncyclopaediaGalactica, type SpaceDiscoveryData } from "./encyclopaediaGalactica";
+import type { EncyclopaediaGalactica, SpaceDiscoveryData } from "./encyclopaediaGalactica";
 
 export class EncyclopaediaGalacticaManager implements EncyclopaediaGalactica {
     readonly backends: EncyclopaediaGalactica[] = [];

--- a/packages/game/src/ts/backend/missions/missionNodeSerialized.ts
+++ b/packages/game/src/ts/backend/missions/missionNodeSerialized.ts
@@ -17,15 +17,12 @@
 
 import { z } from "zod";
 
-import {
-    MissionAsteroidFieldNodeSerializedSchema,
-    type MissionAsteroidFieldNodeSerialized,
-} from "./missionAsteroidFieldNodeSerialized";
-import { MissionFlyByNodeSerializedSchema, type MissionFlyByNodeSerialized } from "./missionFlyByNodeSerialized";
-import {
-    MissionTerminatorLandingNodeSerializedSchema,
-    type MissionTerminatorLandingNodeSerialized,
-} from "./missionTerminatorLandingNodeSerialized";
+import { MissionAsteroidFieldNodeSerializedSchema } from "./missionAsteroidFieldNodeSerialized";
+import type { MissionAsteroidFieldNodeSerialized } from "./missionAsteroidFieldNodeSerialized";
+import { MissionFlyByNodeSerializedSchema } from "./missionFlyByNodeSerialized";
+import type { MissionFlyByNodeSerialized } from "./missionFlyByNodeSerialized";
+import { MissionTerminatorLandingNodeSerializedSchema } from "./missionTerminatorLandingNodeSerialized";
+import type { MissionTerminatorLandingNodeSerialized } from "./missionTerminatorLandingNodeSerialized";
 
 function preprocessLegacyMissionNodeType(type: unknown): unknown {
     if (typeof type !== "number") {

--- a/packages/game/src/ts/backend/save/commanderArchive.ts
+++ b/packages/game/src/ts/backend/save/commanderArchive.ts
@@ -15,15 +15,17 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, ok, type DeepReadonly, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly, Result } from "@cosmos-journeyer/typescript";
 import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
 import { z } from "zod";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { jsonSafeParse } from "@/utils/json";
 
-import { safeParseSave, type CmdrSaves } from "./saveFileData";
+import { safeParseSave } from "./saveFileData";
+import type { CmdrSaves } from "./saveFileData";
 
 const MANIFEST_FILE_NAME = "manifest.json";
 

--- a/packages/game/src/ts/backend/save/opfsFileSystem.ts
+++ b/packages/game/src/ts/backend/save/opfsFileSystem.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 
 import type { IFileSystem } from "./saveBackendMultiFile";
 

--- a/packages/game/src/ts/backend/save/saveBackendMultiFile.spec.ts
+++ b/packages/game/src/ts/backend/save/saveBackendMultiFile.spec.ts
@@ -21,8 +21,9 @@ import { SerializedPlayerSchema } from "@/backend/player/serializedPlayer";
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { SaveBackendMultiFile, type IFileSystem } from "./saveBackendMultiFile";
-import { type CmdrSaves, type Save } from "./saveFileData";
+import { SaveBackendMultiFile } from "./saveBackendMultiFile";
+import type { IFileSystem } from "./saveBackendMultiFile";
+import type { CmdrSaves, Save } from "./saveFileData";
 
 /**
  * Mock implementation of IFileSystem for testing

--- a/packages/game/src/ts/backend/save/saveBackendMultiFile.ts
+++ b/packages/game/src/ts/backend/save/saveBackendMultiFile.ts
@@ -15,17 +15,20 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, ok, type DeepReadonly, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly, Result } from "@cosmos-journeyer/typescript";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { jsonSafeParse } from "@/utils/json";
 
 import { Settings } from "@/settings";
 
 import type { ISaveBackend } from "./saveBackend";
-import { safeParseSave, type CmdrSaves, type Save } from "./saveFileData";
-import { saveLoadingErrorToI18nString, type SaveLoadingError } from "./saveLoadingError";
+import { safeParseSave } from "./saveFileData";
+import type { CmdrSaves, Save } from "./saveFileData";
+import { saveLoadingErrorToI18nString } from "./saveLoadingError";
+import type { SaveLoadingError } from "./saveLoadingError";
 
 /**
  * Interface defining the file system operations for save data.

--- a/packages/game/src/ts/backend/save/saveBackendSingleFile.spec.ts
+++ b/packages/game/src/ts/backend/save/saveBackendSingleFile.spec.ts
@@ -21,8 +21,9 @@ import { SerializedPlayerSchema } from "@/backend/player/serializedPlayer";
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { SaveBackendSingleFile, type IFile } from "./saveBackendSingleFile";
-import { type CmdrSaves, type Save } from "./saveFileData";
+import { SaveBackendSingleFile } from "./saveBackendSingleFile";
+import type { IFile } from "./saveBackendSingleFile";
+import type { CmdrSaves, Save } from "./saveFileData";
 
 /**
  * Mock implementation of SaveBackend for testing

--- a/packages/game/src/ts/backend/save/saveBackendSingleFile.ts
+++ b/packages/game/src/ts/backend/save/saveBackendSingleFile.ts
@@ -15,17 +15,19 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, ok, type DeepReadonly, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly, Result } from "@cosmos-journeyer/typescript";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { jsonSafeParse } from "@/utils/json";
 
 import { Settings } from "@/settings";
 
 import type { ISaveBackend } from "./saveBackend";
-import { parseSaveArray, SavesSchema, type CmdrSaves, type Save } from "./saveFileData";
-import { type SaveLoadingError } from "./saveLoadingError";
+import { parseSaveArray, SavesSchema } from "./saveFileData";
+import type { CmdrSaves, Save } from "./saveFileData";
+import type { SaveLoadingError } from "./saveLoadingError";
 
 /**
  * Interface defining the storage backend for save data.

--- a/packages/game/src/ts/backend/save/saveFile.ts
+++ b/packages/game/src/ts/backend/save/saveFile.ts
@@ -15,14 +15,16 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, type Result } from "@cosmos-journeyer/typescript";
+import { err } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { jsonSafeParse } from "@/utils/json";
 
-import { safeParseSave, type Save } from "./saveFileData";
-import { type SaveLoadingError } from "./saveLoadingError";
+import { safeParseSave } from "./saveFileData";
+import type { Save } from "./saveFileData";
+import type { SaveLoadingError } from "./saveLoadingError";
 
 export async function parseSaveFile(
     rawSaveFile: File,

--- a/packages/game/src/ts/backend/save/saveFileData.ts
+++ b/packages/game/src/ts/backend/save/saveFileData.ts
@@ -18,11 +18,11 @@
 import type { Assert, DeepMutable, DeepReadonly, Result, StrictEqual } from "@cosmos-journeyer/typescript";
 import { z } from "zod";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { encodeBase64 } from "@/utils/base64";
 
-import { type SaveLoadingError } from "./saveLoadingError";
+import type { SaveLoadingError } from "./saveLoadingError";
 import { safeParseSaveV2, SaveSchemaV2 } from "./v2/saveV2";
 
 export const SaveSchema = SaveSchemaV2;

--- a/packages/game/src/ts/backend/save/saveLoadingError.ts
+++ b/packages/game/src/ts/backend/save/saveLoadingError.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
-import { type z } from "zod";
+import type { z } from "zod";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/backend/save/saveLocalStorage.ts
+++ b/packages/game/src/ts/backend/save/saveLocalStorage.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type IFile } from "./saveBackendSingleFile";
+import type { IFile } from "./saveBackendSingleFile";
 
 export class SaveLocalStorage implements IFile {
     public static readonly SAVES_KEY = "saves";

--- a/packages/game/src/ts/backend/save/v1/saveV1.spec.ts
+++ b/packages/game/src/ts/backend/save/v1/saveV1.spec.ts
@@ -5,7 +5,7 @@ import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { safeParseSave } from "../saveFileData";
-import { type SaveV1 } from "./saveV1";
+import type { SaveV1 } from "./saveV1";
 
 test("Loading a correct save file", () => {
     const saveFileString: DeepPartial<SaveV1> = {

--- a/packages/game/src/ts/backend/save/v1/saveV1.ts
+++ b/packages/game/src/ts/backend/save/v1/saveV1.ts
@@ -15,14 +15,15 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 import { StarSystemCoordinatesSchema } from "@cosmos-journeyer/universe-model";
 import { z } from "zod";
 
 import { CompletedTutorialsSchema } from "@/backend/player/serializedPlayer";
 
 import projectInfo from "../../../../../package.json";
-import { type SaveLoadingError } from "../saveLoadingError";
+import type { SaveLoadingError } from "../saveLoadingError";
 
 export const SystemObjectType = {
     STELLAR_OBJECT: 0,

--- a/packages/game/src/ts/backend/save/v2/saveV2.spec.ts
+++ b/packages/game/src/ts/backend/save/v2/saveV2.spec.ts
@@ -5,7 +5,7 @@ import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { safeParseSave } from "../saveFileData";
-import { type SaveV2 } from "./saveV2";
+import type { SaveV2 } from "./saveV2";
 
 test("Loading a correct save file", () => {
     const universeBackend = new UniverseBackend(getLoneStarSystem());

--- a/packages/game/src/ts/backend/save/v2/saveV2.ts
+++ b/packages/game/src/ts/backend/save/v2/saveV2.ts
@@ -15,17 +15,22 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertUnreachable, ok, type DeepReadonly, type Result } from "@cosmos-journeyer/typescript";
-import { getCelestialBodyRadius, type OrbitalObjectModel } from "@cosmos-journeyer/universe-model";
+import { assertUnreachable, ok } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly, Result } from "@cosmos-journeyer/typescript";
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type { OrbitalObjectModel } from "@cosmos-journeyer/universe-model";
 import { z } from "zod";
 
-import { ItinerarySchema, SerializedPlayerSchema, type Itinerary } from "@/backend/player/serializedPlayer";
+import { ItinerarySchema, SerializedPlayerSchema } from "@/backend/player/serializedPlayer";
+import type { Itinerary } from "@/backend/player/serializedPlayer";
 import { getDefaultSerializedSpaceship } from "@/backend/spaceship/serializedSpaceship";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type SaveLoadingError } from "../saveLoadingError";
-import { UniverseCoordinatesSchema, type UniverseCoordinates } from "../universeCoordinates";
-import { safeParseSaveV1, SystemObjectType, type SaveV1 } from "../v1/saveV1";
+import type { SaveLoadingError } from "../saveLoadingError";
+import { UniverseCoordinatesSchema } from "../universeCoordinates";
+import type { UniverseCoordinates } from "../universeCoordinates";
+import { safeParseSaveV1, SystemObjectType } from "../v1/saveV1";
+import type { SaveV1 } from "../v1/saveV1";
 
 export const SaveSchemaV2 = z.object({
     uuid: z.string().default(() => crypto.randomUUID()),

--- a/packages/game/src/ts/backend/spaceship/serializedComponents/pricing.ts
+++ b/packages/game/src/ts/backend/spaceship/serializedComponents/pricing.ts
@@ -17,7 +17,7 @@
 
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type SerializedComponent } from "./component";
+import type { SerializedComponent } from "./component";
 
 export function getComponentValue(serializedComponent: SerializedComponent): number {
     switch (serializedComponent.type) {

--- a/packages/game/src/ts/backend/universe/customSystems/alphaTestis.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/alphaTestis.ts
@@ -28,7 +28,7 @@ import {
     generateTelluricPlanetModel,
     generateTelluricSatelliteModel,
 } from "@cosmos-journeyer/universe-generation";
-import { type StarSystemCoordinates, type StarSystemModel } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, StarSystemModel } from "@cosmos-journeyer/universe-model";
 
 export function getAlphaTestisSystemModel(): StarSystemModel {
     const systemName = "Alpha Testis";

--- a/packages/game/src/ts/backend/universe/customSystems/chronos.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/chronos.ts
@@ -16,13 +16,13 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { degreesToRadians, getShadowRadius, solarMassToKg } from "@cosmos-journeyer/physics";
-import {
-    type StarSystemModel,
-    type BlackHoleModel,
-    type DarkKnightModel,
-    type SpaceStationModel,
-    type StarSystemCoordinates,
-    getCelestialBodyRadius,
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type {
+    StarSystemModel,
+    BlackHoleModel,
+    DarkKnightModel,
+    SpaceStationModel,
+    StarSystemCoordinates,
 } from "@cosmos-journeyer/universe-model";
 
 import { CropType } from "@/utils/agriculture";

--- a/packages/game/src/ts/backend/universe/customSystems/eclipseTest.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/eclipseTest.ts
@@ -20,7 +20,7 @@ import {
     generateTelluricPlanetModel,
     generateTelluricSatelliteModel,
 } from "@cosmos-journeyer/universe-generation";
-import { type StarSystemCoordinates, type StarSystemModel } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, StarSystemModel } from "@cosmos-journeyer/universe-model";
 
 export function getEclipseTestSystemModel(): StarSystemModel {
     const systemName = "Eclipse Test";

--- a/packages/game/src/ts/backend/universe/customSystems/loneStar.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/loneStar.ts
@@ -17,7 +17,7 @@
 
 import { SolarMass, SolarRadius } from "@cosmos-journeyer/physics";
 import { generateSpaceStationModel } from "@cosmos-journeyer/universe-generation";
-import { type StarSystemModel } from "@cosmos-journeyer/universe-model";
+import type { StarSystemModel } from "@cosmos-journeyer/universe-model";
 
 export function getLoneStarSystem(): StarSystemModel {
     const systemModel: StarSystemModel = {

--- a/packages/game/src/ts/backend/universe/customSystems/registerCustomSystems.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/registerCustomSystems.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { getChronosSystemModel } from "./chronos";
 import { getVestaSystemModel } from "./vesta";

--- a/packages/game/src/ts/backend/universe/customSystems/sol/jupiter.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/sol/jupiter.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { degreesToRadians, durationToSeconds, EarthSeaLevelPressure } from "@cosmos-journeyer/physics";
-import { type GasPlanetModel, type OrbitalObjectId } from "@cosmos-journeyer/universe-model";
+import type { GasPlanetModel, OrbitalObjectId } from "@cosmos-journeyer/universe-model";
 
 export function getJupiterModel(parentIds: ReadonlyArray<OrbitalObjectId>): GasPlanetModel {
     return {

--- a/packages/game/src/ts/backend/universe/customSystems/sol/saturn.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/sol/saturn.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { degreesToRadians, durationToSeconds, EarthSeaLevelPressure } from "@cosmos-journeyer/physics";
-import { type GasPlanetModel, type OrbitalObjectId } from "@cosmos-journeyer/universe-model";
+import type { GasPlanetModel, OrbitalObjectId } from "@cosmos-journeyer/universe-model";
 
 export function getSaturnModel(parentIds: ReadonlyArray<OrbitalObjectId>): GasPlanetModel {
     return {

--- a/packages/game/src/ts/backend/universe/customSystems/sol/sol.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/sol/sol.ts
@@ -22,11 +22,11 @@ import {
     degreesToRadians,
     durationToSeconds,
 } from "@cosmos-journeyer/physics";
-import {
-    type GasPlanetModel,
-    type TelluricPlanetModel,
-    type TelluricSatelliteModel,
-    type StarSystemModel,
+import type {
+    GasPlanetModel,
+    TelluricPlanetModel,
+    TelluricSatelliteModel,
+    StarSystemModel,
 } from "@cosmos-journeyer/universe-model";
 
 import { getJupiterModel } from "./jupiter";

--- a/packages/game/src/ts/backend/universe/customSystems/sol/sun.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/sol/sun.ts
@@ -1,5 +1,5 @@
 import { degreesToRadians, durationToSeconds } from "@cosmos-journeyer/physics";
-import { type StarModel } from "@cosmos-journeyer/universe-model";
+import type { StarModel } from "@cosmos-journeyer/universe-model";
 
 export function getSunModel(): StarModel {
     return {

--- a/packages/game/src/ts/backend/universe/customSystems/vesta.ts
+++ b/packages/game/src/ts/backend/universe/customSystems/vesta.ts
@@ -33,14 +33,14 @@ import {
     SolarRadius,
     SolarTemperature,
 } from "@cosmos-journeyer/physics";
-import {
-    type StarSystemModel,
-    type StarSystemCoordinates,
-    type StarModel,
-    type GasPlanetModel,
-    type TelluricPlanetModel,
-    type SpaceStationModel,
-    type TelluricSatelliteModel,
+import type {
+    StarSystemModel,
+    StarSystemCoordinates,
+    StarModel,
+    GasPlanetModel,
+    TelluricPlanetModel,
+    SpaceStationModel,
+    TelluricSatelliteModel,
 } from "@cosmos-journeyer/universe-model";
 
 import { CropType } from "@/utils/agriculture";

--- a/packages/game/src/ts/backend/universe/universeBackend.spec.ts
+++ b/packages/game/src/ts/backend/universe/universeBackend.spec.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type StarSystemCoordinates, type StarSystemModel } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, StarSystemModel } from "@cosmos-journeyer/universe-model";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { getLoneStarSystem } from "./customSystems/loneStar";

--- a/packages/game/src/ts/backend/universe/universeBackend.ts
+++ b/packages/game/src/ts/backend/universe/universeBackend.ts
@@ -19,12 +19,14 @@ import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import { generateStarSystemModel } from "@cosmos-journeyer/universe-generation";
 import {
     starSystemCoordinatesEquals,
-    type StarSystemCoordinates,
-    type UniverseObjectId,
-    type OrbitalObjectModel,
     getObjectModelById,
-    type StarSystemModel,
     serializeStarSystemCoordinates,
+} from "@cosmos-journeyer/universe-model";
+import type {
+    StarSystemCoordinates,
+    UniverseObjectId,
+    OrbitalObjectModel,
+    StarSystemModel,
 } from "@cosmos-journeyer/universe-model";
 import { centeredRand } from "extended-random";
 import { makeNoise3D } from "fast-simplex-noise/lib/3d";

--- a/packages/game/src/ts/frontend/assets/assets.ts
+++ b/packages/game/src/ts/frontend/assets/assets.ts
@@ -16,11 +16,13 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { loadAudioAssets, type AudioAssets } from "./audio";
-import { type ILoadingProgressMonitor } from "./loadingProgressMonitor";
-import { loadRenderingAssets, type RenderingAssets } from "./renderingAssets";
+import { loadAudioAssets } from "./audio";
+import type { AudioAssets } from "./audio";
+import type { ILoadingProgressMonitor } from "./loadingProgressMonitor";
+import { loadRenderingAssets } from "./renderingAssets";
+import type { RenderingAssets } from "./renderingAssets";
 
 export type Assets = {
     readonly audio: Readonly<AudioAssets>;

--- a/packages/game/src/ts/frontend/assets/audio/index.ts
+++ b/packages/game/src/ts/frontend/assets/audio/index.ts
@@ -17,10 +17,13 @@
 
 import type { AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
-import { loadMusics, type Musics } from "./musics";
-import { loadSounds, type Sounds } from "./sounds";
-import { loadVoiceLines, type SpeakerVoiceLines } from "./voiceLines";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import { loadMusics } from "./musics";
+import type { Musics } from "./musics";
+import { loadSounds } from "./sounds";
+import type { Sounds } from "./sounds";
+import { loadVoiceLines } from "./voiceLines";
+import type { SpeakerVoiceLines } from "./voiceLines";
 
 export type AudioAssets = {
     readonly sounds: Sounds;

--- a/packages/game/src/ts/frontend/assets/audio/musics.ts
+++ b/packages/game/src/ts/frontend/assets/audio/musics.ts
@@ -19,10 +19,11 @@ import "@babylonjs/core/Audio/audioEngine";
 import "@babylonjs/core/Audio/audioSceneComponent";
 
 import type { AbstractSound } from "@babylonjs/core/AudioV2/abstractAudio/abstractSound";
-import { CreateStreamingSoundAsync, type AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
+import { CreateStreamingSoundAsync } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
+import type { AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
 import type { IStreamingSoundOptions, StreamingSound } from "@babylonjs/core/AudioV2/abstractAudio/streamingSound";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 
 import wanderingPath from "@assets/sound/music/455855__andrewkn__wandering.mp3";
 import atlanteanTwilightPath from "@assets/sound/music/Atlantean_Twilight.mp3";

--- a/packages/game/src/ts/frontend/assets/audio/sounds.ts
+++ b/packages/game/src/ts/frontend/assets/audio/sounds.ts
@@ -18,10 +18,11 @@
 import "@babylonjs/core/Audio/audioEngine";
 import "@babylonjs/core/Audio/audioSceneComponent";
 
-import { CreateSoundAsync, type AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
+import { CreateSoundAsync } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
+import type { AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
 import type { IStaticSoundOptions, StaticSound } from "@babylonjs/core/AudioV2/abstractAudio/staticSound";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 
 import menuHoverSoundPath from "@assets/sound/166186__drminky__menu-screen-mouse-over.mp3";
 import disableWarpDriveSoundPath from "@assets/sound/204418__nhumphrey__large-engine.mp3";

--- a/packages/game/src/ts/frontend/assets/audio/voiceLines.ts
+++ b/packages/game/src/ts/frontend/assets/audio/voiceLines.ts
@@ -19,10 +19,11 @@ import "@babylonjs/core/Audio/audioEngine";
 import "@babylonjs/core/Audio/audioSceneComponent";
 
 import type { AbstractSound } from "@babylonjs/core/AudioV2/abstractAudio/abstractSound";
-import { CreateSoundAsync, type AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
+import { CreateSoundAsync } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
+import type { AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
 import type { IStaticSoundOptions, StaticSound } from "@babylonjs/core/AudioV2/abstractAudio/staticSound";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 
 import cannotEngageWarpDriveSoundPath from "@assets/sound/voice/CannotEngageWarpDriveCharlotte.mp3";
 import engagingWarpDriveSoundPath from "@assets/sound/voice/EngagingWarpDriveCharlotte.mp3";

--- a/packages/game/src/ts/frontend/assets/landingPadTexturePool.ts
+++ b/packages/game/src/ts/frontend/assets/landingPadTexturePool.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { createSquareTextDecalTexture } from "./textures/squareTextDecalTexture";
 

--- a/packages/game/src/ts/frontend/assets/materials/index.ts
+++ b/packages/game/src/ts/frontend/assets/materials/index.ts
@@ -20,7 +20,7 @@ import { PBRMaterial } from "@babylonjs/core/Materials/PBR/pbrMaterial";
 import { PBRMetallicRoughnessMaterial } from "@babylonjs/core/Materials/PBR/pbrMetallicRoughnessMaterial";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { TireMaterial } from "@/frontend/vehicle/tireMaterial";
 
@@ -30,7 +30,7 @@ import { RockMaterial } from "../procedural/rock/rockMaterial";
 import { SolarPanelMaterial } from "../procedural/solarPanel/solarPanelMaterial";
 import { LandingPadMaterial } from "../procedural/spaceStation/landingPad/landingPadMaterial";
 import { MetalSectionMaterial } from "../procedural/spaceStation/metalSectionMaterial";
-import { type Textures } from "../textures";
+import type { Textures } from "../textures";
 import { CrateMaterial } from "./crate";
 
 export type Materials = {

--- a/packages/game/src/ts/frontend/assets/objects/asteroids.ts
+++ b/packages/game/src/ts/frontend/assets/objects/asteroids.ts
@@ -15,14 +15,15 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AssetContainer } from "@babylonjs/core/assetContainer";
+import type { AssetContainer } from "@babylonjs/core/assetContainer";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
-import { PhysicsShapeMesh, type PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
-import { type Scene } from "@babylonjs/core/scene";
+import { PhysicsShapeMesh } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { CollisionMask } from "@/settings";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 import { loadAssetInContainerAsync } from "./utils";
 
 import asteroidPath from "@assets/asteroid/asteroid.glb";

--- a/packages/game/src/ts/frontend/assets/objects/humanoids.ts
+++ b/packages/game/src/ts/frontend/assets/objects/humanoids.ts
@@ -22,10 +22,11 @@ import type { Skeleton } from "@babylonjs/core/Bones/skeleton";
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { type Scene } from "@babylonjs/core/scene";
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import type { Scene } from "@babylonjs/core/scene";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 import { loadAssetInContainerAsync } from "./utils";
 
 import astronautHumanoidPath from "@assets/character/astronaut.glb";

--- a/packages/game/src/ts/frontend/assets/objects/index.ts
+++ b/packages/game/src/ts/frontend/assets/objects/index.ts
@@ -21,17 +21,20 @@ import "@babylonjs/loaders";
 
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type PhysicsShape, PhysicsShapeConvexHull } from "@babylonjs/core/Physics/v2/physicsShape";
-import { type Scene } from "@babylonjs/core/scene";
+import { PhysicsShapeConvexHull } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { CollisionMask } from "@/settings";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
-import { type Materials } from "../materials";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { Materials } from "../materials";
 import { createButterfly } from "../procedural/butterfly/butterfly";
 import { createGrassBlade } from "../procedural/grass/grassBlade";
-import { loadAsteroids, type Asteroid } from "./asteroids";
-import { loadHumanoidPrefabs, type HumanoidPrefabs } from "./humanoids";
+import { loadAsteroids } from "./asteroids";
+import type { Asteroid } from "./asteroids";
+import { loadHumanoidPrefabs } from "./humanoids";
+import type { HumanoidPrefabs } from "./humanoids";
 import { loadRock } from "./rock";
 import { loadAssetInContainerAsync } from "./utils";
 

--- a/packages/game/src/ts/frontend/assets/objects/rock.ts
+++ b/packages/game/src/ts/frontend/assets/objects/rock.ts
@@ -17,7 +17,8 @@
 
 import type { Material } from "@babylonjs/core/Materials/material";
 import { Mesh } from "@babylonjs/core/Meshes";
-import { PhysicsShapeConvexHull, type PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
+import { PhysicsShapeConvexHull } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
 import type { Scene } from "@babylonjs/core/scene";
 
 import { CollisionMask } from "@/settings";

--- a/packages/game/src/ts/frontend/assets/objects/utils.ts
+++ b/packages/game/src/ts/frontend/assets/objects/utils.ts
@@ -15,11 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AssetContainer } from "@babylonjs/core/assetContainer";
+import type { AssetContainer } from "@babylonjs/core/assetContainer";
 import { LoadAssetContainerAsync } from "@babylonjs/core/Loading";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 
 export async function loadAssetInContainerAsync(
     name: string,

--- a/packages/game/src/ts/frontend/assets/procedural/butterfly/butterfly.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/butterfly/butterfly.ts
@@ -17,7 +17,7 @@
 
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 export function createButterfly(scene: Scene): Mesh {
     const positions = new Float32Array(6 * 3);

--- a/packages/game/src/ts/frontend/assets/procedural/grass/grassBlade.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/grass/grassBlade.ts
@@ -18,7 +18,7 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 // rotation using https://www.wikiwand.com/en/Rodrigues%27_rotation_formula
 function rotateAround(vector: Vector3, axis: Vector3, theta: number): Vector3 {

--- a/packages/game/src/ts/frontend/assets/procedural/helpers/helixBuilder.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/helpers/helixBuilder.ts
@@ -1,7 +1,7 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Mesh } from "@babylonjs/core/Meshes";
 import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 /**
  * Create two walled spiral.

--- a/packages/game/src/ts/frontend/assets/procedural/helpers/ringBuilder.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/helpers/ringBuilder.ts
@@ -1,7 +1,7 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Mesh } from "@babylonjs/core/Meshes";
 import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 /**
  * Create two walled cylinder with a hole in the middle.

--- a/packages/game/src/ts/frontend/assets/procedural/hyperSpaceTunnel.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/hyperSpaceTunnel.ts
@@ -2,14 +2,14 @@ import { Effect } from "@babylonjs/core/Materials/effect";
 import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes";
+import type { TransformNode } from "@babylonjs/core/Meshes";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type NoiseTextures } from "@/frontend/assets/textures/noises";
+import type { NoiseTextures } from "@/frontend/assets/textures/noises";
 import { rotate } from "@/frontend/helpers/transform";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 import { clamp } from "@/utils/math";
 

--- a/packages/game/src/ts/frontend/assets/procedural/proceduralTexture.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/proceduralTexture.ts
@@ -18,7 +18,7 @@
 import { Engine } from "@babylonjs/core/Engines/engine";
 import { RawTexture } from "@babylonjs/core/Materials/Textures/rawTexture";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 export function createEmptyTexture(scene: Scene): RawTexture {
     const emptyTextureData = new Uint8Array([0, 0, 0, 0]); // RGBA

--- a/packages/game/src/ts/frontend/assets/procedural/solarPanel/solarPanelMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/solarPanel/solarPanelMaterial.ts
@@ -17,7 +17,7 @@
 
 import { NodeMaterialModes } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialModes";
 import { NodeMaterial } from "@babylonjs/core/Materials/Node/nodeMaterial";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import {
     float,
     mul,

--- a/packages/game/src/ts/frontend/assets/procedural/spaceDots.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceDots.ts
@@ -26,7 +26,8 @@ import type { Transformable } from "@/frontend/universe/architecture/transformab
 
 import { lerpSmooth } from "@/utils/math";
 
-import { SpaceDotsMaterial, type SpaceDotsMaterialOptions } from "./spaceDotsMaterial";
+import { SpaceDotsMaterial } from "./spaceDotsMaterial";
+import type { SpaceDotsMaterialOptions } from "./spaceDotsMaterial";
 
 export type SpaceDotsOptions = SpaceDotsMaterialOptions;
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/climber/climberRingMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/climber/climberRingMaterial.ts
@@ -18,10 +18,10 @@
 import { NodeMaterialModes } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialModes";
 import { NodeMaterial } from "@babylonjs/core/Materials/Node/nodeMaterial";
 import { Vector2 } from "@babylonjs/core/Maths/math.vector";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import * as BSL from "babylonjs-shading-language";
 
-import { type PBRTextures } from "@/frontend/assets/textures/materials";
+import type { PBRTextures } from "@/frontend/assets/textures/materials";
 
 export class ClimberRingMaterial extends NodeMaterial {
     constructor(name: string, textures: PBRTextures, scene: Scene) {

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/climber/spaceElevatorClimber.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/climber/spaceElevatorClimber.ts
@@ -15,19 +15,20 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Material } from "@babylonjs/core/Materials/material";
+import type { Material } from "@babylonjs/core/Materials/material";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { CreateBox, CreateTube, TransformNode } from "@babylonjs/core/Meshes";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type PBRTextures } from "@/frontend/assets/textures/materials";
-import { ObjectTargetCursorType, type Targetable, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import type { PBRTextures } from "@/frontend/assets/textures/materials";
+import { ObjectTargetCursorType } from "@/frontend/universe/architecture/targetable";
+import type { Targetable, TargetInfo } from "@/frontend/universe/architecture/targetable";
 
 import i18n from "@/i18n";
 
-import { type SolarPanelMaterial } from "../../solarPanel/solarPanelMaterial";
+import type { SolarPanelMaterial } from "../../solarPanel/solarPanelMaterial";
 import { MetalSectionMaterial } from "../metalSectionMaterial";
 import { ClimberRingMaterial } from "./climberRingMaterial";
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/engineBay.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/engineBay.ts
@@ -16,19 +16,20 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Light } from "@babylonjs/core/Lights/light";
-import { type Material } from "@babylonjs/core/Materials/material";
+import type { Material } from "@babylonjs/core/Materials/material";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { MeshBuilder, type Mesh } from "@babylonjs/core/Meshes";
-import { type AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import { MeshBuilder } from "@babylonjs/core/Meshes";
+import type { Mesh } from "@babylonjs/core/Meshes";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsMotionType, PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
-import { type PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
-import { type Scene } from "@babylonjs/core/scene";
+import type { PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { createEnvironmentAggregate } from "@/frontend/helpers/havok";
 import type { StationSection } from "@/frontend/universe/orbitalFacility/stationSection";
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/cylinder/cylinderHabitat.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/cylinder/cylinderHabitat.ts
@@ -20,18 +20,18 @@ import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Axis } from "@babylonjs/core/Maths/math.axis";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Matrix, Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { Scene } from "@babylonjs/core/scene";
 import { EarthG, getRotationPeriodForArtificialGravity } from "@cosmos-journeyer/physics";
 import type { CylinderHabitatModel } from "@cosmos-journeyer/universe-model";
 
-import { type Textures } from "@/frontend/assets/textures";
+import type { Textures } from "@/frontend/assets/textures";
 import { createEnvironmentAggregate } from "@/frontend/helpers/havok";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 import { Settings } from "@/settings";
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/cylinder/cylinderHabitatMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/cylinder/cylinderHabitatMaterial.ts
@@ -17,7 +17,7 @@
 
 import { NodeMaterialModes } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialModes";
 import { NodeMaterial } from "@babylonjs/core/Materials/Node/nodeMaterial";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import {
     abs,
     atan2,
@@ -46,7 +46,7 @@ import {
     vertexAttribute,
 } from "babylonjs-shading-language";
 
-import { type PBRTextures } from "@/frontend/assets/textures/materials";
+import type { PBRTextures } from "@/frontend/assets/textures/materials";
 
 export class CylinderHabitatMaterial extends NodeMaterial {
     constructor(radius: number, height: number, tesselation: number, textures: PBRTextures, scene: Scene) {

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/helix/helixHabitat.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/helix/helixHabitat.ts
@@ -16,25 +16,25 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { PointLight } from "@babylonjs/core/Lights/pointLight";
-import { type Material } from "@babylonjs/core/Materials/material";
+import type { Material } from "@babylonjs/core/Materials/material";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Matrix, Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { Scene } from "@babylonjs/core/scene";
 import { EarthG, getRotationPeriodForArtificialGravity } from "@cosmos-journeyer/physics";
 import type { HelixHabitatModel } from "@cosmos-journeyer/universe-model";
 
 import { createHelix } from "@/frontend/assets/procedural/helpers/helixBuilder";
-import { type Textures } from "@/frontend/assets/textures";
+import type { Textures } from "@/frontend/assets/textures";
 import { createEnvironmentAggregate } from "@/frontend/helpers/havok";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 import { Settings } from "@/settings";
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/helix/helixHabitatMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/helix/helixHabitatMaterial.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { NodeMaterial } from "@babylonjs/core/Materials/Node/nodeMaterial";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import {
     abs,
     f,
@@ -41,7 +41,7 @@ import {
     vertexAttribute,
 } from "babylonjs-shading-language";
 
-import { type PBRTextures } from "@/frontend/assets/textures/materials";
+import type { PBRTextures } from "@/frontend/assets/textures/materials";
 
 export class HelixHabitatMaterial extends NodeMaterial {
     constructor(

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/ring/ringHabitat.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/ring/ringHabitat.ts
@@ -20,19 +20,19 @@ import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Matrix, Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { Scene } from "@babylonjs/core/scene";
 import { EarthG, getRotationPeriodForArtificialGravity } from "@cosmos-journeyer/physics";
 import type { RingHabitatModel } from "@cosmos-journeyer/universe-model";
 
 import { createRing } from "@/frontend/assets/procedural/helpers/ringBuilder";
-import { type Textures } from "@/frontend/assets/textures";
+import type { Textures } from "@/frontend/assets/textures";
 import { createEnvironmentAggregate } from "@/frontend/helpers/havok";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 import { Settings } from "@/settings";
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/ring/ringHabitatMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/habitats/ring/ringHabitatMaterial.ts
@@ -17,7 +17,7 @@
 
 import { NodeMaterialModes } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialModes";
 import { NodeMaterial } from "@babylonjs/core/Materials/Node/nodeMaterial";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import {
     abs,
     f,
@@ -42,7 +42,7 @@ import {
     vertexAttribute,
 } from "babylonjs-shading-language";
 
-import { type PBRTextures } from "@/frontend/assets/textures/materials";
+import type { PBRTextures } from "@/frontend/assets/textures/materials";
 
 export class RingHabitatMaterial extends NodeMaterial {
     constructor(meanRadius: number, deltaRadius: number, height: number, textures: PBRTextures, scene: Scene) {

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingBay/landingBay.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingBay/landingBay.ts
@@ -22,26 +22,29 @@ import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { Scene } from "@babylonjs/core/scene";
 import { degreesToRadians, EarthG, getRotationPeriodForArtificialGravity } from "@cosmos-journeyer/physics";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type OrbitalFacilityModel, type LandingBayModel } from "@cosmos-journeyer/universe-model";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { OrbitalFacilityModel, LandingBayModel } from "@cosmos-journeyer/universe-model";
 
 import { createRing } from "@/frontend/assets/procedural/helpers/ringBuilder";
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { createEnvironmentAggregate } from "@/frontend/helpers/havok";
 import { createCircleInstanceBuffer } from "@/frontend/helpers/instancing";
-import { ObjectTargetCursorType, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import { ObjectTargetCursorType } from "@/frontend/universe/architecture/targetable";
+import type { TargetInfo } from "@/frontend/universe/architecture/targetable";
 import { LandingPadSize, LandingPadStatus } from "@/frontend/universe/orbitalFacility/landingPadManager";
 
 import i18n from "@/i18n";
 
-import { ProceduralSpotLightInstances, type ProceduralSpotLightInstanceData } from "../../spotLight";
+import { ProceduralSpotLightInstances } from "../../spotLight";
+import type { ProceduralSpotLightInstanceData } from "../../spotLight";
 import { LandingPad } from "../landingPad/landingPad";
 import { MetalSectionMaterial } from "../metalSectionMaterial";
 import { LandingBayMaterial } from "./landingBayMaterial";

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingBay/landingBayMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingBay/landingBayMaterial.ts
@@ -18,9 +18,9 @@
 import { NodeMaterialModes } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialModes";
 import { NodeMaterial } from "@babylonjs/core/Materials/Node/nodeMaterial";
 import { DynamicTexture } from "@babylonjs/core/Materials/Textures/dynamicTexture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type OrbitalFacilityModel } from "@cosmos-journeyer/universe-model";
+import type { OrbitalFacilityModel } from "@cosmos-journeyer/universe-model";
 import {
     abs,
     atan2,
@@ -50,7 +50,7 @@ import {
     vertexAttribute,
 } from "babylonjs-shading-language";
 
-import { type PBRTextures } from "@/frontend/assets/textures/materials";
+import type { PBRTextures } from "@/frontend/assets/textures/materials";
 
 import { Settings } from "@/settings";
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingPad/landingPad.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingPad/landingPad.ts
@@ -19,15 +19,17 @@ import { Material } from "@babylonjs/core/Materials/material";
 import { PBRMaterial } from "@babylonjs/core/Materials/PBR/pbrMaterial";
 import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { CreateDecal, type Mesh } from "@babylonjs/core/Meshes";
+import { CreateDecal } from "@babylonjs/core/Meshes";
+import type { Mesh } from "@babylonjs/core/Meshes";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { ObjectTargetCursorType, type TargetInfo } from "@/frontend/universe/architecture/targetable";
-import { type ILandingPad, type LandingPadSize } from "@/frontend/universe/orbitalFacility/landingPadManager";
+import { ObjectTargetCursorType } from "@/frontend/universe/architecture/targetable";
+import type { TargetInfo } from "@/frontend/universe/architecture/targetable";
+import type { ILandingPad, LandingPadSize } from "@/frontend/universe/orbitalFacility/landingPadManager";
 
 import i18n from "@/i18n";
 import { CollisionMask, Settings } from "@/settings";

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingPad/landingPadMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/landingPad/landingPadMaterial.ts
@@ -18,7 +18,7 @@
 import { NodeMaterialModes } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialModes";
 import { NodeMaterial } from "@babylonjs/core/Materials/Node/nodeMaterial";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import {
     add,
     f,
@@ -48,7 +48,7 @@ import {
     vertexAttribute,
 } from "babylonjs-shading-language";
 
-import { type PBRTextures } from "@/frontend/assets/textures/materials";
+import type { PBRTextures } from "@/frontend/assets/textures/materials";
 
 import { Settings } from "@/settings";
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/metalSectionMaterial.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/metalSectionMaterial.ts
@@ -17,10 +17,10 @@
 
 import { NodeMaterialModes } from "@babylonjs/core/Materials/Node/Enums/nodeMaterialModes";
 import { NodeMaterial } from "@babylonjs/core/Materials/Node/nodeMaterial";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import * as BSL from "babylonjs-shading-language";
 
-import { type PBRTextures } from "@/frontend/assets/textures/materials";
+import type { PBRTextures } from "@/frontend/assets/textures/materials";
 
 export class MetalSectionMaterial extends NodeMaterial {
     constructor(name: string, textures: PBRTextures, scene: Scene) {

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/solarSection.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/solarSection.ts
@@ -16,26 +16,26 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { PointLight } from "@babylonjs/core/Lights/pointLight";
-import { type Material } from "@babylonjs/core/Materials/material";
+import type { Material } from "@babylonjs/core/Materials/material";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Matrix, Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type AbstractMesh, type Mesh } from "@babylonjs/core/Meshes";
+import type { AbstractMesh, Mesh } from "@babylonjs/core/Meshes";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { Scene } from "@babylonjs/core/scene";
 import type { SolarSectionModel } from "@cosmos-journeyer/universe-model";
 
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { createEnvironmentAggregate } from "@/frontend/helpers/havok";
 import type { StationSection } from "@/frontend/universe/orbitalFacility/stationSection";
 
 import { Settings } from "@/settings";
 
-import { type SolarPanelMaterial } from "../solarPanel/solarPanelMaterial";
+import type { SolarPanelMaterial } from "../solarPanel/solarPanelMaterial";
 import { MetalSectionMaterial } from "./metalSectionMaterial";
 
 export class SolarSection implements StationSection {

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/tokamakSection.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/tokamakSection.ts
@@ -21,14 +21,14 @@ import { Axis } from "@babylonjs/core/Maths/math.axis";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { CreateBox, CreateCylinder, Mesh } from "@babylonjs/core/Meshes";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { Scene } from "@babylonjs/core/scene";
 import { getRadiatorAreaForHeat } from "@cosmos-journeyer/physics";
 import type { FusionSectionModel } from "@cosmos-journeyer/universe-model";
 
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { createEnvironmentAggregate } from "@/frontend/helpers/havok";
 import type { StationSection } from "@/frontend/universe/orbitalFacility/stationSection";
 

--- a/packages/game/src/ts/frontend/assets/procedural/spaceStation/utilitySection.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spaceStation/utilitySection.ts
@@ -16,22 +16,23 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { PointLight } from "@babylonjs/core/Lights/pointLight";
-import { type Material } from "@babylonjs/core/Materials/material";
+import type { Material } from "@babylonjs/core/Materials/material";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsMotionType, PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
-import { PhysicsShapeSphere, type PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
-import { type Scene } from "@babylonjs/core/scene";
+import { PhysicsShapeSphere } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { Scene } from "@babylonjs/core/scene";
 import type { UtilitySectionModel } from "@cosmos-journeyer/universe-model";
 
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import type { StationSection } from "@/frontend/universe/orbitalFacility/stationSection";
 
 import { CollisionMask, Settings } from "@/settings";

--- a/packages/game/src/ts/frontend/assets/procedural/spotLight.ts
+++ b/packages/game/src/ts/frontend/assets/procedural/spotLight.ts
@@ -17,7 +17,7 @@
 
 import { SpotLight } from "@babylonjs/core/Lights/spotLight";
 import { PBRMaterial } from "@babylonjs/core/Materials/PBR/pbrMaterial";
-import { type Color3 } from "@babylonjs/core/Maths/math.color";
+import type { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Matrix, Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";

--- a/packages/game/src/ts/frontend/assets/renderingAssets.ts
+++ b/packages/game/src/ts/frontend/assets/renderingAssets.ts
@@ -15,12 +15,15 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "./loadingProgressMonitor";
-import { initMaterials, type Materials } from "./materials";
-import { loadObjects, type Objects } from "./objects";
-import { loadTextures, type Textures } from "./textures";
+import type { ILoadingProgressMonitor } from "./loadingProgressMonitor";
+import { initMaterials } from "./materials";
+import type { Materials } from "./materials";
+import { loadObjects } from "./objects";
+import type { Objects } from "./objects";
+import { loadTextures } from "./textures";
+import type { Textures } from "./textures";
 
 export type RenderingAssets = {
     readonly textures: Textures;

--- a/packages/game/src/ts/frontend/assets/textures/gasPlanet.ts
+++ b/packages/game/src/ts/frontend/assets/textures/gasPlanet.ts
@@ -15,10 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 import { loadTextureAsync } from "./utils";
 
 import jupiterTexturePath from "@assets/sol/textures/jupiter.jpg";

--- a/packages/game/src/ts/frontend/assets/textures/index.ts
+++ b/packages/game/src/ts/frontend/assets/textures/index.ts
@@ -18,19 +18,26 @@
 import "@babylonjs/core/Helpers/sceneHelpers";
 import "@babylonjs/core/Materials/Textures/Loaders/envTextureLoader";
 
-import { type CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 import { loadEnvironmentTextures } from "./environment";
-import { loadGasPlanetTextures, type GasPlanetTextures } from "./gasPlanet";
-import { loadMaterialTextures, type AllMaterialTextures } from "./materials";
-import { loadNoiseTextures, type NoiseTextures } from "./noises";
-import { loadParticleTextures, type ParticleTextures } from "./particles";
-import { loadRingsTextures, type RingsTextures } from "./rings";
-import { loadTerrainTextures, type AllTerrainTextures } from "./terrains";
-import { createTexturePools, type TexturePools } from "./texturePools";
+import { loadGasPlanetTextures } from "./gasPlanet";
+import type { GasPlanetTextures } from "./gasPlanet";
+import { loadMaterialTextures } from "./materials";
+import type { AllMaterialTextures } from "./materials";
+import { loadNoiseTextures } from "./noises";
+import type { NoiseTextures } from "./noises";
+import { loadParticleTextures } from "./particles";
+import type { ParticleTextures } from "./particles";
+import { loadRingsTextures } from "./rings";
+import type { RingsTextures } from "./rings";
+import { loadTerrainTextures } from "./terrains";
+import type { AllTerrainTextures } from "./terrains";
+import { createTexturePools } from "./texturePools";
+import type { TexturePools } from "./texturePools";
 import { loadTextureAsync } from "./utils";
 
 import empty from "@assets/oneBlackPixel.webp";

--- a/packages/game/src/ts/frontend/assets/textures/materials/index.ts
+++ b/packages/game/src/ts/frontend/assets/textures/materials/index.ts
@@ -15,16 +15,20 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "../../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../../loadingProgressMonitor";
 import { loadTextureAsync } from "../utils";
 import { loadConcreteTextures } from "./concrete";
-import { loadCrateTextures, type CrateTextures } from "./crate";
-import { loadSolarPanelTextures, type SolarPanelTextures } from "./solarPanel";
-import { loadStyroFoamTextures, type StyroFoamTextures } from "./styrofoam";
-import { loadTireTextures, type TireTextures } from "./tire";
+import { loadCrateTextures } from "./crate";
+import type { CrateTextures } from "./crate";
+import { loadSolarPanelTextures } from "./solarPanel";
+import type { SolarPanelTextures } from "./solarPanel";
+import { loadStyroFoamTextures } from "./styrofoam";
+import type { StyroFoamTextures } from "./styrofoam";
+import { loadTireTextures } from "./tire";
+import type { TireTextures } from "./tire";
 
 import metalPanelsMetallicRoughness from "@assets/metalPanelMaterial/metallicRoughness.webp";
 import metalPanelsAlbedo from "@assets/metalPanelMaterial/sci-fi-panel1-albedo.webp";

--- a/packages/game/src/ts/frontend/assets/textures/particles.ts
+++ b/packages/game/src/ts/frontend/assets/textures/particles.ts
@@ -15,10 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 import { loadTextureAsync } from "./utils";
 
 import butterflyTexture from "@assets/butterfly.webp";

--- a/packages/game/src/ts/frontend/assets/textures/rings.ts
+++ b/packages/game/src/ts/frontend/assets/textures/rings.ts
@@ -15,10 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 import { loadTextureAsync } from "./utils";
 
 import saturnRingsPath from "@assets/sol/textures/saturn_rings.png";

--- a/packages/game/src/ts/frontend/assets/textures/terrains.ts
+++ b/packages/game/src/ts/frontend/assets/textures/terrains.ts
@@ -15,10 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 import { loadTextureAsync } from "./utils";
 
 import grassAlbedoRoughnessMap from "@assets/grassMaterial/wispy-grass-meadow_albedo_roughness.webp";

--- a/packages/game/src/ts/frontend/assets/textures/texturePools.ts
+++ b/packages/game/src/ts/frontend/assets/textures/texturePools.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { CloudsLut } from "@/frontend/postProcesses/clouds/cloudsLut";
 import { RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";

--- a/packages/game/src/ts/frontend/assets/textures/utils.ts
+++ b/packages/game/src/ts/frontend/assets/textures/utils.ts
@@ -17,9 +17,9 @@
 
 import { CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "../loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "../loadingProgressMonitor";
 
 export async function loadTextureAsync(
     name: string,

--- a/packages/game/src/ts/frontend/audio/musicConductor.ts
+++ b/packages/game/src/ts/frontend/audio/musicConductor.ts
@@ -21,8 +21,8 @@ import { SoundState } from "@babylonjs/core/AudioV2/soundState";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type Musics } from "@/frontend/assets/audio/musics";
-import { type StarSystemView } from "@/frontend/starSystemView";
+import type { Musics } from "@/frontend/assets/audio/musics";
+import type { StarSystemView } from "@/frontend/starSystemView";
 
 export class MusicConductor {
     private currentMusic: AbstractSound | null = null;

--- a/packages/game/src/ts/frontend/audio/soundPlayer.ts
+++ b/packages/game/src/ts/frontend/audio/soundPlayer.ts
@@ -18,9 +18,10 @@
 import type { StaticSound } from "@babylonjs/core/AudioV2/abstractAudio/staticSound";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type Sounds } from "@/frontend/assets/audio/sounds";
+import type { Sounds } from "@/frontend/assets/audio/sounds";
 
-import { SoundInstance, SoundInstanceMock, type ISoundInstance, type SoundInstanceOptions } from "./soundInstance";
+import { SoundInstance, SoundInstanceMock } from "./soundInstance";
+import type { ISoundInstance, SoundInstanceOptions } from "./soundInstance";
 
 export type SoundType =
     | "click"

--- a/packages/game/src/ts/frontend/audio/tts.ts
+++ b/packages/game/src/ts/frontend/audio/tts.ts
@@ -18,7 +18,7 @@
 import type { AbstractSound } from "@babylonjs/core/AudioV2/abstractAudio/abstractSound";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type SpeakerVoiceLines, type VoiceLines } from "@/frontend/assets/audio/voiceLines";
+import type { SpeakerVoiceLines, VoiceLines } from "@/frontend/assets/audio/voiceLines";
 
 export type Speaker = "Charlotte";
 

--- a/packages/game/src/ts/frontend/controls/characterControls/characterControls.ts
+++ b/packages/game/src/ts/frontend/controls/characterControls/characterControls.ts
@@ -18,19 +18,19 @@
 import "@babylonjs/core/Collisions/collisionCoordinator";
 
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { FreeCamera } from "@babylonjs/core/Cameras/freeCamera";
 import { Axis, Quaternion, Space } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
 
 import { lerpSmooth } from "@/utils/math";
 
 import { Settings } from "@/settings";
 
-import { type Controls } from "../";
+import type { Controls } from "../";
 import { CharacterInputs } from "./characterControlsInputs";
 import type { HumanoidAvatar } from "./humanoidAvatar";
 

--- a/packages/game/src/ts/frontend/controls/characterControls/humanoidAvatar.ts
+++ b/packages/game/src/ts/frontend/controls/characterControls/humanoidAvatar.ts
@@ -22,7 +22,8 @@ import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
 import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
-import { PhysicsAggregate, PhysicsShapeCapsule, type PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import { PhysicsAggregate, PhysicsShapeCapsule } from "@babylonjs/core/Physics/v2";
+import type { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
 import type { Scene } from "@babylonjs/core/scene";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
 

--- a/packages/game/src/ts/frontend/controls/defaultControls/defaultControls.ts
+++ b/packages/game/src/ts/frontend/controls/defaultControls/defaultControls.ts
@@ -15,12 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { FreeCamera } from "@babylonjs/core/Cameras/freeCamera";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { pitch, roll, translate, yaw } from "@/frontend/helpers/transform";
 
@@ -28,7 +28,7 @@ import { lerpSmooth } from "@/utils/math";
 
 import { Settings } from "@/settings";
 
-import { type Controls } from "../";
+import type { Controls } from "../";
 import { DefaultControlsInputs } from "./defaultControlsInputs";
 
 export class DefaultControls implements Controls {

--- a/packages/game/src/ts/frontend/controls/index.ts
+++ b/packages/game/src/ts/frontend/controls/index.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 export interface Controls extends Transformable {
     /**

--- a/packages/game/src/ts/frontend/cosmosJourneyer.ts
+++ b/packages/game/src/ts/frontend/cosmosJourneyer.ts
@@ -21,33 +21,37 @@ import "@babylonjs/core/Physics/physicsEngineComponent";
 
 import type { AudioEngineV2 } from "@babylonjs/core/AudioV2/abstractAudio/audioEngineV2";
 import { CreateAudioEngineAsync } from "@babylonjs/core/AudioV2/webAudio/webAudioEngine";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Engine } from "@babylonjs/core/Engines/engine";
 import { EngineFactory } from "@babylonjs/core/Engines/engineFactory";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { VideoRecorder } from "@babylonjs/core/Misc/videoRecorder";
 import { HavokPlugin } from "@babylonjs/core/Physics/v2/Plugins/havokPlugin";
 import { Scene } from "@babylonjs/core/scene";
 import HavokPhysics from "@babylonjs/havok";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type StarSystemCoordinates, getUniverseObjectId } from "@cosmos-journeyer/universe-model";
+import { getUniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
 import type { ICosmosJourneyerBackend } from "@/backend";
 import { CosmosJourneyerBackendLocal } from "@/backend/backendLocal";
-import { createUrlFromSave, type Save } from "@/backend/save/saveFileData";
+import { createUrlFromSave } from "@/backend/save/saveFileData";
+import type { Save } from "@/backend/save/saveFileData";
 import { getLatestSaveFromBackend } from "@/backend/save/saveHelpers";
-import {
-    type AtStationCoordinates,
-    type RelativeCoordinates,
-    type UniverseCoordinates,
+import type {
+    AtStationCoordinates,
+    RelativeCoordinates,
+    UniverseCoordinates,
 } from "@/backend/save/universeCoordinates";
 
-import { loadAssets, type Assets } from "@/frontend/assets/assets";
+import { loadAssets } from "@/frontend/assets/assets";
+import type { Assets } from "@/frontend/assets/assets";
 import { AudioMasks } from "@/frontend/audio/audioMasks";
 import { MusicConductor } from "@/frontend/audio/musicConductor";
-import { SoundPlayer, SoundPlayerMock, type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import { SoundPlayer, SoundPlayerMock } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { Tts } from "@/frontend/audio/tts";
 import { LoadingScreen } from "@/frontend/helpers/loadingScreen";
 import { positionNearObject } from "@/frontend/helpers/positionNearObject";
@@ -56,14 +60,15 @@ import { GeneralInputs } from "@/frontend/inputs/generalInputs";
 import { Player } from "@/frontend/player/player";
 import { StarMapView } from "@/frontend/starmap/starMapView";
 import { StarSystemView } from "@/frontend/starSystemView";
-import { DesktopUpdateController, type UpdatePresentationContext } from "@/frontend/ui/desktopUpdateController";
+import { DesktopUpdateController } from "@/frontend/ui/desktopUpdateController";
+import type { UpdatePresentationContext } from "@/frontend/ui/desktopUpdateController";
 import { alertModal, promptModalBoolean, promptModalString } from "@/frontend/ui/dialogModal";
 import { MainMenu } from "@/frontend/ui/mainMenu";
 import { PauseMenu } from "@/frontend/ui/pauseMenu";
 import { SidePanels } from "@/frontend/ui/sidePanels";
 import { TutorialLayer } from "@/frontend/ui/tutorial/tutorialLayer";
 import { TerrainSystemCpu } from "@/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystemCpu";
-import { type View } from "@/frontend/view";
+import type { View } from "@/frontend/view";
 
 import { getDesktopUpdateApi } from "@/utils/desktopUpdateApi";
 import { downloadCommanderArchive } from "@/utils/downloadCommanderArchive";
@@ -73,16 +78,18 @@ import { getPhysicsEngineV2 } from "@/utils/physicsEngineV2";
 import i18n, { initI18n } from "@/i18n";
 import { Settings } from "@/settings";
 
-import { LoadingProgressMonitor, type ILoadingProgressMonitor } from "./assets/loadingProgressMonitor";
+import { LoadingProgressMonitor } from "./assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "./assets/loadingProgressMonitor";
 import { loadStarMapTextures } from "./assets/textures/starMap";
 import { lookAt } from "./helpers/transform";
-import { NotificationManager, type INotificationManager } from "./ui/notificationManager";
+import { NotificationManager } from "./ui/notificationManager";
+import type { INotificationManager } from "./ui/notificationManager";
 import { FlightTutorial } from "./ui/tutorial/tutorials/flightTutorial";
 import { FuelScoopTutorial } from "./ui/tutorial/tutorials/fuelScoopTutorial";
 import { PlanetaryLandingTutorial } from "./ui/tutorial/tutorials/planetaryLandingTutorial";
 import { StarMapTutorial } from "./ui/tutorial/tutorials/starMapTutorial";
 import { StationLandingTutorial } from "./ui/tutorial/tutorials/stationLandingTutorial";
-import { type Tutorial } from "./ui/tutorial/tutorials/tutorial";
+import type { Tutorial } from "./ui/tutorial/tutorials/tutorial";
 
 type EngineState = "uninitialized" | "running" | "paused";
 

--- a/packages/game/src/ts/frontend/helpers/animations/cameraShake.ts
+++ b/packages/game/src/ts/frontend/helpers/animations/cameraShake.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import type { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
 import { Vector2 } from "@babylonjs/core/Maths/math.vector";
 
 import { CustomAnimation } from "./customAnimation";

--- a/packages/game/src/ts/frontend/helpers/animations/translation.ts
+++ b/packages/game/src/ts/frontend/helpers/animations/translation.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes";
+import type { TransformNode } from "@babylonjs/core/Meshes";
 
 import { translate } from "../transform";
 import { CustomAnimation } from "./customAnimation";

--- a/packages/game/src/ts/frontend/helpers/cipher.spec.ts
+++ b/packages/game/src/ts/frontend/helpers/cipher.spec.ts
@@ -17,7 +17,8 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { decryptFunction, encryptFunction, type EncryptedCodePayload } from "./cipher";
+import { decryptFunction, encryptFunction } from "./cipher";
+import type { EncryptedCodePayload } from "./cipher";
 
 describe("cipher", () => {
     const passphrase = "correct horse battery staple";

--- a/packages/game/src/ts/frontend/helpers/cipher.ts
+++ b/packages/game/src/ts/frontend/helpers/cipher.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertUnreachable, err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { assertUnreachable, err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 
 export type EncryptedCodePayloadV1 = {
     version: 1;

--- a/packages/game/src/ts/frontend/helpers/cullable.ts
+++ b/packages/game/src/ts/frontend/helpers/cullable.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 
 export interface Cullable {
     computeCulling(camera: Camera): void;

--- a/packages/game/src/ts/frontend/helpers/d3PieChart.ts
+++ b/packages/game/src/ts/frontend/helpers/d3PieChart.ts
@@ -16,7 +16,8 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { arc, interpolateViridis, pie, scaleSequential, type PieArcDatum } from "d3";
+import { arc, interpolateViridis, pie, scaleSequential } from "d3";
+import type { PieArcDatum } from "d3";
 
 export function makeD3PieChart<T>(
     data: DeepReadonly<T[]>,

--- a/packages/game/src/ts/frontend/helpers/getNeighborStarSystems.ts
+++ b/packages/game/src/ts/frontend/helpers/getNeighborStarSystems.ts
@@ -16,9 +16,10 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { starSystemCoordinatesEquals, type StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 

--- a/packages/game/src/ts/frontend/helpers/havok.ts
+++ b/packages/game/src/ts/frontend/helpers/havok.ts
@@ -15,10 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
-import { type PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type { PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { CollisionMask } from "@/settings";
 

--- a/packages/game/src/ts/frontend/helpers/inputControlsString.ts
+++ b/packages/game/src/ts/frontend/helpers/inputControlsString.ts
@@ -1,4 +1,4 @@
-import { type AxisComposite, type ButtonInputControl, type StickInputControl } from "@brianchirls/game-input/browser";
+import type { AxisComposite, ButtonInputControl, StickInputControl } from "@brianchirls/game-input/browser";
 import type DPadComposite from "@brianchirls/game-input/controls/DPadComposite";
 import type PressInteraction from "@brianchirls/game-input/interactions/PressInteraction";
 

--- a/packages/game/src/ts/frontend/helpers/isObjectVisibleOnScreen.ts
+++ b/packages/game/src/ts/frontend/helpers/isObjectVisibleOnScreen.ts
@@ -15,11 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Vector3 } from "@babylonjs/core/Maths/math";
 
-import { type HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 export function getProjectedDiameter01(
     position: Vector3,

--- a/packages/game/src/ts/frontend/helpers/loadingScreen.ts
+++ b/packages/game/src/ts/frontend/helpers/loadingScreen.ts
@@ -1,5 +1,5 @@
-import { type ILoadingScreen } from "@babylonjs/core/Loading/loadingScreen";
-import { type Nullable } from "@babylonjs/core/types";
+import type { ILoadingScreen } from "@babylonjs/core/Loading/loadingScreen";
+import type { Nullable } from "@babylonjs/core/types";
 
 import i18next from "@/i18n";
 

--- a/packages/game/src/ts/frontend/helpers/orbitalObjectTypeToDisplay.ts
+++ b/packages/game/src/ts/frontend/helpers/orbitalObjectTypeToDisplay.ts
@@ -16,8 +16,9 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getStellarTypeFromTemperature } from "@cosmos-journeyer/physics";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type OrbitalObjectModel } from "@cosmos-journeyer/universe-model";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { OrbitalObjectModel } from "@cosmos-journeyer/universe-model";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/helpers/positionNearObject.ts
+++ b/packages/game/src/ts/frontend/helpers/positionNearObject.ts
@@ -16,15 +16,16 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Lerp } from "@babylonjs/core/Maths/math.scalar.functions";
-import { Vector3, type Quaternion } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Quaternion } from "@babylonjs/core/Maths/math.vector";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 
-import { type Controls } from "@/frontend/controls";
+import type { Controls } from "@/frontend/controls";
 import { lookAt, roll, rotateAround, setRotationQuaternion } from "@/frontend/helpers/transform";
-import { type CanHaveRings } from "@/frontend/universe/architecture/canHaveRings";
-import { type HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
-import { type StarSystemController } from "@/frontend/universe/starSystemController";
+import type { CanHaveRings } from "@/frontend/universe/architecture/canHaveRings";
+import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
+import type { StarSystemController } from "@/frontend/universe/starSystemController";
 
 export function nearestObject(objectPosition: Vector3, bodies: ReadonlyArray<Transformable>): Transformable {
     let distance = -1;

--- a/packages/game/src/ts/frontend/helpers/screenshot.ts
+++ b/packages/game/src/ts/frontend/helpers/screenshot.ts
@@ -18,10 +18,12 @@
 import type { Camera } from "@babylonjs/core/Cameras/camera";
 import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { CreateScreenshotAsync } from "@babylonjs/core/Misc/screenshotTools";
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 import { z } from "zod";
 
-import { RelativeCoordinatesSchema, type RelativeCoordinates } from "@/backend/save/universeCoordinates";
+import { RelativeCoordinatesSchema } from "@/backend/save/universeCoordinates";
+import type { RelativeCoordinates } from "@/backend/save/universeCoordinates";
 
 import packageInfo from "../../../../package.json";
 

--- a/packages/game/src/ts/frontend/helpers/transform.ts
+++ b/packages/game/src/ts/frontend/helpers/transform.ts
@@ -16,8 +16,9 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
-import { Vector3, type Quaternion } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Quaternion } from "@babylonjs/core/Maths/math.vector";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 
 export function lookAt(transformNode: TransformNode, target: Vector3, useRightHandedSystem: boolean): void {
     transformNode.lookAt(target);

--- a/packages/game/src/ts/frontend/missions/common.ts
+++ b/packages/game/src/ts/frontend/missions/common.ts
@@ -1,8 +1,9 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { lightYearsToMeters } from "@cosmos-journeyer/physics";
-import { starSystemCoordinatesEquals, type StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
@@ -12,7 +13,7 @@ import { parseDistance } from "@/utils/strings/parseToStrings";
 
 import i18n from "@/i18n";
 
-import { type MissionContext } from "./missionContext";
+import type { MissionContext } from "./missionContext";
 
 export function getGoToSystemInstructions(
     missionContext: MissionContext,

--- a/packages/game/src/ts/frontend/missions/generateSightSeeingMissions.ts
+++ b/packages/game/src/ts/frontend/missions/generateSightSeeingMissions.ts
@@ -15,25 +15,21 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type OrbitalFacilityModel,
-    type StarSystemModel,
-    getUniverseObjectId,
-    type UniverseObjectId,
-} from "@cosmos-journeyer/universe-model";
+import { getUniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { OrbitalFacilityModel, StarSystemModel, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 import { uniformRandBool } from "extended-random";
 
 import { MissionType } from "@/backend/missions/missionSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { getNeighborStarSystemCoordinates } from "@/frontend/helpers/getNeighborStarSystems";
-import { type Player } from "@/frontend/player/player";
+import type { Player } from "@/frontend/player/player";
 
 import { getRngFromSeed } from "@/utils/getRngFromSeed";
 
-import { type Mission } from "./mission";
+import type { Mission } from "./mission";
 import { newSightSeeingMission } from "./sightSeeingMission";
 
 /**

--- a/packages/game/src/ts/frontend/missions/mission.ts
+++ b/packages/game/src/ts/frontend/missions/mission.ts
@@ -15,17 +15,19 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type StarSystemCoordinates, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { MissionType, type MissionSerialized } from "@/backend/missions/missionSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { MissionType } from "@/backend/missions/missionSerialized";
+import type { MissionSerialized } from "@/backend/missions/missionSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import i18n from "@/i18n";
 
-import { type MissionContext } from "./missionContext";
+import type { MissionContext } from "./missionContext";
 import { deserializeMissionNode } from "./nodes/deserializeNode";
-import { type MissionNode } from "./nodes/missionNode";
+import type { MissionNode } from "./nodes/missionNode";
 
 /**
  * General mission abstraction. The mission can have any arbitrary task tree and reward.

--- a/packages/game/src/ts/frontend/missions/missionContext.ts
+++ b/packages/game/src/ts/frontend/missions/missionContext.ts
@@ -15,13 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 
-import { type Itinerary } from "@/backend/player/serializedPlayer";
+import type { Itinerary } from "@/backend/player/serializedPlayer";
 
-import { type StarSystemController } from "@/frontend/universe/starSystemController";
+import type { StarSystemController } from "@/frontend/universe/starSystemController";
 
 /**
  * Describes information used by mission nodes to update their state

--- a/packages/game/src/ts/frontend/missions/nodes/actions/sightseeing/missionAsteroidFieldNode.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/actions/sightseeing/missionAsteroidFieldNode.ts
@@ -20,17 +20,14 @@ import { lightYearsToMeters } from "@cosmos-journeyer/physics";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 import {
     starSystemCoordinatesEquals,
-    type StarSystemCoordinates,
     universeObjectIdEquals,
-    type UniverseObjectId,
     getObjectModelById,
 } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import {
-    AsteroidFieldMissionState,
-    type MissionAsteroidFieldNodeSerialized,
-} from "@/backend/missions/missionAsteroidFieldNodeSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { AsteroidFieldMissionState } from "@/backend/missions/missionAsteroidFieldNodeSerialized";
+import type { MissionAsteroidFieldNodeSerialized } from "@/backend/missions/missionAsteroidFieldNodeSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 
@@ -40,8 +37,8 @@ import { parseDistance } from "@/utils/strings/parseToStrings";
 import i18n from "@/i18n";
 
 import { getGoToSystemInstructions } from "../../../common";
-import { type MissionContext } from "../../../missionContext";
-import { type MissionNode } from "../../missionNode";
+import type { MissionContext } from "../../../missionContext";
+import type { MissionNode } from "../../missionNode";
 import type { MissionNodeBase } from "../../missionNodeBase";
 
 /**

--- a/packages/game/src/ts/frontend/missions/nodes/actions/sightseeing/missionFlyByNode.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/actions/sightseeing/missionFlyByNode.ts
@@ -18,15 +18,12 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { lightYearsToMeters } from "@cosmos-journeyer/physics";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
-import {
-    starSystemCoordinatesEquals,
-    type StarSystemCoordinates,
-    universeObjectIdEquals,
-    type UniverseObjectId,
-} from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals, universeObjectIdEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { FlyByState, type MissionFlyByNodeSerialized } from "@/backend/missions/missionFlyByNodeSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { FlyByState } from "@/backend/missions/missionFlyByNodeSerialized";
+import type { MissionFlyByNodeSerialized } from "@/backend/missions/missionFlyByNodeSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
@@ -36,8 +33,8 @@ import { parseDistance } from "@/utils/strings/parseToStrings";
 import i18n from "@/i18n";
 
 import { getGoToSystemInstructions } from "../../../common";
-import { type MissionContext } from "../../../missionContext";
-import { type MissionNode } from "../../missionNode";
+import type { MissionContext } from "../../../missionContext";
+import type { MissionNode } from "../../missionNode";
 import type { MissionNodeBase } from "../../missionNodeBase";
 
 /**

--- a/packages/game/src/ts/frontend/missions/nodes/actions/sightseeing/missionTerminatorLandingNode.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/actions/sightseeing/missionTerminatorLandingNode.ts
@@ -19,18 +19,12 @@ import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
 import { lightYearsToMeters } from "@cosmos-journeyer/physics";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
-import {
-    starSystemCoordinatesEquals,
-    type StarSystemCoordinates,
-    universeObjectIdEquals,
-    type UniverseObjectId,
-} from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals, universeObjectIdEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import {
-    LandMissionState,
-    type MissionTerminatorLandingNodeSerialized,
-} from "@/backend/missions/missionTerminatorLandingNodeSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { LandMissionState } from "@/backend/missions/missionTerminatorLandingNodeSerialized";
+import type { MissionTerminatorLandingNodeSerialized } from "@/backend/missions/missionTerminatorLandingNodeSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 
@@ -40,8 +34,8 @@ import i18n from "@/i18n";
 import { CollisionMask } from "@/settings";
 
 import { getGoToSystemInstructions } from "../../../common";
-import { type MissionContext } from "../../../missionContext";
-import { type MissionNode } from "../../missionNode";
+import type { MissionContext } from "../../../missionContext";
+import type { MissionNode } from "../../missionNode";
 import type { MissionNodeBase } from "../../missionNodeBase";
 
 /**

--- a/packages/game/src/ts/frontend/missions/nodes/deserializeNode.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/deserializeNode.ts
@@ -15,19 +15,20 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 
-import { type MissionAsteroidFieldNodeSerialized } from "@/backend/missions/missionAsteroidFieldNodeSerialized";
-import { type MissionFlyByNodeSerialized } from "@/backend/missions/missionFlyByNodeSerialized";
-import {
-    type MissionAndNodeSerialized,
-    type MissionNodeSerialized,
-    type MissionOrNodeSerialized,
-    type MissionSequenceNodeSerialized,
-    type MissionXorNodeSerialized,
+import type { MissionAsteroidFieldNodeSerialized } from "@/backend/missions/missionAsteroidFieldNodeSerialized";
+import type { MissionFlyByNodeSerialized } from "@/backend/missions/missionFlyByNodeSerialized";
+import type {
+    MissionAndNodeSerialized,
+    MissionNodeSerialized,
+    MissionOrNodeSerialized,
+    MissionSequenceNodeSerialized,
+    MissionXorNodeSerialized,
 } from "@/backend/missions/missionNodeSerialized";
-import { type MissionTerminatorLandingNodeSerialized } from "@/backend/missions/missionTerminatorLandingNodeSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { MissionTerminatorLandingNodeSerialized } from "@/backend/missions/missionTerminatorLandingNodeSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { MissionAsteroidFieldNode } from "./actions/sightseeing/missionAsteroidFieldNode";
 import { MissionFlyByNode } from "./actions/sightseeing/missionFlyByNode";
@@ -36,7 +37,7 @@ import { MissionAndNode } from "./logic/missionAndNode";
 import { MissionOrNode } from "./logic/missionOrNode";
 import { MissionSequenceNode } from "./logic/missionSequenceNode";
 import { MissionXorNode } from "./logic/missionXorNode";
-import { type MissionNode } from "./missionNode";
+import type { MissionNode } from "./missionNode";
 
 /**
  * Deserialize recursively a mission node.

--- a/packages/game/src/ts/frontend/missions/nodes/logic/missionAndNode.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/logic/missionAndNode.ts
@@ -15,16 +15,16 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type StarSystemCoordinates, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type MissionAndNodeSerialized } from "@/backend/missions/missionNodeSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { MissionAndNodeSerialized } from "@/backend/missions/missionNodeSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import i18n from "@/i18n";
 
-import { type MissionContext } from "../../missionContext";
+import type { MissionContext } from "../../missionContext";
 import type { MissionNode } from "../missionNode";
-import { type MissionNodeBase } from "../missionNodeBase";
+import type { MissionNodeBase } from "../missionNodeBase";
 
 /**
  * Node used to describe a set of tasks that must all be completed in any order.

--- a/packages/game/src/ts/frontend/missions/nodes/logic/missionOrNode.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/logic/missionOrNode.ts
@@ -15,16 +15,16 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type StarSystemCoordinates, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type MissionOrNodeSerialized } from "@/backend/missions/missionNodeSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { MissionOrNodeSerialized } from "@/backend/missions/missionNodeSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import i18n from "@/i18n";
 
-import { type MissionContext } from "../../missionContext";
+import type { MissionContext } from "../../missionContext";
 import type { MissionNode } from "../missionNode";
-import { type MissionNodeBase } from "../missionNodeBase";
+import type { MissionNodeBase } from "../missionNodeBase";
 
 /**
  * Node used to describe a set of tasks where only a subset must be completed in any order.

--- a/packages/game/src/ts/frontend/missions/nodes/logic/missionSequenceNode.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/logic/missionSequenceNode.ts
@@ -15,14 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type StarSystemCoordinates, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type MissionSequenceNodeSerialized } from "@/backend/missions/missionNodeSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { MissionSequenceNodeSerialized } from "@/backend/missions/missionNodeSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type MissionContext } from "../../missionContext";
+import type { MissionContext } from "../../missionContext";
 import type { MissionNode } from "../missionNode";
-import { type MissionNodeBase } from "../missionNodeBase";
+import type { MissionNodeBase } from "../missionNodeBase";
 
 /**
  * Node used to describe a sequence of tasks that must be completed in order.

--- a/packages/game/src/ts/frontend/missions/nodes/logic/missionXorNode.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/logic/missionXorNode.ts
@@ -15,14 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type StarSystemCoordinates, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type MissionXorNodeSerialized } from "@/backend/missions/missionNodeSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { MissionXorNodeSerialized } from "@/backend/missions/missionNodeSerialized";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type MissionContext } from "../../missionContext";
+import type { MissionContext } from "../../missionContext";
 import type { MissionNode } from "../missionNode";
-import { type MissionNodeBase } from "../missionNodeBase";
+import type { MissionNodeBase } from "../missionNodeBase";
 
 /**
  * Node used to describe a set of tasks where only one must be completed.

--- a/packages/game/src/ts/frontend/missions/nodes/missionNodeBase.ts
+++ b/packages/game/src/ts/frontend/missions/nodes/missionNodeBase.ts
@@ -15,12 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type StarSystemCoordinates, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type MissionContext } from "../missionContext";
-import { type MissionNode } from "./missionNode";
+import type { MissionContext } from "../missionContext";
+import type { MissionNode } from "./missionNode";
 
 /**
  * Describes any node in the mission tree.

--- a/packages/game/src/ts/frontend/missions/sightSeeingMission.ts
+++ b/packages/game/src/ts/frontend/missions/sightSeeingMission.ts
@@ -17,10 +17,10 @@
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
-import { type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
 import { MissionType } from "@/backend/missions/missionSerialized";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 
@@ -28,7 +28,7 @@ import { Mission } from "./mission";
 import { MissionAsteroidFieldNode } from "./nodes/actions/sightseeing/missionAsteroidFieldNode";
 import { MissionFlyByNode } from "./nodes/actions/sightseeing/missionFlyByNode";
 import { MissionTerminatorLandingNode } from "./nodes/actions/sightseeing/missionTerminatorLandingNode";
-import { type MissionNode } from "./nodes/missionNode";
+import type { MissionNode } from "./nodes/missionNode";
 
 /**
  * Sightseeing mission types are a subset of mission types.

--- a/packages/game/src/ts/frontend/player/aiPlayerControls.ts
+++ b/packages/game/src/ts/frontend/player/aiPlayerControls.ts
@@ -15,12 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { AiSpaceshipControls } from "@/frontend/spaceship/aiSpaceshipControls";
 import { Spaceship } from "@/frontend/spaceship/spaceship";
 

--- a/packages/game/src/ts/frontend/player/player.spec.ts
+++ b/packages/game/src/ts/frontend/player/player.spec.ts
@@ -15,13 +15,15 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type StarSystemCoordinates, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type SpaceDiscoveryData } from "@/backend/encyclopaedia/encyclopaediaGalactica";
+import type { SpaceDiscoveryData } from "@/backend/encyclopaedia/encyclopaediaGalactica";
 import { FlyByState } from "@/backend/missions/missionFlyByNodeSerialized";
-import { MissionType, type MissionSerialized } from "@/backend/missions/missionSerialized";
-import { SerializedPlayerSchema, type SerializedPlayer } from "@/backend/player/serializedPlayer";
+import { MissionType } from "@/backend/missions/missionSerialized";
+import type { MissionSerialized } from "@/backend/missions/missionSerialized";
+import { SerializedPlayerSchema } from "@/backend/player/serializedPlayer";
+import type { SerializedPlayer } from "@/backend/player/serializedPlayer";
 import { getDefaultSerializedSpaceship } from "@/backend/spaceship/serializedSpaceship";
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";

--- a/packages/game/src/ts/frontend/player/player.ts
+++ b/packages/game/src/ts/frontend/player/player.ts
@@ -17,24 +17,18 @@
 
 import { Observable } from "@babylonjs/core/Misc/observable";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type StarSystemCoordinates,
-    type UniverseObjectId,
-    serializeUniverseObjectId,
-} from "@cosmos-journeyer/universe-model";
+import { serializeUniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type SpaceDiscoveryData } from "@/backend/encyclopaedia/encyclopaediaGalactica";
-import { type CompletedTutorials, type Itinerary, type SerializedPlayer } from "@/backend/player/serializedPlayer";
-import { type SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
-import {
-    getDefaultSerializedSpaceship,
-    SerializedSpaceshipSchema,
-    type SerializedSpaceship,
-} from "@/backend/spaceship/serializedSpaceship";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { SpaceDiscoveryData } from "@/backend/encyclopaedia/encyclopaediaGalactica";
+import type { CompletedTutorials, Itinerary, SerializedPlayer } from "@/backend/player/serializedPlayer";
+import type { SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
+import { getDefaultSerializedSpaceship, SerializedSpaceshipSchema } from "@/backend/spaceship/serializedSpaceship";
+import type { SerializedSpaceship } from "@/backend/spaceship/serializedSpaceship";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { Mission } from "@/frontend/missions/mission";
-import { type Spaceship } from "@/frontend/spaceship/spaceship";
+import type { Spaceship } from "@/frontend/spaceship/spaceship";
 
 import { jsonSafeParse } from "@/utils/json";
 

--- a/packages/game/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/atmosphere/atmosphereUniforms.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Effect } from "@babylonjs/core/Materials/effect";
+import type { Effect } from "@babylonjs/core/Materials/effect";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 import { Settings } from "@/settings";

--- a/packages/game/src/ts/frontend/postProcesses/celestialBodyUberShader/celestialBodyUberShaderPass.ts
+++ b/packages/game/src/ts/frontend/postProcesses/celestialBodyUberShader/celestialBodyUberShaderPass.ts
@@ -15,42 +15,41 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import type { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Matrix } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
-import { type Scene } from "@babylonjs/core/scene";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type AnomalyModel, type DarkKnightModel } from "@cosmos-journeyer/universe-model";
+import type { Scene } from "@babylonjs/core/scene";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { AnomalyModel, DarkKnightModel } from "@cosmos-journeyer/universe-model";
 
 import type { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
-import { type AtmosphereUniforms } from "@/frontend/postProcesses/atmosphere/atmosphereUniforms";
-import {
-    CloudsSamplerNames,
-    CloudsUniformNames,
-    type CloudsUniforms,
-} from "@/frontend/postProcesses/clouds/cloudsUniforms";
-import { type OceanUniforms } from "@/frontend/postProcesses/ocean/oceanUniforms";
-import { RingsSamplerNames, RingsUniformNames, type RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
+import type { AtmosphereUniforms } from "@/frontend/postProcesses/atmosphere/atmosphereUniforms";
+import { CloudsSamplerNames, CloudsUniformNames } from "@/frontend/postProcesses/clouds/cloudsUniforms";
+import type { CloudsUniforms } from "@/frontend/postProcesses/clouds/cloudsUniforms";
+import type { OceanUniforms } from "@/frontend/postProcesses/ocean/oceanUniforms";
+import { RingsSamplerNames, RingsUniformNames } from "@/frontend/postProcesses/rings/ringsUniform";
+import type { RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
 import { CameraUniformNames, setCameraUniforms } from "@/frontend/postProcesses/uniforms/cameraUniforms";
 import { ObjectUniformNames, setObjectUniforms } from "@/frontend/postProcesses/uniforms/objectUniforms";
 import { SamplerUniformNames, setSamplerUniforms } from "@/frontend/postProcesses/uniforms/samplerUniforms";
 import {
     setSphereShadowCasterUniforms,
     SphereShadowCasterUniformNames,
-    type SphereShadowCaster,
 } from "@/frontend/postProcesses/uniforms/sphereShadowCasterUniforms";
+import type { SphereShadowCaster } from "@/frontend/postProcesses/uniforms/sphereShadowCasterUniforms";
 import {
     setStellarObjectUniforms,
     StellarObjectUniformNames,
 } from "@/frontend/postProcesses/uniforms/stellarObjectUniforms";
-import { type UpdatablePostProcess } from "@/frontend/postProcesses/updatablePostProcess";
+import type { UpdatablePostProcess } from "@/frontend/postProcesses/updatablePostProcess";
 
-import { type MatterJetsSettings } from "./matterJetsSettings";
+import type { MatterJetsSettings } from "./matterJetsSettings";
 
 import celestialBodyUberShaderFragment from "@shaders/celestialBodyUberShaderFragment.glsl";
 

--- a/packages/game/src/ts/frontend/postProcesses/clouds/cloudsLut.ts
+++ b/packages/game/src/ts/frontend/postProcesses/clouds/cloudsLut.ts
@@ -17,9 +17,9 @@
 
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { ProceduralTexture } from "@babylonjs/core/Materials/Textures/Procedurals/proceduralTexture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type CloudsModel } from "@cosmos-journeyer/universe-model";
+import type { CloudsModel } from "@cosmos-journeyer/universe-model";
 
 import flatCloudLUT from "@shaders/textures/flatCloudLUT.glsl";
 

--- a/packages/game/src/ts/frontend/postProcesses/clouds/cloudsUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/clouds/cloudsUniforms.ts
@@ -15,17 +15,17 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Effect } from "@babylonjs/core/Materials/effect";
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Effect } from "@babylonjs/core/Materials/effect";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type CloudsModel } from "@cosmos-journeyer/universe-model";
+import type { CloudsModel } from "@cosmos-journeyer/universe-model";
 
 import { createEmptyTexture } from "@/frontend/assets/procedural/proceduralTexture";
 
-import { type ItemPool } from "@/utils/itemPool";
+import type { ItemPool } from "@/utils/itemPool";
 
-import { type CloudsLut } from "./cloudsLut";
+import type { CloudsLut } from "./cloudsLut";
 
 export const CloudsUniformNames = {
     LAYER_RADIUS: "clouds_layerRadius",

--- a/packages/game/src/ts/frontend/postProcesses/colorCorrection.ts
+++ b/packages/game/src/ts/frontend/postProcesses/colorCorrection.ts
@@ -19,7 +19,7 @@ import { Constants } from "@babylonjs/core/Engines/constants";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import colorCorrectionFragment from "@shaders/colorCorrection.glsl";
 

--- a/packages/game/src/ts/frontend/postProcesses/lensFlarePostProcess.ts
+++ b/packages/game/src/ts/frontend/postProcesses/lensFlarePostProcess.ts
@@ -15,15 +15,15 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Matrix } from "@babylonjs/core/Maths/math";
 import { Vector3, Vector4 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import type { RGBColor } from "@/utils/colors";
 

--- a/packages/game/src/ts/frontend/postProcesses/ocean/oceanUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/ocean/oceanUniforms.ts
@@ -15,10 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Effect } from "@babylonjs/core/Materials/effect";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { Effect } from "@babylonjs/core/Materials/effect";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 
-import { type WaterTextures } from "@/frontend/assets/textures";
+import type { WaterTextures } from "@/frontend/assets/textures";
 
 const OceanUniformNames = {
     OCEAN_RADIUS: "ocean_radius",

--- a/packages/game/src/ts/frontend/postProcesses/postProcessManager.ts
+++ b/packages/game/src/ts/frontend/postProcesses/postProcessManager.ts
@@ -17,38 +17,39 @@
 
 import "@babylonjs/core/PostProcesses/RenderPipeline/postProcessRenderPipelineManagerSceneComponent";
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import type { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
 import { BloomEffect } from "@babylonjs/core/PostProcesses/bloomEffect";
 import { FxaaPostProcess } from "@babylonjs/core/PostProcesses/fxaaPostProcess";
-import { type PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
+import type { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 import { PostProcessRenderEffect } from "@babylonjs/core/PostProcesses/RenderPipeline/postProcessRenderEffect";
 import { PostProcessRenderPipeline } from "@babylonjs/core/PostProcesses/RenderPipeline/postProcessRenderPipeline";
-import { type PostProcessRenderPipelineManager } from "@babylonjs/core/PostProcesses/RenderPipeline/postProcessRenderPipelineManager";
+import type { PostProcessRenderPipelineManager } from "@babylonjs/core/PostProcesses/RenderPipeline/postProcessRenderPipelineManager";
 import type { Scene } from "@babylonjs/core/scene";
-import { arraysEqual, assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type JuliaSetModel,
-    type MandelboxModel,
-    type MandelbulbModel,
-    type MengerSpongeModel,
-    type SierpinskiPyramidModel,
+import { arraysEqual, assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type {
+    JuliaSetModel,
+    MandelboxModel,
+    MandelbulbModel,
+    MengerSpongeModel,
+    SierpinskiPyramidModel,
 } from "@cosmos-journeyer/universe-model";
 
-import { type HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
-import { type CelestialBody } from "@/frontend/universe/architecture/orbitalObject";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
-import { type GasPlanet } from "@/frontend/universe/planets/gasPlanet/gasPlanet";
-import { type TelluricPlanet } from "@/frontend/universe/planets/telluricPlanet/telluricPlanet";
-import { type BlackHole } from "@/frontend/universe/stellarObjects/blackHole/blackHole";
+import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
+import type { CelestialBody } from "@/frontend/universe/architecture/orbitalObject";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
+import type { GasPlanet } from "@/frontend/universe/planets/gasPlanet/gasPlanet";
+import type { TelluricPlanet } from "@/frontend/universe/planets/telluricPlanet/telluricPlanet";
+import type { BlackHole } from "@/frontend/universe/stellarObjects/blackHole/blackHole";
 import { BlackHolePostProcess } from "@/frontend/universe/stellarObjects/blackHole/blackHolePostProcess";
-import { type NeutronStar } from "@/frontend/universe/stellarObjects/neutronStar/neutronStar";
-import { type Star } from "@/frontend/universe/stellarObjects/star/star";
+import type { NeutronStar } from "@/frontend/universe/stellarObjects/neutronStar/neutronStar";
+import type { Star } from "@/frontend/universe/stellarObjects/star/star";
 
 import { getRgbFromTemperature } from "@/utils/specrend";
 
@@ -58,9 +59,9 @@ import { CelestialBodyUberShaderPass } from "./celestialBodyUberShader/celestial
 import { getMatterJetsVisibilityRadius } from "./celestialBodyUberShader/matterJetsSettings";
 import { ColorCorrection } from "./colorCorrection";
 import { LensFlarePostProcess } from "./lensFlarePostProcess";
-import { type RingsUniforms } from "./rings/ringsUniform";
+import type { RingsUniforms } from "./rings/ringsUniform";
 import { SphereShadowsPostProcess } from "./sphereShadowsPostProcess";
-import { type UpdatablePostProcess } from "./updatablePostProcess";
+import type { UpdatablePostProcess } from "./updatablePostProcess";
 import { VolumetricLight } from "./volumetricLight/volumetricLight";
 
 type RenderableBodyEntry = {

--- a/packages/game/src/ts/frontend/postProcesses/rings/ringsProceduralLut.ts
+++ b/packages/game/src/ts/frontend/postProcesses/rings/ringsProceduralLut.ts
@@ -18,9 +18,9 @@
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { ProceduralTexture } from "@babylonjs/core/Materials/Textures/Procedurals/proceduralTexture";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type ProceduralRingsModel } from "@cosmos-journeyer/universe-model";
+import type { ProceduralRingsModel } from "@cosmos-journeyer/universe-model";
 
 import ringsPatternLutCode from "@shaders/textures/ringsPatternLUT.glsl";
 

--- a/packages/game/src/ts/frontend/postProcesses/rings/ringsUniform.ts
+++ b/packages/game/src/ts/frontend/postProcesses/rings/ringsUniform.ts
@@ -15,18 +15,19 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Effect } from "@babylonjs/core/Materials/effect";
-import { type Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type Scene } from "@babylonjs/core/scene";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type ProceduralRingsModel, type RingsModel, type TexturedRingsModel } from "@cosmos-journeyer/universe-model";
+import type { Effect } from "@babylonjs/core/Materials/effect";
+import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { ProceduralRingsModel, RingsModel, TexturedRingsModel } from "@cosmos-journeyer/universe-model";
 
 import { createEmptyTexture } from "@/frontend/assets/procedural/proceduralTexture";
-import { type Textures } from "@/frontend/assets/textures";
+import type { Textures } from "@/frontend/assets/textures";
 
-import { type ItemPool } from "@/utils/itemPool";
+import type { ItemPool } from "@/utils/itemPool";
 
-import { type RingsProceduralPatternLut } from "./ringsProceduralLut";
+import type { RingsProceduralPatternLut } from "./ringsProceduralLut";
 
 export const RingsUniformNames = {
     RING_INNER_RADIUS: "rings_inner_radius",

--- a/packages/game/src/ts/frontend/postProcesses/sphereShadowsPostProcess.ts
+++ b/packages/game/src/ts/frontend/postProcesses/sphereShadowsPostProcess.ts
@@ -15,13 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import type { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import type { DepthRendererManager } from "../helpers/depthRendererManager";
 import type { HasBoundingSphere } from "../universe/architecture/hasBoundingSphere";

--- a/packages/game/src/ts/frontend/postProcesses/starMapNebulaPostProcess.ts
+++ b/packages/game/src/ts/frontend/postProcesses/starMapNebulaPostProcess.ts
@@ -15,14 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { PassPostProcess } from "@babylonjs/core/PostProcesses/passPostProcess";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { CameraUniformNames, setCameraUniforms } from "@/frontend/postProcesses/uniforms/cameraUniforms";
 

--- a/packages/game/src/ts/frontend/postProcesses/uniforms/cameraUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/uniforms/cameraUniforms.ts
@@ -15,8 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
-import { type Effect } from "@babylonjs/core/Materials/effect";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
+import type { Effect } from "@babylonjs/core/Materials/effect";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 import { OffsetViewToRef } from "@/frontend/helpers/floatingOrigin";

--- a/packages/game/src/ts/frontend/postProcesses/uniforms/objectUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/uniforms/objectUniforms.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Effect } from "@babylonjs/core/Materials/effect";
+import type { Effect } from "@babylonjs/core/Materials/effect";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 
 export const ObjectUniformNames = {
     OBJECT_POSITION: "object_position",

--- a/packages/game/src/ts/frontend/postProcesses/uniforms/samplerUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/uniforms/samplerUniforms.ts
@@ -15,8 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
-import { type Effect } from "@babylonjs/core/Materials/effect";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
+import type { Effect } from "@babylonjs/core/Materials/effect";
 
 import type { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 

--- a/packages/game/src/ts/frontend/postProcesses/uniforms/sphereShadowCasterUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/uniforms/sphereShadowCasterUniforms.ts
@@ -15,11 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Effect } from "@babylonjs/core/Materials/effect";
+import type { Effect } from "@babylonjs/core/Materials/effect";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
-import { type HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 export const maxShadowCastingSpheres = 8;
 

--- a/packages/game/src/ts/frontend/postProcesses/uniforms/stellarObjectUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/uniforms/stellarObjectUniforms.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
-import { type Effect } from "@babylonjs/core/Materials/effect";
+import type { Effect } from "@babylonjs/core/Materials/effect";
 
 export const StellarObjectUniformNames = {
     STAR_DIRECTIONS: "star_directions",

--- a/packages/game/src/ts/frontend/postProcesses/updatablePostProcess.ts
+++ b/packages/game/src/ts/frontend/postProcesses/updatablePostProcess.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
+import type { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
 
 export interface UpdatablePostProcess extends PostProcess {
     /**

--- a/packages/game/src/ts/frontend/postProcesses/volumetricLight/volumetricLight.ts
+++ b/packages/game/src/ts/frontend/postProcesses/volumetricLight/volumetricLight.ts
@@ -16,12 +16,12 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { VolumetricLightScatteringPostProcess } from "@babylonjs/core/PostProcesses/volumetricLightScatteringPostProcess";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type VolumetricLightUniforms } from "./volumetricLightUniforms";
+import type { VolumetricLightUniforms } from "./volumetricLightUniforms";
 
 export class VolumetricLight extends VolumetricLightScatteringPostProcess {
     constructor(

--- a/packages/game/src/ts/frontend/spaceship/aiSpaceshipControls.ts
+++ b/packages/game/src/ts/frontend/spaceship/aiSpaceshipControls.ts
@@ -16,15 +16,15 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { type Scene } from "@babylonjs/core/scene";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type Controls } from "@/frontend/controls";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { Controls } from "@/frontend/controls";
 
-import { type Spaceship } from "./spaceship";
+import type { Spaceship } from "./spaceship";
 
 export class AiSpaceshipControls implements Controls {
     readonly spaceship: Spaceship;

--- a/packages/game/src/ts/frontend/spaceship/attitudePdController.spec.ts
+++ b/packages/game/src/ts/frontend/spaceship/attitudePdController.spec.ts
@@ -1,7 +1,8 @@
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { describe, expect, it } from "vitest";
 
-import { AttitudePDController, type AngularMassProperties } from "./attitudePdController";
+import { AttitudePDController } from "./attitudePdController";
+import type { AngularMassProperties } from "./attitudePdController";
 
 const expectVectorClose = (actual: Vector3, expected: Vector3, precision = 6): void => {
     expect(actual.x).toBeCloseTo(expected.x, precision);

--- a/packages/game/src/ts/frontend/spaceship/componentSlot.ts
+++ b/packages/game/src/ts/frontend/spaceship/componentSlot.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Component } from "./components/component";
+import type { Component } from "./components/component";
 
 export class ComponentSlot {
     readonly maxSize: number;

--- a/packages/game/src/ts/frontend/spaceship/components/component.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/component.ts
@@ -17,7 +17,7 @@
 
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
+import type { SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
 
 import { DiscoveryScanner } from "./discoveryScanner";
 import { FuelScoop } from "./fuelScoop";

--- a/packages/game/src/ts/frontend/spaceship/components/discoveryScanner.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/discoveryScanner.ts
@@ -18,12 +18,10 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import {
-    getDiscoveryScannerSpec,
-    type SerializedDiscoveryScanner,
-} from "@/backend/spaceship/serializedComponents/discoveryScanner";
+import { getDiscoveryScannerSpec } from "@/backend/spaceship/serializedComponents/discoveryScanner";
+import type { SerializedDiscoveryScanner } from "@/backend/spaceship/serializedComponents/discoveryScanner";
 
-import { type CelestialBody } from "@/frontend/universe/architecture/orbitalObject";
+import type { CelestialBody } from "@/frontend/universe/architecture/orbitalObject";
 
 export class DiscoveryScanner {
     readonly type;

--- a/packages/game/src/ts/frontend/spaceship/components/fuelScoop.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/fuelScoop.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { getFuelScoopSpec, type SerializedFuelScoop } from "@/backend/spaceship/serializedComponents/fuelScoop";
+import { getFuelScoopSpec } from "@/backend/spaceship/serializedComponents/fuelScoop";
+import type { SerializedFuelScoop } from "@/backend/spaceship/serializedComponents/fuelScoop";
 
 export class FuelScoop {
     readonly type;

--- a/packages/game/src/ts/frontend/spaceship/components/fuelTank.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/fuelTank.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { getFuelTankSpecs, type SerializedFuelTank } from "@/backend/spaceship/serializedComponents/fuelTank";
+import { getFuelTankSpecs } from "@/backend/spaceship/serializedComponents/fuelTank";
+import type { SerializedFuelTank } from "@/backend/spaceship/serializedComponents/fuelTank";
 
 export class FuelTank {
     readonly type;

--- a/packages/game/src/ts/frontend/spaceship/components/optionalComponents.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/optionalComponents.ts
@@ -15,8 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type DiscoveryScanner } from "./discoveryScanner";
-import { type FuelScoop } from "./fuelScoop";
-import { type FuelTank } from "./fuelTank";
+import type { DiscoveryScanner } from "./discoveryScanner";
+import type { FuelScoop } from "./fuelScoop";
+import type { FuelTank } from "./fuelTank";
 
 export type OptionalComponent = FuelTank | FuelScoop | DiscoveryScanner;

--- a/packages/game/src/ts/frontend/spaceship/components/thrusters.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/thrusters.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { getThrustersSpec, type SerializedThrusters } from "@/backend/spaceship/serializedComponents/thrusters";
+import { getThrustersSpec } from "@/backend/spaceship/serializedComponents/thrusters";
+import type { SerializedThrusters } from "@/backend/spaceship/serializedComponents/thrusters";
 
 export class Thrusters {
     readonly type;

--- a/packages/game/src/ts/frontend/spaceship/components/warpDrive.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/warpDrive.ts
@@ -15,14 +15,16 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { getWarpDriveSpec, type SerializedWarpDrive } from "@/backend/spaceship/serializedComponents/warpDrive";
+import { getWarpDriveSpec } from "@/backend/spaceship/serializedComponents/warpDrive";
+import type { SerializedWarpDrive } from "@/backend/spaceship/serializedComponents/warpDrive";
 
 import { clamp, lerpSmooth, remap } from "@/utils/math";
 
-import { computeMaxTargetSpeedFromWarpInfluences, type WarpInfluence } from "./warpInfluence";
+import { computeMaxTargetSpeedFromWarpInfluences } from "./warpInfluence";
+import type { WarpInfluence } from "./warpInfluence";
 
 type WarpDriveState = "disabled" | "enabled" | "disengaging";
 

--- a/packages/game/src/ts/frontend/spaceship/components/warpDriveUtils.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/warpDriveUtils.ts
@@ -16,9 +16,9 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 
-import { type OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
+import type { OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
 
 import { isInsideRingRadialBounds, isPositionInsideRingVolume, projectPositionOnRingPlane } from "@/utils/ringVolume";
 

--- a/packages/game/src/ts/frontend/spaceship/components/warpInfluence.spec.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/warpInfluence.spec.ts
@@ -1,11 +1,8 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { describe, expect, it } from "vitest";
 
-import {
-    computeMaxTargetSpeedFromWarpInfluences,
-    type RingWarpInfluence,
-    type SolidWarpInfluence,
-} from "./warpInfluence";
+import { computeMaxTargetSpeedFromWarpInfluences } from "./warpInfluence";
+import type { RingWarpInfluence, SolidWarpInfluence } from "./warpInfluence";
 
 const minWarpSpeed = 30_000;
 const maxWarpSpeed = 1_000_000;

--- a/packages/game/src/ts/frontend/spaceship/components/warpInfluence.ts
+++ b/packages/game/src/ts/frontend/spaceship/components/warpInfluence.ts
@@ -2,7 +2,8 @@ import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
 import { clamp, lerp, remap } from "@/utils/math";
-import { distanceToRingVolume, getNearestPointOnRingVolume, type RingVolume } from "@/utils/ringVolume";
+import { distanceToRingVolume, getNearestPointOnRingVolume } from "@/utils/ringVolume";
+import type { RingVolume } from "@/utils/ringVolume";
 
 type SolidVolume = {
     readonly center: Vector3;

--- a/packages/game/src/ts/frontend/spaceship/landingComputer.spec.ts
+++ b/packages/game/src/ts/frontend/spaceship/landingComputer.spec.ts
@@ -1,12 +1,12 @@
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { type PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
-import { type PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
+import type { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type LandingPad } from "@/frontend/assets/procedural/spaceStation/landingPad/landingPad";
+import type { LandingPad } from "@/frontend/assets/procedural/spaceStation/landingPad/landingPad";
 
 import { LandingComputer, LandingComputerStatusBit } from "./landingComputer";
 

--- a/packages/game/src/ts/frontend/spaceship/landingComputer.ts
+++ b/packages/game/src/ts/frontend/spaceship/landingComputer.ts
@@ -16,14 +16,14 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Matrix, Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
-import { type PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { EarthG } from "@cosmos-journeyer/physics";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type ILandingPad } from "@/frontend/universe/orbitalFacility/landingPadManager";
+import type { ILandingPad } from "@/frontend/universe/orbitalFacility/landingPadManager";
 
 import { CollisionMask } from "@/settings";
 

--- a/packages/game/src/ts/frontend/spaceship/shipControls.ts
+++ b/packages/game/src/ts/frontend/spaceship/shipControls.ts
@@ -16,26 +16,27 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { FreeCamera } from "@babylonjs/core/Cameras/freeCamera";
-import { Quaternion, type Vector2, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Vector2 } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
 import { Observable } from "@babylonjs/core/Misc/observable";
 import { Tools } from "@babylonjs/core/Misc/tools";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type ITts } from "@/frontend/audio/tts";
-import { type Controls } from "@/frontend/controls";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ITts } from "@/frontend/audio/tts";
+import type { Controls } from "@/frontend/controls";
 import { createCameraShakeAnimation } from "@/frontend/helpers/animations/cameraShake";
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 import { pitch, roll, yaw } from "@/frontend/helpers/transform";
 import { StarSystemInputs } from "@/frontend/inputs/starSystemInputs";
-import { type HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 import { LandingPadSize } from "@/frontend/universe/orbitalFacility/landingPadManager";
-import { type ManagesLandingPads } from "@/frontend/universe/orbitalFacility/managesLandingPads";
+import type { ManagesLandingPads } from "@/frontend/universe/orbitalFacility/managesLandingPads";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
 import { lerp, lerpAngle, lerpSmooth } from "@/utils/math";
@@ -45,15 +46,12 @@ import i18n from "@/i18n";
 
 import { CustomAnimation } from "../helpers/animations/customAnimation";
 import { easeInOutCubic, slerpSmoothToRef } from "../helpers/animations/interpolations";
-import { type INotificationManager } from "../ui/notificationManager";
+import type { INotificationManager } from "../ui/notificationManager";
 import { canEngageWarpDrive } from "./components/warpDriveUtils";
 import { Spaceship } from "./spaceship";
 import { SpaceShipControlsInputs } from "./spaceShipControlsInputs";
-import {
-    type ThirdPersonCameraPreset,
-    type ThirdPersonCameraPresetNames,
-    thirdPersonCameraPresets,
-} from "./thirdPersonCameraPresets";
+import { thirdPersonCameraPresets } from "./thirdPersonCameraPresets";
+import type { ThirdPersonCameraPreset, ThirdPersonCameraPresetNames } from "./thirdPersonCameraPresets";
 
 type CameraPresetInput = (typeof SpaceShipControlsInputs.map)["resetCamera"];
 

--- a/packages/game/src/ts/frontend/spaceship/spaceship.ts
+++ b/packages/game/src/ts/frontend/spaceship/spaceship.ts
@@ -18,45 +18,41 @@
 import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type AbstractMesh, type TransformNode } from "@babylonjs/core/Meshes";
+import type { AbstractMesh, TransformNode } from "@babylonjs/core/Meshes";
 import { Observable } from "@babylonjs/core/Misc/observable";
-import { type PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
-import {
-    PhysicsMotionType,
-    PhysicsShapeType,
-    type IPhysicsCollisionEvent,
-} from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
+import type { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import { PhysicsMotionType, PhysicsShapeType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
+import type { IPhysicsCollisionEvent } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import { C } from "@cosmos-journeyer/physics";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 
-import { type SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
-import {
-    getDefaultSerializedSpaceship,
-    type SerializedSpaceship,
-    type ShipType,
-} from "@/backend/spaceship/serializedSpaceship";
+import type { SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
+import { getDefaultSerializedSpaceship } from "@/backend/spaceship/serializedSpaceship";
+import type { SerializedSpaceship, ShipType } from "@/backend/spaceship/serializedSpaceship";
 
 import { HyperSpaceTunnel } from "@/frontend/assets/procedural/hyperSpaceTunnel";
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { AudioMasks } from "@/frontend/audio/audioMasks";
-import { type ISoundInstance } from "@/frontend/audio/soundInstance";
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundInstance } from "@/frontend/audio/soundInstance";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { translate } from "@/frontend/helpers/transform";
-import { type HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
-import { type CelestialBody, type OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
-import { type ILandingPad } from "@/frontend/universe/orbitalFacility/landingPadManager";
+import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
+import type { CelestialBody, OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
+import type { ILandingPad } from "@/frontend/universe/orbitalFacility/landingPadManager";
 
 import i18n from "@/i18n";
 import { CollisionMask } from "@/settings";
 
 import { SpaceDots } from "../assets/procedural/spaceDots";
-import { ObjectTargetCursorType, type Targetable, type TargetInfo } from "../universe/architecture/targetable";
+import { ObjectTargetCursorType } from "../universe/architecture/targetable";
+import type { Targetable, TargetInfo } from "../universe/architecture/targetable";
 import { Altimeter } from "./altimeter";
 import { canEngageWarpDrive } from "./components/warpDriveUtils";
-import { type WarpInfluence } from "./components/warpInfluence";
+import type { WarpInfluence } from "./components/warpInfluence";
 import { LandingComputer, LandingComputerStatusBit } from "./landingComputer";
 import { SpaceshipInternals } from "./spaceshipInternals";
 import { Thruster } from "./thruster";

--- a/packages/game/src/ts/frontend/spaceship/spaceshipInternals.ts
+++ b/packages/game/src/ts/frontend/spaceship/spaceshipInternals.ts
@@ -15,16 +15,17 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 
-import { type SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
-import { type SerializedOptionalComponent } from "@/backend/spaceship/serializedComponents/optionalComponents";
-import { type SerializedSpaceship, type ShipType } from "@/backend/spaceship/serializedSpaceship";
+import type { SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
+import type { SerializedOptionalComponent } from "@/backend/spaceship/serializedComponents/optionalComponents";
+import type { SerializedSpaceship, ShipType } from "@/backend/spaceship/serializedSpaceship";
 
 import { DiscoveryScanner } from "./components/discoveryScanner";
 import { FuelScoop } from "./components/fuelScoop";
 import { FuelTank } from "./components/fuelTank";
-import { type OptionalComponent } from "./components/optionalComponents";
+import type { OptionalComponent } from "./components/optionalComponents";
 import { Thrusters } from "./components/thrusters";
 import { WarpDrive } from "./components/warpDrive";
 import { ComponentSlot } from "./componentSlot";

--- a/packages/game/src/ts/frontend/spaceship/thruster.ts
+++ b/packages/game/src/ts/frontend/spaceship/thruster.ts
@@ -18,9 +18,9 @@
 import { SpotLight } from "@babylonjs/core/Lights/spotLight";
 import { Vector3 } from "@babylonjs/core/Maths/math";
 import { Quaternion } from "@babylonjs/core/Maths/math.vector";
-import { type AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
 import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { type PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
+import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
 
 import type { Transformable } from "../universe/architecture/transformable";

--- a/packages/game/src/ts/frontend/spaceship/thrusterExhaust.ts
+++ b/packages/game/src/ts/frontend/spaceship/thrusterExhaust.ts
@@ -17,13 +17,14 @@
 
 import { Matrix } from "@babylonjs/core/Maths/math.vector";
 import { CreateBox } from "@babylonjs/core/Meshes/Builders/boxBuilder";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
-import { type ThrusterExhaustCrossSection, ThrusterExhaustMaterial } from "./thrusterExhaustMaterial";
+import { ThrusterExhaustMaterial } from "./thrusterExhaustMaterial";
+import type { ThrusterExhaustCrossSection } from "./thrusterExhaustMaterial";
 
 export interface ThrusterExhaustOptions {
     readonly crossSection?: ThrusterExhaustCrossSection;

--- a/packages/game/src/ts/frontend/spaceship/thrusterExhaustMaterial.ts
+++ b/packages/game/src/ts/frontend/spaceship/thrusterExhaustMaterial.ts
@@ -20,7 +20,7 @@ import { Effect } from "@babylonjs/core/Materials/effect";
 import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
 import { Matrix } from "@babylonjs/core/Maths/math.vector";
 import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { OffsetWorldToRef } from "../helpers/floatingOrigin";
 

--- a/packages/game/src/ts/frontend/starSystemView.ts
+++ b/packages/game/src/ts/frontend/starSystemView.ts
@@ -19,33 +19,28 @@ import "@babylonjs/core/Lights/Clustered/clusteredLightingSceneComponent";
 import "@babylonjs/core/Loading/loadingScreen";
 
 import type { Camera } from "@babylonjs/core/Cameras/camera";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Quaternion, Space, Vector3 } from "@babylonjs/core/Maths/math";
 import { Observable } from "@babylonjs/core/Misc/observable";
 import { PhysicsRaycastResult } from "@babylonjs/core/Physics/physicsRaycastResult";
-import { type PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
+import type { PhysicsEngineV2 } from "@babylonjs/core/Physics/v2";
 import type { Scene } from "@babylonjs/core/scene";
 import { AxisComposite } from "@brianchirls/game-input/browser";
 import type DPadComposite from "@brianchirls/game-input/controls/DPadComposite";
 import { metersToLightYears } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    starSystemCoordinatesEquals,
-    type StarSystemCoordinates,
-    type StarSystemModel,
-    getUniverseObjectId,
-    type UniverseObjectId,
-} from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals, getUniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, StarSystemModel, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/encyclopaediaGalacticaManager";
+import type { EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/encyclopaediaGalacticaManager";
 import { ItinerarySchema } from "@/backend/player/serializedPlayer";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { AudioMasks } from "@/frontend/audio/audioMasks";
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type ITts } from "@/frontend/audio/tts";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ITts } from "@/frontend/audio/tts";
 import { CharacterControls } from "@/frontend/controls/characterControls/characterControls";
 import { CharacterInputs } from "@/frontend/controls/characterControls/characterControlsInputs";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
@@ -56,8 +51,8 @@ import { axisCompositeToString, dPadCompositeToString } from "@/frontend/helpers
 import { positionNearObjectBrightSide } from "@/frontend/helpers/positionNearObject";
 import { getRotationQuaternion, lookAt, setRotationQuaternion, setUpVector } from "@/frontend/helpers/transform";
 import { StarSystemInputs } from "@/frontend/inputs/starSystemInputs";
-import { type Mission } from "@/frontend/missions/mission";
-import { type MissionContext } from "@/frontend/missions/missionContext";
+import type { Mission } from "@/frontend/missions/mission";
+import type { MissionContext } from "@/frontend/missions/missionContext";
 import { PostProcessManager } from "@/frontend/postProcesses/postProcessManager";
 import { ShipControls } from "@/frontend/spaceship/shipControls";
 import { Spaceship } from "@/frontend/spaceship/spaceship";
@@ -66,17 +61,17 @@ import { alertModal, radialChoiceModal } from "@/frontend/ui/dialogModal";
 import { SpaceShipLayer } from "@/frontend/ui/spaceShipLayer";
 import { SpaceStationLayer } from "@/frontend/ui/spaceStation/spaceStationLayer";
 import { TargetCursorLayer } from "@/frontend/ui/targetCursorLayer";
-import { type HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
-import { type Targetable } from "@/frontend/universe/architecture/targetable";
+import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
+import type { Targetable } from "@/frontend/universe/architecture/targetable";
 import { AxisRenderer } from "@/frontend/universe/axisRenderer";
 import { OrbitRenderer } from "@/frontend/universe/orbitRenderer";
-import { type ITerrainSystem } from "@/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystem";
+import type { ITerrainSystem } from "@/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystem";
 import { StarSystemController } from "@/frontend/universe/starSystemController";
 import { StarSystemLoader } from "@/frontend/universe/starSystemLoader";
 import { BlackHole } from "@/frontend/universe/stellarObjects/blackHole/blackHole";
 import { NeutronStar } from "@/frontend/universe/stellarObjects/neutronStar/neutronStar";
 import { SystemTarget } from "@/frontend/universe/systemTarget";
-import { type View } from "@/frontend/view";
+import type { View } from "@/frontend/view";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
 
@@ -92,12 +87,12 @@ import { setCollisionsEnabled } from "./helpers/havok";
 import { getOrbitAxisObjectList } from "./helpers/orbitAxisRendering";
 import { getGuidanceMissionTargetables, getSystemTargetables } from "./helpers/targeting";
 import { InteractionSystem } from "./inputs/interaction/interactionSystem";
-import { type Player } from "./player/player";
+import type { Player } from "./player/player";
 import { isScannerInRange } from "./spaceship/components/discoveryScanner";
 import { InteractionLayer } from "./ui/interactionLayer";
-import { type INotificationManager } from "./ui/notificationManager";
-import { type Transformable } from "./universe/architecture/transformable";
-import { type TypedObject } from "./universe/architecture/typedObject";
+import type { INotificationManager } from "./ui/notificationManager";
+import type { Transformable } from "./universe/architecture/transformable";
+import type { TypedObject } from "./universe/architecture/typedObject";
 import { CreateLinesHelper } from "./universe/lineRendering";
 import { VehicleControls } from "./vehicle/vehicleControls";
 import { VehicleInputs } from "./vehicle/vehicleControlsInputs";

--- a/packages/game/src/ts/frontend/starmap/starMap.ts
+++ b/packages/game/src/ts/frontend/starmap/starMap.ts
@@ -29,7 +29,7 @@ import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import { Observable } from "@babylonjs/core/Misc/observable";
 import type { Scene } from "@babylonjs/core/scene";
-import { type StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
 import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
@@ -38,7 +38,8 @@ import { getRgbFromTemperature } from "@/utils/specrend";
 import { Settings } from "@/settings";
 
 import type { StarMapTextures } from "../assets/textures/starMap";
-import { StarSectorView, vector3ToString, type BuildData } from "./starSectorView";
+import { StarSectorView, vector3ToString } from "./starSectorView";
+import type { BuildData } from "./starSectorView";
 
 export class StarMap {
     private readonly scene: Scene;

--- a/packages/game/src/ts/frontend/starmap/starMapBookmarkButton.ts
+++ b/packages/game/src/ts/frontend/starmap/starMapBookmarkButton.ts
@@ -1,10 +1,11 @@
-import { starSystemCoordinatesEquals, type StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import i18n from "@/i18n";
 
-import { type Player } from "../player/player";
+import type { Player } from "../player/player";
 
 export class StarMapBookmarkButton {
     readonly rootNode: HTMLElement;

--- a/packages/game/src/ts/frontend/starmap/starMapControls.ts
+++ b/packages/game/src/ts/frontend/starmap/starMapControls.ts
@@ -18,13 +18,13 @@
 import "@babylonjs/core/Collisions/collisionCoordinator";
 
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type Controls } from "@/frontend/controls";
+import type { Controls } from "@/frontend/controls";
 
 import { lerpSmooth } from "@/utils/math";
 

--- a/packages/game/src/ts/frontend/starmap/starMapPath.ts
+++ b/packages/game/src/ts/frontend/starmap/starMapPath.ts
@@ -18,11 +18,8 @@
 import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { GreasedLineTools } from "@babylonjs/core/Misc/greasedLineTools";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    serializeStarSystemCoordinates,
-    starSystemCoordinatesEquals,
-    type StarSystemCoordinates,
-} from "@cosmos-journeyer/universe-model";
+import { serializeStarSystemCoordinates, starSystemCoordinatesEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 

--- a/packages/game/src/ts/frontend/starmap/starMapUI.ts
+++ b/packages/game/src/ts/frontend/starmap/starMapUI.ts
@@ -18,18 +18,15 @@
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Observable } from "@babylonjs/core/Misc/observable";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import { factionToString } from "@cosmos-journeyer/universe-generation";
-import {
-    starSystemCoordinatesEquals,
-    type StarSystemCoordinates,
-    type StarSystemModel,
-} from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, StarSystemModel } from "@cosmos-journeyer/universe-model";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
 
@@ -37,7 +34,7 @@ import { getRgbFromTemperature } from "@/utils/specrend";
 
 import i18n from "@/i18n";
 
-import { type Player } from "../player/player";
+import type { Player } from "../player/player";
 import { StarMapBookmarkButton } from "./starMapBookmarkButton";
 import { SystemIcons } from "./systemIcons";
 

--- a/packages/game/src/ts/frontend/starmap/starMapView.ts
+++ b/packages/game/src/ts/frontend/starmap/starMapView.ts
@@ -28,28 +28,30 @@ import type { GreasedLineBaseMesh } from "@babylonjs/core/Meshes/GreasedLine/gre
 import { GreasedLineTools } from "@babylonjs/core/Misc/greasedLineTools";
 import { Observable } from "@babylonjs/core/Misc/observable";
 import { DefaultRenderingPipeline } from "@babylonjs/core/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { starSystemCoordinatesEquals, type StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
-import { type EncyclopaediaGalactica } from "@/backend/encyclopaedia/encyclopaediaGalactica";
-import { ItinerarySchema, type Itinerary } from "@/backend/player/serializedPlayer";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { EncyclopaediaGalactica } from "@/backend/encyclopaedia/encyclopaediaGalactica";
+import { ItinerarySchema } from "@/backend/player/serializedPlayer";
+import type { Itinerary } from "@/backend/player/serializedPlayer";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 import { lookAt } from "@/frontend/helpers/transform";
-import { type Player } from "@/frontend/player/player";
+import type { Player } from "@/frontend/player/player";
 import { StarMapNebulaPostProcess } from "@/frontend/postProcesses/starMapNebulaPostProcess";
 import { alertModal } from "@/frontend/ui/dialogModal";
-import { type View } from "@/frontend/view";
+import type { View } from "@/frontend/view";
 
 import { lerp } from "@/utils/math";
 
-import { type StarMapTextures } from "../assets/textures/starMap";
+import type { StarMapTextures } from "../assets/textures/starMap";
 import { CustomAnimation } from "../helpers/animations/customAnimation";
 import { easeInOutQuadratic } from "../helpers/animations/interpolations";
-import { type INotificationManager } from "../ui/notificationManager";
+import type { INotificationManager } from "../ui/notificationManager";
 import { StarMap } from "./starMap";
 import { StarMapControls } from "./starMapControls";
 import { StarMapInputs } from "./starMapInputs";

--- a/packages/game/src/ts/frontend/starmap/starSectorView.ts
+++ b/packages/game/src/ts/frontend/starmap/starSectorView.ts
@@ -17,11 +17,11 @@
 
 import { BoundingBox } from "@babylonjs/core/Culling/boundingBox";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type InstancedMesh } from "@babylonjs/core/Meshes/instancedMesh";
+import type { InstancedMesh } from "@babylonjs/core/Meshes/instancedMesh";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type StarSystemCoordinates, type StarSystemModel } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, StarSystemModel } from "@cosmos-journeyer/universe-model";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 

--- a/packages/game/src/ts/frontend/starmap/stellarPathfinder.ts
+++ b/packages/game/src/ts/frontend/starmap/stellarPathfinder.ts
@@ -16,10 +16,12 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
-import { starSystemCoordinatesEquals, type StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
+import { starSystemCoordinatesEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 import { getNeighborStarSystemCoordinates } from "@/frontend/helpers/getNeighborStarSystems";

--- a/packages/game/src/ts/frontend/starmap/systemIcons.ts
+++ b/packages/game/src/ts/frontend/starmap/systemIcons.ts
@@ -1,4 +1,5 @@
-import { starSystemCoordinatesEquals, type StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
+import { starSystemCoordinatesEquals } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 
 const SystemIconMask = {
     BOOKMARK: 0b01,

--- a/packages/game/src/ts/frontend/ui/currentMissionDisplay.ts
+++ b/packages/game/src/ts/frontend/ui/currentMissionDisplay.ts
@@ -15,13 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
-import { type Mission } from "@/frontend/missions/mission";
-import { type MissionContext } from "@/frontend/missions/missionContext";
-import { type Player } from "@/frontend/player/player";
+import type { Mission } from "@/frontend/missions/mission";
+import type { MissionContext } from "@/frontend/missions/missionContext";
+import type { Player } from "@/frontend/player/player";
 import { SpaceShipControlsInputs } from "@/frontend/spaceship/spaceShipControlsInputs";
 
 import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";

--- a/packages/game/src/ts/frontend/ui/desktopUpdateController.spec.ts
+++ b/packages/game/src/ts/frontend/ui/desktopUpdateController.spec.ts
@@ -4,15 +4,12 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 
-import { type DesktopUpdateApi, type DesktopUpdateState } from "@/utils/desktopUpdateApi";
+import type { DesktopUpdateApi, DesktopUpdateState } from "@/utils/desktopUpdateApi";
 
 import i18n, { initI18n } from "@/i18n";
 
-import {
-    DesktopUpdateController,
-    type DesktopUpdatePlayerActions,
-    type UpdatePresentationContext,
-} from "./desktopUpdateController";
+import { DesktopUpdateController } from "./desktopUpdateController";
+import type { DesktopUpdatePlayerActions, UpdatePresentationContext } from "./desktopUpdateController";
 import { NotificationManagerMock } from "./notificationManager";
 
 class DesktopUpdateApiMock implements DesktopUpdateApi {

--- a/packages/game/src/ts/frontend/ui/desktopUpdateController.ts
+++ b/packages/game/src/ts/frontend/ui/desktopUpdateController.ts
@@ -1,15 +1,12 @@
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
-import { type DesktopUpdateApi, type DesktopUpdateState } from "@/utils/desktopUpdateApi";
+import type { DesktopUpdateApi, DesktopUpdateState } from "@/utils/desktopUpdateApi";
 
 import i18n from "@/i18n";
 
-import {
-    type CommanderBackupTarget,
-    DesktopUpdateModal,
-    type DesktopUpdateModalAction,
-} from "./dialogModal/desktopUpdateModal";
-import { type INotificationManager } from "./notificationManager";
+import { DesktopUpdateModal } from "./dialogModal/desktopUpdateModal";
+import type { CommanderBackupTarget, DesktopUpdateModalAction } from "./dialogModal/desktopUpdateModal";
+import type { INotificationManager } from "./notificationManager";
 
 export type UpdatePresentationContext = "gameplay" | "mainMenu" | "pauseMenu";
 

--- a/packages/game/src/ts/frontend/ui/dialogModal/alertModal.ts
+++ b/packages/game/src/ts/frontend/ui/dialogModal/alertModal.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/ui/dialogModal/connectEncyclopaediaGalacticaModal.ts
+++ b/packages/game/src/ts/frontend/ui/dialogModal/connectEncyclopaediaGalacticaModal.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/ui/dialogModal/desktopUpdateModal.ts
+++ b/packages/game/src/ts/frontend/ui/dialogModal/desktopUpdateModal.ts
@@ -1,6 +1,6 @@
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
-import { type DesktopUpdateState } from "@/utils/desktopUpdateApi";
+import type { DesktopUpdateState } from "@/utils/desktopUpdateApi";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/ui/dialogModal/promptModalBoolean.ts
+++ b/packages/game/src/ts/frontend/ui/dialogModal/promptModalBoolean.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/ui/dialogModal/promptModalString.ts
+++ b/packages/game/src/ts/frontend/ui/dialogModal/promptModalString.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/ui/dialogModal/radialChoiceModal.ts
+++ b/packages/game/src/ts/frontend/ui/dialogModal/radialChoiceModal.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import { Settings } from "@/settings";
 

--- a/packages/game/src/ts/frontend/ui/mainMenu.ts
+++ b/packages/game/src/ts/frontend/ui/mainMenu.ts
@@ -19,21 +19,22 @@ import { Quaternion } from "@babylonjs/core/Maths/math.vector";
 import { Observable } from "@babylonjs/core/Misc/observable";
 import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type StarSystemModel, getUniverseObjectId, type UniverseObjectId } from "@cosmos-journeyer/universe-model";
+import { getUniverseObjectId } from "@cosmos-journeyer/universe-model";
+import type { StarSystemModel, UniverseObjectId } from "@cosmos-journeyer/universe-model";
 
-import { type ISaveBackend } from "@/backend/save/saveBackend";
+import type { ISaveBackend } from "@/backend/save/saveBackend";
 import { getLatestSaveFromBackend } from "@/backend/save/saveHelpers";
 import { getVestaSystemModel } from "@/backend/universe/customSystems/vesta";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { TransformTranslationAnimation } from "@/frontend/helpers/animations/translation";
 import {
     positionNearObjectAsteroidField,
     positionNearObjectWithStarVisible,
 } from "@/frontend/helpers/positionNearObject";
-import { type StarSystemView } from "@/frontend/starSystemView";
+import type { StarSystemView } from "@/frontend/starSystemView";
 
 import i18n from "@/i18n";
 
@@ -41,7 +42,7 @@ import packageInfo from "../../../../package.json";
 import { CustomAnimation } from "../helpers/animations/customAnimation";
 import { easeInOutQuadratic } from "../helpers/animations/interpolations";
 import { createOfficialOriginNotice } from "./officialOriginNotice";
-import { type SidePanels } from "./sidePanels";
+import type { SidePanels } from "./sidePanels";
 
 export class MainMenu {
     readonly scene: Scene;

--- a/packages/game/src/ts/frontend/ui/notification.ts
+++ b/packages/game/src/ts/frontend/ui/notification.ts
@@ -17,7 +17,7 @@
 
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import informationIcon from "@assets/icons/information.webp";
 import explorationIcon from "@assets/icons/space-exploration.webp";

--- a/packages/game/src/ts/frontend/ui/notificationManager.ts
+++ b/packages/game/src/ts/frontend/ui/notificationManager.ts
@@ -16,7 +16,8 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { ISoundPlayer } from "../audio/soundPlayer";
-import { Notification, type NotificationIntent, type NotificationOrigin } from "./notification";
+import { Notification } from "./notification";
+import type { NotificationIntent, NotificationOrigin } from "./notification";
 
 export interface INotificationManager {
     update(deltaSeconds: number): void;

--- a/packages/game/src/ts/frontend/ui/objectTargetCursor.ts
+++ b/packages/game/src/ts/frontend/ui/objectTargetCursor.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Matrix } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
@@ -25,7 +25,8 @@ import { getProjectedDiameter01 } from "@/frontend/helpers/isObjectVisibleOnScre
 import { smoothstep } from "@/utils/math";
 import { parseDistance, parseSecondsRough } from "@/utils/strings/parseToStrings";
 
-import { ObjectTargetCursorType, type Targetable } from "../universe/architecture/targetable";
+import { ObjectTargetCursorType } from "../universe/architecture/targetable";
+import type { Targetable } from "../universe/architecture/targetable";
 
 export class ObjectTargetCursor {
     readonly htmlRoot: HTMLDivElement;

--- a/packages/game/src/ts/frontend/ui/panels/loadSavePanel.ts
+++ b/packages/game/src/ts/frontend/ui/panels/loadSavePanel.ts
@@ -15,14 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ISaveBackend } from "@/backend/save/saveBackend";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { ISaveBackend } from "@/backend/save/saveBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import i18n from "@/i18n";
 
-import { type INotificationManager } from "../notificationManager";
+import type { INotificationManager } from "../notificationManager";
 import { SaveLoadingPanelContent } from "../saveLoadingPanelContent";
 
 export class LoadSavePanel {

--- a/packages/game/src/ts/frontend/ui/panels/settingsPanel.ts
+++ b/packages/game/src/ts/frontend/ui/panels/settingsPanel.ts
@@ -38,7 +38,7 @@ import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
 
 import i18n from "@/i18n";
 
-import { type MusicConductor } from "../../audio/musicConductor";
+import type { MusicConductor } from "../../audio/musicConductor";
 
 export class SettingsPanel {
     readonly htmlRoot: HTMLElement;

--- a/packages/game/src/ts/frontend/ui/pauseMenu.ts
+++ b/packages/game/src/ts/frontend/ui/pauseMenu.ts
@@ -17,12 +17,12 @@
 
 import { Observable } from "@babylonjs/core/Misc/observable";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
 import i18n from "@/i18n";
 
 import { createOfficialOriginNotice } from "./officialOriginNotice";
-import { type SidePanels } from "./sidePanels";
+import type { SidePanels } from "./sidePanels";
 
 export class PauseMenu {
     private readonly rootNode: HTMLElement;

--- a/packages/game/src/ts/frontend/ui/saveLoadingPanelContent.ts
+++ b/packages/game/src/ts/frontend/ui/saveLoadingPanelContent.ts
@@ -2,13 +2,15 @@ import { Observable } from "@babylonjs/core/Misc/observable";
 import type { DeepReadonly, Result } from "@cosmos-journeyer/typescript";
 
 import { parseCommanderArchive } from "@/backend/save/commanderArchive";
-import { type ISaveBackend } from "@/backend/save/saveBackend";
+import type { ISaveBackend } from "@/backend/save/saveBackend";
 import { parseSaveFile } from "@/backend/save/saveFile";
-import { createUrlFromSave, type Save } from "@/backend/save/saveFileData";
-import { saveLoadingErrorToI18nString, type SaveLoadingError } from "@/backend/save/saveLoadingError";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { createUrlFromSave } from "@/backend/save/saveFileData";
+import type { Save } from "@/backend/save/saveFileData";
+import { saveLoadingErrorToI18nString } from "@/backend/save/saveLoadingError";
+import type { SaveLoadingError } from "@/backend/save/saveLoadingError";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { alertModal, promptModalBoolean } from "@/frontend/ui/dialogModal";
 
 import { downloadBlob } from "@/utils/downloadBlob";
@@ -17,7 +19,7 @@ import { renderMarkdownInline } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
-import { type INotificationManager } from "./notificationManager";
+import type { INotificationManager } from "./notificationManager";
 
 import collapseIconPath from "@assets/icons/collapse.webp";
 import downloadIconPath from "@assets/icons/download.webp";

--- a/packages/game/src/ts/frontend/ui/sidePanels.ts
+++ b/packages/game/src/ts/frontend/ui/sidePanels.ts
@@ -1,12 +1,12 @@
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type ISaveBackend } from "@/backend/save/saveBackend";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { ISaveBackend } from "@/backend/save/saveBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 
-import { type MusicConductor } from "../audio/musicConductor";
-import { type INotificationManager } from "./notificationManager";
+import type { MusicConductor } from "../audio/musicConductor";
+import type { INotificationManager } from "./notificationManager";
 import { AboutPanel } from "./panels/aboutPanel";
 import { ContributePanel } from "./panels/contributePanel";
 import { CreditsPanel } from "./panels/creditsPanel";

--- a/packages/game/src/ts/frontend/ui/spaceShipLayer.ts
+++ b/packages/game/src/ts/frontend/ui/spaceShipLayer.ts
@@ -17,14 +17,14 @@
 
 import { Matrix } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes";
+import type { TransformNode } from "@babylonjs/core/Meshes";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type MissionContext } from "@/frontend/missions/missionContext";
-import { type Player } from "@/frontend/player/player";
-import { type Spaceship } from "@/frontend/spaceship/spaceship";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { MissionContext } from "@/frontend/missions/missionContext";
+import type { Player } from "@/frontend/player/player";
+import type { Spaceship } from "@/frontend/spaceship/spaceship";
 
 import { smoothstep } from "@/utils/math";
 import { parseDistance, parseSpeed } from "@/utils/strings/parseToStrings";

--- a/packages/game/src/ts/frontend/ui/spaceStation/acceptMissionButton.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/acceptMissionButton.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type Mission } from "@/frontend/missions/mission";
-import { type Player } from "@/frontend/player/player";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { Mission } from "@/frontend/missions/mission";
+import type { Player } from "@/frontend/player/player";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/ui/spaceStation/componentBrowserUI.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/componentBrowserUI.ts
@@ -18,7 +18,8 @@
 import { Observable } from "@babylonjs/core/Misc/observable";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { getComponentTypeI18n, type SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
+import { getComponentTypeI18n } from "@/backend/spaceship/serializedComponents/component";
+import type { SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
 
 import i18n from "@/i18n";
 import { Settings } from "@/settings";

--- a/packages/game/src/ts/frontend/ui/spaceStation/componentSpecUI.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/componentSpecUI.ts
@@ -17,16 +17,19 @@
 
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { getComponentTypeI18n, type SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
-import {
-    getDiscoveryScannerSpec,
-    type SerializedDiscoveryScanner,
-} from "@/backend/spaceship/serializedComponents/discoveryScanner";
-import { getFuelScoopSpec, type SerializedFuelScoop } from "@/backend/spaceship/serializedComponents/fuelScoop";
-import { getFuelTankSpecs, type SerializedFuelTank } from "@/backend/spaceship/serializedComponents/fuelTank";
+import { getComponentTypeI18n } from "@/backend/spaceship/serializedComponents/component";
+import type { SerializedComponent } from "@/backend/spaceship/serializedComponents/component";
+import { getDiscoveryScannerSpec } from "@/backend/spaceship/serializedComponents/discoveryScanner";
+import type { SerializedDiscoveryScanner } from "@/backend/spaceship/serializedComponents/discoveryScanner";
+import { getFuelScoopSpec } from "@/backend/spaceship/serializedComponents/fuelScoop";
+import type { SerializedFuelScoop } from "@/backend/spaceship/serializedComponents/fuelScoop";
+import { getFuelTankSpecs } from "@/backend/spaceship/serializedComponents/fuelTank";
+import type { SerializedFuelTank } from "@/backend/spaceship/serializedComponents/fuelTank";
 import { getComponentValue } from "@/backend/spaceship/serializedComponents/pricing";
-import { getThrustersSpec, type SerializedThrusters } from "@/backend/spaceship/serializedComponents/thrusters";
-import { getWarpDriveSpec, type SerializedWarpDrive } from "@/backend/spaceship/serializedComponents/warpDrive";
+import { getThrustersSpec } from "@/backend/spaceship/serializedComponents/thrusters";
+import type { SerializedThrusters } from "@/backend/spaceship/serializedComponents/thrusters";
+import { getWarpDriveSpec } from "@/backend/spaceship/serializedComponents/warpDrive";
+import type { SerializedWarpDrive } from "@/backend/spaceship/serializedComponents/warpDrive";
 
 import i18n from "@/i18n";
 import { Settings } from "@/settings";

--- a/packages/game/src/ts/frontend/ui/spaceStation/discoveryDetails.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/discoveryDetails.ts
@@ -19,12 +19,12 @@ import { Observable } from "@babylonjs/core/Misc/observable";
 import { getOrbitalPeriod } from "@cosmos-journeyer/physics";
 import { getObjectModelById } from "@cosmos-journeyer/universe-model";
 
-import { type EncyclopaediaGalactica, type SpaceDiscoveryData } from "@/backend/encyclopaedia/encyclopaediaGalactica";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { EncyclopaediaGalactica, SpaceDiscoveryData } from "@/backend/encyclopaedia/encyclopaediaGalactica";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
-import { type Player } from "@/frontend/player/player";
+import type { Player } from "@/frontend/player/player";
 import { alertModal } from "@/frontend/ui/dialogModal";
 
 import { parseDistance, parseSecondsPrecise } from "@/utils/strings/parseToStrings";
@@ -32,7 +32,7 @@ import { parseDistance, parseSecondsPrecise } from "@/utils/strings/parseToStrin
 import i18n from "@/i18n";
 import { Settings } from "@/settings";
 
-import { type INotificationManager } from "../notificationManager";
+import type { INotificationManager } from "../notificationManager";
 
 export class DiscoveryDetails {
     readonly htmlRoot: HTMLElement;

--- a/packages/game/src/ts/frontend/ui/spaceStation/explorationCenterPanel.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/explorationCenterPanel.ts
@@ -17,18 +17,18 @@
 
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
-import { type SpaceDiscoveryData } from "@/backend/encyclopaedia/encyclopaediaGalactica";
-import { type EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/encyclopaediaGalacticaManager";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { SpaceDiscoveryData } from "@/backend/encyclopaedia/encyclopaediaGalactica";
+import type { EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/encyclopaediaGalacticaManager";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type Player } from "@/frontend/player/player";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { Player } from "@/frontend/player/player";
 import { connectEncyclopaediaGalacticaModal } from "@/frontend/ui/dialogModal";
 
 import i18n from "@/i18n";
 import { Settings } from "@/settings";
 
-import { type INotificationManager } from "../notificationManager";
+import type { INotificationManager } from "../notificationManager";
 import { DiscoveryDetails } from "./discoveryDetails";
 
 const ExplorationCenterFilter = {

--- a/packages/game/src/ts/frontend/ui/spaceStation/missionContainer.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/missionContainer.ts
@@ -15,11 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type Mission } from "@/frontend/missions/mission";
-import { type Player } from "@/frontend/player/player";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { Mission } from "@/frontend/missions/mission";
+import type { Player } from "@/frontend/player/player";
 
 import { Settings } from "@/settings";
 

--- a/packages/game/src/ts/frontend/ui/spaceStation/spaceStationInfos.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/spaceStationInfos.ts
@@ -18,11 +18,12 @@
 import { getOrbitalPeriod } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import { factionToString } from "@cosmos-journeyer/universe-generation";
-import { type OrbitalFacilityModel, type OrbitalObjectModel } from "@cosmos-journeyer/universe-model";
+import type { OrbitalFacilityModel, OrbitalObjectModel } from "@cosmos-journeyer/universe-model";
 
 import { makeD3PieChart } from "@/frontend/helpers/d3PieChart";
 
-import { cropTypeToString, type CropType } from "@/utils/agriculture";
+import { cropTypeToString } from "@/utils/agriculture";
+import type { CropType } from "@/utils/agriculture";
 
 export function generateInfoHTML(
     model: DeepReadonly<OrbitalFacilityModel>,

--- a/packages/game/src/ts/frontend/ui/spaceStation/spaceStationLayer.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/spaceStationLayer.ts
@@ -16,20 +16,21 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Observable } from "@babylonjs/core/Misc/observable";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type OrbitalFacilityModel, type OrbitalObjectModel } from "@cosmos-journeyer/universe-model";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { OrbitalFacilityModel, OrbitalObjectModel } from "@cosmos-journeyer/universe-model";
 
-import { type EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/encyclopaediaGalacticaManager";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/encyclopaediaGalacticaManager";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type Player } from "@/frontend/player/player";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { Player } from "@/frontend/player/player";
 import { alertModal, promptModalString } from "@/frontend/ui/dialogModal";
 
 import i18n from "@/i18n";
 import { Settings } from "@/settings";
 
-import { type INotificationManager } from "../notificationManager";
+import type { INotificationManager } from "../notificationManager";
 import { ExplorationCenterPanel } from "./explorationCenterPanel";
 import { SpaceshipDockUI } from "./spaceshipDock";
 import { generateInfoHTML } from "./spaceStationInfos";

--- a/packages/game/src/ts/frontend/ui/spaceStation/spaceStationMissions.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/spaceStationMissions.ts
@@ -17,15 +17,15 @@
 
 import { lightYearsToMeters } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type OrbitalFacilityModel } from "@cosmos-journeyer/universe-model";
+import type { OrbitalFacilityModel } from "@cosmos-journeyer/universe-model";
 import { uniformRandBool } from "extended-random";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { getNeighborStarSystemCoordinates } from "@/frontend/helpers/getNeighborStarSystems";
 import { generateSightseeingMissions } from "@/frontend/missions/generateSightSeeingMissions";
-import { type Player } from "@/frontend/player/player";
+import type { Player } from "@/frontend/player/player";
 
 import { getRngFromSeed } from "@/utils/getRngFromSeed";
 import { parseDistance } from "@/utils/strings/parseToStrings";

--- a/packages/game/src/ts/frontend/ui/spaceStation/spaceshipDock.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/spaceshipDock.ts
@@ -15,8 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type Player } from "@/frontend/player/player";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { Player } from "@/frontend/player/player";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/ui/spaceStation/spaceshipOutfittingUI.ts
+++ b/packages/game/src/ts/frontend/ui/spaceStation/spaceshipOutfittingUI.ts
@@ -18,11 +18,11 @@
 import { getComponentTypeI18n } from "@/backend/spaceship/serializedComponents/component";
 import { getComponentValue } from "@/backend/spaceship/serializedComponents/pricing";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
-import { type Player } from "@/frontend/player/player";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { Player } from "@/frontend/player/player";
 import { deserializeComponent } from "@/frontend/spaceship/components/component";
-import { type ComponentSlot } from "@/frontend/spaceship/componentSlot";
-import { type SpaceshipInternals } from "@/frontend/spaceship/spaceshipInternals";
+import type { ComponentSlot } from "@/frontend/spaceship/componentSlot";
+import type { SpaceshipInternals } from "@/frontend/spaceship/spaceshipInternals";
 
 import i18n from "@/i18n";
 import { Settings } from "@/settings";

--- a/packages/game/src/ts/frontend/ui/targetCursorLayer.ts
+++ b/packages/game/src/ts/frontend/ui/targetCursorLayer.ts
@@ -15,14 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type IDisposable } from "@babylonjs/core/scene";
+import type { IDisposable } from "@babylonjs/core/scene";
 
-import { type HasBoundingSphere } from "../universe/architecture/hasBoundingSphere";
-import { type Targetable } from "../universe/architecture/targetable";
-import { type Transformable } from "../universe/architecture/transformable";
-import { type TypedObject } from "../universe/architecture/typedObject";
+import type { HasBoundingSphere } from "../universe/architecture/hasBoundingSphere";
+import type { Targetable } from "../universe/architecture/targetable";
+import type { Transformable } from "../universe/architecture/transformable";
+import type { TypedObject } from "../universe/architecture/typedObject";
 import { ObjectTargetCursor } from "./objectTargetCursor";
 
 export class TargetCursorLayer implements IDisposable {

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorialLayer.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorialLayer.ts
@@ -1,7 +1,7 @@
 import { Observable } from "@babylonjs/core/Misc/observable";
-import { type IDisposable } from "@babylonjs/core/scene";
+import type { IDisposable } from "@babylonjs/core/scene";
 
-import { type ISoundPlayer } from "@/frontend/audio/soundPlayer";
+import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 import { promptModalBoolean } from "@/frontend/ui/dialogModal";
 
@@ -10,7 +10,7 @@ import { getGlobalKeyboardLayoutMap } from "@/utils/keyboardAPI";
 import i18n from "@/i18n";
 
 import { TutorialControlsInputs } from "./tutorialLayerInputs";
-import { type Tutorial } from "./tutorials/tutorial";
+import type { Tutorial } from "./tutorials/tutorial";
 
 export class TutorialLayer implements IDisposable {
     readonly root: HTMLDivElement;

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/flightTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/flightTutorial.ts
@@ -18,9 +18,10 @@
 import { AxisComposite } from "@brianchirls/game-input/browser";
 import type { Result } from "@cosmos-journeyer/typescript";
 
-import { safeParseSave, type Save } from "@/backend/save/saveFileData";
-import { type SaveLoadingError } from "@/backend/save/saveLoadingError";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { safeParseSave } from "@/backend/save/saveFileData";
+import type { Save } from "@/backend/save/saveFileData";
+import type { SaveLoadingError } from "@/backend/save/saveLoadingError";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { StarSystemInputs } from "@/frontend//inputs/starSystemInputs";
 import { SpaceShipControlsInputs } from "@/frontend//spaceship/spaceShipControlsInputs";
@@ -32,7 +33,7 @@ import { renderMarkdownBlock } from "@/utils/markdown";
 import i18n from "@/i18n";
 
 import { TutorialControlsInputs } from "../tutorialLayerInputs";
-import { type Tutorial } from "./tutorial";
+import type { Tutorial } from "./tutorial";
 
 import congratsImageSrc from "@assets/tutorials/flightTutorial/congrats.webp";
 import rotationImageSrc from "@assets/tutorials/flightTutorial/rotation.webp";

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/fuelScoopTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/fuelScoopTutorial.ts
@@ -17,9 +17,10 @@
 
 import type { Result } from "@cosmos-journeyer/typescript";
 
-import { safeParseSave, type Save } from "@/backend/save/saveFileData";
-import { type SaveLoadingError } from "@/backend/save/saveLoadingError";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { safeParseSave } from "@/backend/save/saveFileData";
+import type { Save } from "@/backend/save/saveFileData";
+import type { SaveLoadingError } from "@/backend/save/saveLoadingError";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 
@@ -29,7 +30,7 @@ import { renderMarkdownBlock } from "@/utils/markdown";
 import i18n from "@/i18n";
 
 import { TutorialControlsInputs } from "../tutorialLayerInputs";
-import { type Tutorial } from "./tutorial";
+import type { Tutorial } from "./tutorial";
 
 import fuelIconLocation from "@assets/tutorials/fuelScoopTutorial/fuelIconLocation.webp";
 import welcomeImageSrc from "@assets/tutorials/fuelScoopTutorial/fuelScoop.webp";

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/planetaryLandingTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/planetaryLandingTutorial.ts
@@ -15,12 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AxisComposite } from "@brianchirls/game-input/browser";
+import type { AxisComposite } from "@brianchirls/game-input/browser";
 import type { Result } from "@cosmos-journeyer/typescript";
 
-import { safeParseSave, type Save } from "@/backend/save/saveFileData";
-import { type SaveLoadingError } from "@/backend/save/saveLoadingError";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { safeParseSave } from "@/backend/save/saveFileData";
+import type { Save } from "@/backend/save/saveFileData";
+import type { SaveLoadingError } from "@/backend/save/saveLoadingError";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { axisCompositeToString, pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 import { StarSystemInputs } from "@/frontend/inputs/starSystemInputs";
@@ -32,7 +33,7 @@ import { renderMarkdownBlock } from "@/utils/markdown";
 import i18n from "@/i18n";
 
 import { TutorialControlsInputs } from "../tutorialLayerInputs";
-import { type Tutorial } from "./tutorial";
+import type { Tutorial } from "./tutorial";
 
 import welcomeImageSrc from "@assets/tutorials/planetaryLandingTutorial/cover.webp";
 import gettingCloseToSurfaceImageSrc from "@assets/tutorials/planetaryLandingTutorial/gettingCloseToSurface.png";

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/starMapTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/starMapTutorial.ts
@@ -19,9 +19,10 @@ import type AxisComposite from "@brianchirls/game-input/controls/AxisComposite";
 import type DPadComposite from "@brianchirls/game-input/controls/DPadComposite";
 import type { Result } from "@cosmos-journeyer/typescript";
 
-import { safeParseSave, type Save } from "@/backend/save/saveFileData";
-import { type SaveLoadingError } from "@/backend/save/saveLoadingError";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { safeParseSave } from "@/backend/save/saveFileData";
+import type { Save } from "@/backend/save/saveFileData";
+import type { SaveLoadingError } from "@/backend/save/saveLoadingError";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import {
     axisCompositeToString,
@@ -38,7 +39,7 @@ import { escapeMarkdown, renderMarkdownBlock, renderMarkdownInline } from "@/uti
 import i18n from "@/i18n";
 
 import { TutorialControlsInputs } from "../tutorialLayerInputs";
-import { type Tutorial } from "./tutorial";
+import type { Tutorial } from "./tutorial";
 
 import controlsImgSrc from "@assets/tutorials/starMapTutorial/controls.webp";
 import coverImgSrc from "@assets/tutorials/starMapTutorial/cover.webp";

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/stationLandingTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/stationLandingTutorial.ts
@@ -17,9 +17,10 @@
 
 import type { Result } from "@cosmos-journeyer/typescript";
 
-import { safeParseSave, type Save } from "@/backend/save/saveFileData";
-import { type SaveLoadingError } from "@/backend/save/saveLoadingError";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { safeParseSave } from "@/backend/save/saveFileData";
+import type { Save } from "@/backend/save/saveFileData";
+import type { SaveLoadingError } from "@/backend/save/saveLoadingError";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 import { SpaceShipControlsInputs } from "@/frontend/spaceship/spaceShipControlsInputs";
@@ -30,7 +31,7 @@ import { renderMarkdownBlock } from "@/utils/markdown";
 
 import i18n from "@/i18n";
 
-import { type Tutorial } from "./tutorial";
+import type { Tutorial } from "./tutorial";
 
 import saveData from "@assets/tutorials/stationLandingTutorial/save.json";
 import station1ImageSrc from "@assets/tutorials/stationLandingTutorial/station1.webp";

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/templateTutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/templateTutorial.ts
@@ -17,9 +17,10 @@
 
 import type { Result } from "@cosmos-journeyer/typescript";
 
-import { safeParseSave, type Save } from "@/backend/save/saveFileData";
-import { type SaveLoadingError } from "@/backend/save/saveLoadingError";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import { safeParseSave } from "@/backend/save/saveFileData";
+import type { Save } from "@/backend/save/saveFileData";
+import type { SaveLoadingError } from "@/backend/save/saveLoadingError";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { pressInteractionToStrings } from "@/frontend/helpers/inputControlsString";
 
@@ -29,7 +30,7 @@ import { renderMarkdownBlock } from "@/utils/markdown";
 import i18n from "@/i18n";
 
 import { TutorialControlsInputs } from "../tutorialLayerInputs";
-import { type Tutorial } from "./tutorial";
+import type { Tutorial } from "./tutorial";
 
 import saveData from "@assets/tutorials/flightTutorial/save.json";
 import welcomeImageSrc from "@assets/tutorials/flightTutorial/welcome.webp";

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorials/tutorial.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorials/tutorial.ts
@@ -17,9 +17,9 @@
 
 import type { Result } from "@cosmos-journeyer/typescript";
 
-import { type Save } from "@/backend/save/saveFileData";
-import { type SaveLoadingError } from "@/backend/save/saveLoadingError";
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { Save } from "@/backend/save/saveFileData";
+import type { SaveLoadingError } from "@/backend/save/saveLoadingError";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
 export interface Tutorial {
     getTitle(): string;

--- a/packages/game/src/ts/frontend/ui/tutorial/tutorialsPanelContent.ts
+++ b/packages/game/src/ts/frontend/ui/tutorial/tutorialsPanelContent.ts
@@ -24,7 +24,7 @@ import { FuelScoopTutorial } from "./tutorials/fuelScoopTutorial";
 import { PlanetaryLandingTutorial } from "./tutorials/planetaryLandingTutorial";
 import { StarMapTutorial } from "./tutorials/starMapTutorial";
 import { StationLandingTutorial } from "./tutorials/stationLandingTutorial";
-import { type Tutorial } from "./tutorials/tutorial";
+import type { Tutorial } from "./tutorials/tutorial";
 
 export class TutorialsPanelContent {
     readonly htmlRoot: HTMLElement;

--- a/packages/game/src/ts/frontend/universe/architecture/canHaveRings.ts
+++ b/packages/game/src/ts/frontend/universe/architecture/canHaveRings.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
+import type { RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
 
-import { type AsteroidField } from "../asteroidFields/asteroidField";
+import type { AsteroidField } from "../asteroidFields/asteroidField";
 
 /**
  * Describes objects that can have a ring system

--- a/packages/game/src/ts/frontend/universe/architecture/celestialBody.ts
+++ b/packages/game/src/ts/frontend/universe/architecture/celestialBody.ts
@@ -15,11 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type OrbitalObjectType } from "@cosmos-journeyer/universe-model";
+import type { OrbitalObjectType } from "@cosmos-journeyer/universe-model";
 
-import { type CanHaveRings } from "./canHaveRings";
-import { type OrbitalObjectBase } from "./orbitalObjectBase";
-import { type Targetable } from "./targetable";
+import type { CanHaveRings } from "./canHaveRings";
+import type { OrbitalObjectBase } from "./orbitalObjectBase";
+import type { Targetable } from "./targetable";
 
 /**
  * Describes all celestial bodies (a combination of OrbitalObject, CanHaveRings)

--- a/packages/game/src/ts/frontend/universe/architecture/orbitalObject.ts
+++ b/packages/game/src/ts/frontend/universe/architecture/orbitalObject.ts
@@ -15,17 +15,17 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type CustomOrbitalObject } from "@/frontend/universe/customOrbitalObject";
-import { type BlackHole } from "@/frontend/universe/stellarObjects/blackHole/blackHole";
-import { type NeutronStar } from "@/frontend/universe/stellarObjects/neutronStar/neutronStar";
-import { type Star } from "@/frontend/universe/stellarObjects/star/star";
+import type { CustomOrbitalObject } from "@/frontend/universe/customOrbitalObject";
+import type { BlackHole } from "@/frontend/universe/stellarObjects/blackHole/blackHole";
+import type { NeutronStar } from "@/frontend/universe/stellarObjects/neutronStar/neutronStar";
+import type { Star } from "@/frontend/universe/stellarObjects/star/star";
 
-import { type DarkKnight } from "../darkKnight";
-import { type EmptyCelestialBody } from "../emptyCelestialBody";
-import { type SpaceElevator } from "../orbitalFacility/spaceElevator";
-import { type SpaceStation } from "../orbitalFacility/spaceStation";
-import { type GasPlanet } from "../planets/gasPlanet/gasPlanet";
-import { type TelluricPlanet } from "../planets/telluricPlanet/telluricPlanet";
+import type { DarkKnight } from "../darkKnight";
+import type { EmptyCelestialBody } from "../emptyCelestialBody";
+import type { SpaceElevator } from "../orbitalFacility/spaceElevator";
+import type { SpaceStation } from "../orbitalFacility/spaceStation";
+import type { GasPlanet } from "../planets/gasPlanet/gasPlanet";
+import type { TelluricPlanet } from "../planets/telluricPlanet/telluricPlanet";
 
 export type StellarObject = Star | NeutronStar | BlackHole;
 

--- a/packages/game/src/ts/frontend/universe/architecture/orbitalObjectBase.ts
+++ b/packages/game/src/ts/frontend/universe/architecture/orbitalObjectBase.ts
@@ -16,9 +16,9 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type OrbitalObjectModel, type OrbitalObjectType } from "@cosmos-journeyer/universe-model";
+import type { OrbitalObjectModel, OrbitalObjectType } from "@cosmos-journeyer/universe-model";
 
-import { type Transformable } from "./transformable";
+import type { Transformable } from "./transformable";
 
 export interface OrbitalObjectBase<T extends OrbitalObjectType> extends Transformable {
     type: DeepReadonly<T>;

--- a/packages/game/src/ts/frontend/universe/architecture/targetable.ts
+++ b/packages/game/src/ts/frontend/universe/architecture/targetable.ts
@@ -1,6 +1,6 @@
-import { type HasBoundingSphere } from "./hasBoundingSphere";
-import { type Transformable } from "./transformable";
-import { type TypedObject } from "./typedObject";
+import type { HasBoundingSphere } from "./hasBoundingSphere";
+import type { Transformable } from "./transformable";
+import type { TypedObject } from "./typedObject";
 
 export const ObjectTargetCursorType = {
     CELESTIAL_BODY: "CELESTIAL_BODY",

--- a/packages/game/src/ts/frontend/universe/architecture/transformable.ts
+++ b/packages/game/src/ts/frontend/universe/architecture/transformable.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type TransformNode } from "@babylonjs/core/Meshes";
+import type { TransformNode } from "@babylonjs/core/Meshes";
 
 /**
  * Describes all objects that can be moved around, rotated and scaled in the scene

--- a/packages/game/src/ts/frontend/universe/asteroidFields/asteroidField.ts
+++ b/packages/game/src/ts/frontend/universe/asteroidFields/asteroidField.ts
@@ -16,13 +16,13 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { type IDisposable, type Scene } from "@babylonjs/core/scene";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { IDisposable, Scene } from "@babylonjs/core/scene";
 
-import { type Asteroid } from "@/frontend/assets/objects/asteroids";
+import type { Asteroid } from "@/frontend/assets/objects/asteroids";
 
 import { getRngFromSeed } from "@/utils/getRngFromSeed";
-import { type RingVolume } from "@/utils/ringVolume";
+import type { RingVolume } from "@/utils/ringVolume";
 
 import { AsteroidPatch } from "./asteroidPatch";
 

--- a/packages/game/src/ts/frontend/universe/asteroidFields/asteroidPatch.ts
+++ b/packages/game/src/ts/frontend/universe/asteroidFields/asteroidPatch.ts
@@ -15,15 +15,15 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Quaternion } from "@babylonjs/core/Maths/math";
+import type { Quaternion } from "@babylonjs/core/Maths/math";
 import { Space } from "@babylonjs/core/Maths/math.axis";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type InstancedMesh } from "@babylonjs/core/Meshes/instancedMesh";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { InstancedMesh } from "@babylonjs/core/Meshes/instancedMesh";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsMotionType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import { PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
 
-import { type Asteroid } from "@/frontend/assets/objects/asteroids";
+import type { Asteroid } from "@/frontend/assets/objects/asteroids";
 
 export class AsteroidPatch {
     readonly parent: TransformNode;

--- a/packages/game/src/ts/frontend/universe/axisRenderer.ts
+++ b/packages/game/src/ts/frontend/universe/axisRenderer.ts
@@ -16,12 +16,12 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Vector3 } from "@babylonjs/core/Maths/math";
-import { type Mesh } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Mesh } from "@babylonjs/core/Meshes";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type HasBoundingSphere } from "./architecture/hasBoundingSphere";
-import { type Transformable } from "./architecture/transformable";
-import { type CreateLinesMeshFunction } from "./lineRendering";
+import type { HasBoundingSphere } from "./architecture/hasBoundingSphere";
+import type { Transformable } from "./architecture/transformable";
+import type { CreateLinesMeshFunction } from "./lineRendering";
 
 /**
  * Visual helper designed to display the rotation axis of given objects

--- a/packages/game/src/ts/frontend/universe/customOrbitalObject.ts
+++ b/packages/game/src/ts/frontend/universe/customOrbitalObject.ts
@@ -16,12 +16,13 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Quaternion } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type OrbitalObjectModelBase } from "@cosmos-journeyer/universe-model";
+import type { OrbitalObjectModelBase } from "@cosmos-journeyer/universe-model";
 
-import { type OrbitalObjectBase } from "./architecture/orbitalObjectBase";
-import { ObjectTargetCursorType, type Targetable, type TargetInfo } from "./architecture/targetable";
+import type { OrbitalObjectBase } from "./architecture/orbitalObjectBase";
+import { ObjectTargetCursorType } from "./architecture/targetable";
+import type { Targetable, TargetInfo } from "./architecture/targetable";
 
 export class CustomOrbitalObject implements OrbitalObjectBase<"custom">, Targetable {
     private readonly _transform: TransformNode;

--- a/packages/game/src/ts/frontend/universe/darkKnight.ts
+++ b/packages/game/src/ts/frontend/universe/darkKnight.ts
@@ -16,19 +16,21 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { PBRMetallicRoughnessMaterial } from "@babylonjs/core/Materials/PBR/pbrMetallicRoughnessMaterial";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
-import { type Scene } from "@babylonjs/core/scene";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { getCelestialBodyRadius, type DarkKnightModel } from "@cosmos-journeyer/universe-model";
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type { DarkKnightModel } from "@cosmos-journeyer/universe-model";
 
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
-import { type RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
+import type { RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
 
-import { type CelestialBodyBase } from "./architecture/celestialBody";
-import { ObjectTargetCursorType, type TargetInfo } from "./architecture/targetable";
-import { type AsteroidField } from "./asteroidFields/asteroidField";
+import type { CelestialBodyBase } from "./architecture/celestialBody";
+import { ObjectTargetCursorType } from "./architecture/targetable";
+import type { TargetInfo } from "./architecture/targetable";
+import type { AsteroidField } from "./asteroidFields/asteroidField";
 
 export class DarkKnight implements CelestialBodyBase<"darkKnight"> {
     readonly type: "darkKnight";

--- a/packages/game/src/ts/frontend/universe/emptyCelestialBody.ts
+++ b/packages/game/src/ts/frontend/universe/emptyCelestialBody.ts
@@ -17,18 +17,16 @@
 
 import { Quaternion } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    getCelestialBodyRadius,
-    type CelestialBodyModel,
-    type OrbitalObjectType,
-} from "@cosmos-journeyer/universe-model";
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type { CelestialBodyModel, OrbitalObjectType } from "@cosmos-journeyer/universe-model";
 
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
 
-import { type CelestialBodyBase } from "./architecture/celestialBody";
-import { defaultTargetInfoCelestialBody, type TargetInfo } from "./architecture/targetable";
+import type { CelestialBodyBase } from "./architecture/celestialBody";
+import { defaultTargetInfoCelestialBody } from "./architecture/targetable";
+import type { TargetInfo } from "./architecture/targetable";
 
 export class EmptyCelestialBody<TObjectType extends OrbitalObjectType> implements CelestialBodyBase<TObjectType> {
     readonly model: Extract<DeepReadonly<CelestialBodyModel>, { type: TObjectType }>;

--- a/packages/game/src/ts/frontend/universe/keplerianOrbitalSimulation.spec.ts
+++ b/packages/game/src/ts/frontend/universe/keplerianOrbitalSimulation.spec.ts
@@ -18,7 +18,7 @@
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { describe, expect, it } from "vitest";
 
-import { type OrbitalObject } from "./architecture/orbitalObject";
+import type { OrbitalObject } from "./architecture/orbitalObject";
 import { KeplerianOrbitalSimulation } from "./keplerianOrbitalSimulation";
 
 function createTestOrbitalObject({

--- a/packages/game/src/ts/frontend/universe/keplerianOrbitalSimulation.ts
+++ b/packages/game/src/ts/frontend/universe/keplerianOrbitalSimulation.ts
@@ -15,12 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type OrbitalObjectId } from "@cosmos-journeyer/universe-model";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Quaternion } from "@babylonjs/core/Maths/math.vector";
+import type { OrbitalObjectId } from "@cosmos-journeyer/universe-model";
 
 import { computeAbsoluteOrientation, getPointOnOrbitLocal } from "@/frontend/helpers/orbit";
 
-import { type OrbitalObject } from "./architecture/orbitalObject";
+import type { OrbitalObject } from "./architecture/orbitalObject";
 
 export type OrbitalTransform = {
     readonly position: Vector3;

--- a/packages/game/src/ts/frontend/universe/lineRendering.ts
+++ b/packages/game/src/ts/frontend/universe/lineRendering.ts
@@ -17,13 +17,13 @@
 
 import { GreasedLineMeshColorMode } from "@babylonjs/core/Materials/GreasedLine/greasedLineMaterialInterfaces";
 import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
-import { type Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { CreateGreasedLine } from "@babylonjs/core/Meshes/Builders/greasedLineBuilder";
 import { CreateLines } from "@babylonjs/core/Meshes/Builders/linesBuilder";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type RGBColor } from "@/utils/colors";
+import type { RGBColor } from "@/utils/colors";
 
 export type CreateLinesMeshFunction = (
     name: string,

--- a/packages/game/src/ts/frontend/universe/orbitRenderer.ts
+++ b/packages/game/src/ts/frontend/universe/orbitRenderer.ts
@@ -15,15 +15,16 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Quaternion, Vector3, type Matrix } from "@babylonjs/core/Maths/math";
-import { type Mesh } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math";
+import type { Matrix } from "@babylonjs/core/Maths/math";
+import type { Mesh } from "@babylonjs/core/Meshes";
+import type { Scene } from "@babylonjs/core/scene";
 import { getOrbitalPeriod } from "@cosmos-journeyer/physics";
 
 import { getPointOnOrbitLocal } from "@/frontend/helpers/orbit";
-import { type OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
+import type { OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
 
-import { type CreateLinesMeshFunction } from "./lineRendering";
+import type { CreateLinesMeshFunction } from "./lineRendering";
 
 export class OrbitRenderer {
     private readonly orbitMeshes: Map<OrbitalObject, Mesh> = new Map();

--- a/packages/game/src/ts/frontend/universe/orbitalFacility/landingPadManager.spec.ts
+++ b/packages/game/src/ts/frontend/universe/orbitalFacility/landingPadManager.spec.ts
@@ -18,9 +18,11 @@
 import { TransformNode } from "@babylonjs/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ObjectTargetCursorType, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import { ObjectTargetCursorType } from "@/frontend/universe/architecture/targetable";
+import type { TargetInfo } from "@/frontend/universe/architecture/targetable";
 
-import { LandingPadManager, LandingPadSize, type ILandingPad, type LandingRequest } from "./landingPadManager";
+import { LandingPadManager, LandingPadSize } from "./landingPadManager";
+import type { ILandingPad, LandingRequest } from "./landingPadManager";
 
 vi.mock("@babylonjs/core");
 

--- a/packages/game/src/ts/frontend/universe/orbitalFacility/landingPadManager.ts
+++ b/packages/game/src/ts/frontend/universe/orbitalFacility/landingPadManager.ts
@@ -17,7 +17,7 @@
 
 import { Observable } from "@babylonjs/core/Misc/observable";
 
-import { type Targetable } from "@/frontend/universe/architecture/targetable";
+import type { Targetable } from "@/frontend/universe/architecture/targetable";
 
 export const LandingPadSize = {
     SMALL: 1,

--- a/packages/game/src/ts/frontend/universe/orbitalFacility/managesLandingPads.ts
+++ b/packages/game/src/ts/frontend/universe/orbitalFacility/managesLandingPads.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type LandingPadManager } from "./landingPadManager";
+import type { LandingPadManager } from "./landingPadManager";
 
 export interface ManagesLandingPads {
     /**

--- a/packages/game/src/ts/frontend/universe/orbitalFacility/orbitalFacility.ts
+++ b/packages/game/src/ts/frontend/universe/orbitalFacility/orbitalFacility.ts
@@ -15,12 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type OrbitalObjectType } from "@cosmos-journeyer/universe-model";
+import type { OrbitalObjectType } from "@cosmos-journeyer/universe-model";
 
-import { type Cullable } from "@/frontend/helpers/cullable";
-import { type OrbitalObjectBase } from "@/frontend/universe/architecture/orbitalObjectBase";
-import { type Targetable } from "@/frontend/universe/architecture/targetable";
-import { type ManagesLandingPads } from "@/frontend/universe/orbitalFacility/managesLandingPads";
+import type { Cullable } from "@/frontend/helpers/cullable";
+import type { OrbitalObjectBase } from "@/frontend/universe/architecture/orbitalObjectBase";
+import type { Targetable } from "@/frontend/universe/architecture/targetable";
+import type { ManagesLandingPads } from "@/frontend/universe/orbitalFacility/managesLandingPads";
 
 export interface OrbitalFacilityBase<T extends OrbitalObjectType>
     extends OrbitalObjectBase<T>, ManagesLandingPads, Cullable, Targetable {

--- a/packages/game/src/ts/frontend/universe/orbitalFacility/spaceElevator.ts
+++ b/packages/game/src/ts/frontend/universe/orbitalFacility/spaceElevator.ts
@@ -15,16 +15,17 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
 import type { Light } from "@babylonjs/core/Lights/light";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type Scene } from "@babylonjs/core/scene";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { Scene } from "@babylonjs/core/scene";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import type { ElevatorSectionModel, SpaceElevatorModel } from "@cosmos-journeyer/universe-model";
 
 import { SpaceElevatorClimber } from "@/frontend/assets/procedural/spaceStation/climber/spaceElevatorClimber";
@@ -36,16 +37,18 @@ import { MetalSectionMaterial } from "@/frontend/assets/procedural/spaceStation/
 import { SolarSection } from "@/frontend/assets/procedural/spaceStation/solarSection";
 import { TokamakSection } from "@/frontend/assets/procedural/spaceStation/tokamakSection";
 import { UtilitySection } from "@/frontend/assets/procedural/spaceStation/utilitySection";
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { isSizeOnScreenEnough } from "@/frontend/helpers/isObjectVisibleOnScreen";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
-import { ObjectTargetCursorType, type Targetable, type TargetInfo } from "@/frontend/universe/architecture/targetable";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
-import { LandingPadManager, type ILandingPad } from "@/frontend/universe/orbitalFacility/landingPadManager";
+import { ObjectTargetCursorType } from "@/frontend/universe/architecture/targetable";
+import type { Targetable, TargetInfo } from "@/frontend/universe/architecture/targetable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
+import { LandingPadManager } from "@/frontend/universe/orbitalFacility/landingPadManager";
+import type { ILandingPad } from "@/frontend/universe/orbitalFacility/landingPadManager";
 
 import { clamp, remap, triangleWave } from "@/utils/math";
 
-import { type OrbitalFacilityBase } from "./orbitalFacility";
+import type { OrbitalFacilityBase } from "./orbitalFacility";
 import type { StationSection } from "./stationSection";
 
 export class SpaceElevator implements OrbitalFacilityBase<"spaceElevator"> {

--- a/packages/game/src/ts/frontend/universe/orbitalFacility/spaceStation.ts
+++ b/packages/game/src/ts/frontend/universe/orbitalFacility/spaceStation.ts
@@ -15,14 +15,16 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
 import type { Light } from "@babylonjs/core/Lights/light";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
-import { Quaternion, type Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Quaternion } from "@babylonjs/core/Maths/math.vector";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { Scene } from "@babylonjs/core/scene";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import type { SpaceStationModel, StationSectionModel } from "@cosmos-journeyer/universe-model";
 
 import { EngineBay } from "@/frontend/assets/procedural/spaceStation/engineBay";
@@ -33,14 +35,16 @@ import { LandingBay } from "@/frontend/assets/procedural/spaceStation/landingBay
 import { SolarSection } from "@/frontend/assets/procedural/spaceStation/solarSection";
 import { TokamakSection } from "@/frontend/assets/procedural/spaceStation/tokamakSection";
 import { UtilitySection } from "@/frontend/assets/procedural/spaceStation/utilitySection";
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { isSizeOnScreenEnough } from "@/frontend/helpers/isObjectVisibleOnScreen";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
-import { ObjectTargetCursorType, type Targetable, type TargetInfo } from "@/frontend/universe/architecture/targetable";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
-import { LandingPadManager, type ILandingPad } from "@/frontend/universe/orbitalFacility/landingPadManager";
+import { ObjectTargetCursorType } from "@/frontend/universe/architecture/targetable";
+import type { Targetable, TargetInfo } from "@/frontend/universe/architecture/targetable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
+import { LandingPadManager } from "@/frontend/universe/orbitalFacility/landingPadManager";
+import type { ILandingPad } from "@/frontend/universe/orbitalFacility/landingPadManager";
 
-import { type OrbitalFacilityBase } from "./orbitalFacility";
+import type { OrbitalFacilityBase } from "./orbitalFacility";
 import type { StationSection } from "./stationSection";
 
 export class SpaceStation implements OrbitalFacilityBase<"spaceStation"> {

--- a/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
+++ b/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanet.ts
@@ -15,29 +15,30 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import type { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
-import { type Material } from "@babylonjs/core/Materials/material";
+import type { Material } from "@babylonjs/core/Materials/material";
 import { Quaternion } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { TransformNode } from "@babylonjs/core/Meshes";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import { EarthRadius } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type GasPlanetModel } from "@cosmos-journeyer/universe-model";
+import type { GasPlanetModel } from "@cosmos-journeyer/universe-model";
 
-import { type Textures } from "@/frontend/assets/textures";
-import { type Cullable } from "@/frontend/helpers/cullable";
+import type { Textures } from "@/frontend/assets/textures";
+import type { Cullable } from "@/frontend/helpers/cullable";
 import { isSizeOnScreenEnough } from "@/frontend/helpers/isObjectVisibleOnScreen";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
 import { AtmosphereUniforms } from "@/frontend/postProcesses/atmosphere/atmosphereUniforms";
-import { type RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";
+import type { RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";
 import { RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
-import { defaultTargetInfoCelestialBody, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import { defaultTargetInfoCelestialBody } from "@/frontend/universe/architecture/targetable";
+import type { TargetInfo } from "@/frontend/universe/architecture/targetable";
 import { AsteroidField } from "@/frontend/universe/asteroidFields/asteroidField";
 
-import { type ItemPool } from "@/utils/itemPool";
+import type { ItemPool } from "@/utils/itemPool";
 
 import { Settings } from "@/settings";
 

--- a/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanetProceduralMaterial.ts
+++ b/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanetProceduralMaterial.ts
@@ -19,9 +19,9 @@ import type { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type GasPlanetProceduralColorPalette } from "@cosmos-journeyer/universe-model";
+import type { GasPlanetProceduralColorPalette } from "@cosmos-journeyer/universe-model";
 
 import {
     setStellarObjectUniforms,

--- a/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanetTextureMaterial.ts
+++ b/packages/game/src/ts/frontend/universe/planets/gasPlanet/gasPlanetTextureMaterial.ts
@@ -16,11 +16,11 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
-import { type GasPlanetTextureId } from "@cosmos-journeyer/universe-model";
+import type { GasPlanetTextureId } from "@cosmos-journeyer/universe-model";
 
-import { type GasPlanetTextures } from "@/frontend/assets/textures/gasPlanet";
+import type { GasPlanetTextures } from "@/frontend/assets/textures/gasPlanet";
 
 export function createGasPlanetTextureMaterial(
     textureId: GasPlanetTextureId,

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/colorSettingsInterface.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/colorSettingsInterface.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Color3 } from "@babylonjs/core/Maths/math.color";
+import type { Color3 } from "@babylonjs/core/Maths/math.color";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 
 export type ColorMode = "default" | "moisture" | "temperature" | "normal" | "height";

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanet.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanet.ts
@@ -15,28 +15,29 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { TransformNode } from "@babylonjs/core/Meshes";
 import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import { PhysicsShapeSphere } from "@babylonjs/core/Physics/v2/physicsShape";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type TelluricPlanetModel, type TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
+import type { TelluricPlanetModel, TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
 
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
-import { type Cullable } from "@/frontend/helpers/cullable";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { Cullable } from "@/frontend/helpers/cullable";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
 import { AtmosphereUniforms } from "@/frontend/postProcesses/atmosphere/atmosphereUniforms";
-import { type CloudsLut } from "@/frontend/postProcesses/clouds/cloudsLut";
+import type { CloudsLut } from "@/frontend/postProcesses/clouds/cloudsLut";
 import { CloudsUniforms } from "@/frontend/postProcesses/clouds/cloudsUniforms";
 import { OceanUniforms } from "@/frontend/postProcesses/ocean/oceanUniforms";
-import { type RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";
+import type { RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";
 import { RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
-import { defaultTargetInfoCelestialBody, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import { defaultTargetInfoCelestialBody } from "@/frontend/universe/architecture/targetable";
+import type { TargetInfo } from "@/frontend/universe/architecture/targetable";
 import { AsteroidField } from "@/frontend/universe/asteroidFields/asteroidField";
 
-import { type ItemPool } from "@/utils/itemPool";
+import type { ItemPool } from "@/utils/itemPool";
 
 import { CollisionMask, Settings } from "@/settings";
 
@@ -44,7 +45,7 @@ import type { CelestialBodyBase } from "../../architecture/celestialBody";
 import { TelluricPlanetMaterial } from "./telluricPlanetMaterial";
 import type { ScatteringSystem } from "./terrain/chunks/scatteringSystem";
 import { SphericalHeightFieldTerrain } from "./terrain/sphericalHeightFieldTerrain";
-import { type ITerrainSystem } from "./terrain/system/terrainSystem";
+import type { ITerrainSystem } from "./terrain/system/terrainSystem";
 
 export class TelluricPlanet implements CelestialBodyBase<"telluricPlanet" | "telluricSatellite">, Cullable {
     readonly model: DeepReadonly<TelluricPlanetModel> | DeepReadonly<TelluricSatelliteModel>;

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanetMaterial.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanetMaterial.ts
@@ -65,6 +65,8 @@ import {
 } from "@/utils/bslExtensions";
 import { lerp } from "@/utils/math";
 
+import { BeachElevationSpan } from "./terrain/terrainConstants";
+
 type WorldType =
     /** World with atmosphere and liquid water */
     | "wet"
@@ -72,8 +74,6 @@ type WorldType =
     | "dry"
     /** World without atmosphere */
     | "airless";
-
-export const BeachElevationSpan = 100;
 
 export class TelluricPlanetMaterial {
     private readonly material: NodeMaterial;

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanetMaterial.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/telluricPlanetMaterial.ts
@@ -21,7 +21,8 @@ import type { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Vector3, Vector4 } from "@babylonjs/core/Maths/math.vector";
 import type { Scene } from "@babylonjs/core/scene";
 import { celsiusToKelvin } from "@cosmos-journeyer/physics";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import type { TelluricPlanetModel, TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
 import {
     abs,
@@ -57,12 +58,8 @@ import {
 
 import type { TerrainTextures } from "@/frontend/assets/textures/terrains";
 
-import {
-    mixTriPlanarSamples,
-    triangleWave3d,
-    triPlanarMaterial,
-    type TriPlanarMaterialSamples,
-} from "@/utils/bslExtensions";
+import { mixTriPlanarSamples, triangleWave3d, triPlanarMaterial } from "@/utils/bslExtensions";
+import type { TriPlanarMaterialSamples } from "@/utils/bslExtensions";
 import { lerp } from "@/utils/math";
 
 import { BeachElevationSpan } from "./terrain/terrainConstants";

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/createChunkBuffers.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/createChunkBuffers.ts
@@ -19,7 +19,8 @@ import { Axis, Quaternion, Vector3 } from "@babylonjs/core/pure";
 import { build_chunk_vertex_data, BuildData } from "terrain-generation";
 
 import { AvailableRockSizes } from "@/frontend/assets/objects/rockSizes";
-import { filterPoints, MaxScatterDensity, type ScatteringLayer } from "@/frontend/helpers/instancing";
+import { filterPoints, MaxScatterDensity } from "@/frontend/helpers/instancing";
+import type { ScatteringLayer } from "@/frontend/helpers/instancing";
 
 import { smoothstep } from "@/utils/math";
 

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/createChunkBuffers.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/createChunkBuffers.ts
@@ -25,9 +25,9 @@ import { smoothstep } from "@/utils/math";
 
 import { Settings } from "@/settings";
 
-import { BeachElevationSpan } from "../../telluricPlanetMaterial";
 import { createTerrainSettings } from "../createTerrainSettings";
 import type { TerrainBuffers } from "../system/terrainSystem";
+import { BeachElevationSpan } from "../terrainConstants";
 import type { BuildChunkWorkerPayload } from "../workers/terrainSystemWorkerProtocol";
 import type { ScatteredInstanceBuffers } from "./scatteringSystem";
 

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/lodUpdateContext.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/lodUpdateContext.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 export type LodUpdateContext = {
     readonly cameraPositionPlanetSpace: Vector3;

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/scatteringSystem.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/scatteringSystem.ts
@@ -16,11 +16,11 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PhysicsMotionType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import { PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
-import { type PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
 import type { Scene } from "@babylonjs/core/scene";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
 

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/terrainChunkMesh.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/terrainChunkMesh.ts
@@ -17,30 +17,34 @@
 
 import "@babylonjs/core/Engines/Extensions/engine.query";
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
-import { type Material } from "@babylonjs/core/Materials/material";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
+import type { Material } from "@babylonjs/core/Materials/material";
 import { Color4 } from "@babylonjs/core/Maths/math.color";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { VertexData, type TransformNode } from "@babylonjs/core/Meshes";
+import { VertexData } from "@babylonjs/core/Meshes";
+import type { TransformNode } from "@babylonjs/core/Meshes";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { PhysicsMotionType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import { PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
-import { PhysicsShapeMesh, type PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
-import { type Scene } from "@babylonjs/core/scene";
+import { PhysicsShapeMesh } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { PhysicsShape } from "@babylonjs/core/Physics/v2/physicsShape";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type TelluricPlanetModel, type TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
+import type { TelluricPlanetModel, TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
 
-import { type Cullable } from "@/frontend/helpers/cullable";
+import type { Cullable } from "@/frontend/helpers/cullable";
 import { isSizeOnScreenEnough } from "@/frontend/helpers/isObjectVisibleOnScreen";
-import { type HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 import { CollisionMask, Settings } from "@/settings";
 
-import { makeChunkId, type ChunkId, type TerrainBuffers } from "../system/terrainSystem";
-import { type ChunkIndices } from "./chunkIndices";
-import { getQuaternionFromFaceIndex, type FaceIndex } from "./faceIndex";
-import { type LodUpdateContext } from "./lodUpdateContext";
+import { makeChunkId } from "../system/terrainSystem";
+import type { ChunkId, TerrainBuffers } from "../system/terrainSystem";
+import type { ChunkIndices } from "./chunkIndices";
+import { getQuaternionFromFaceIndex } from "./faceIndex";
+import type { FaceIndex } from "./faceIndex";
+import type { LodUpdateContext } from "./lodUpdateContext";
 import type { IScatteringSystem } from "./scatteringSystem";
 
 type ChunkLodMetrics = {

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/terrainFaceQuadTree.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/terrainFaceQuadTree.ts
@@ -15,29 +15,27 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
-import { type Material } from "@babylonjs/core/Materials/material";
-import { type TransformNode } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
+import type { Material } from "@babylonjs/core/Materials/material";
+import type { TransformNode } from "@babylonjs/core/Meshes";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type TelluricPlanetModel,
-    type TelluricSatelliteModel,
-    type TerrainSettings,
-} from "@cosmos-journeyer/universe-model";
+import type { TelluricPlanetModel, TelluricSatelliteModel, TerrainSettings } from "@cosmos-journeyer/universe-model";
 
-import { type Cullable } from "@/frontend/helpers/cullable";
+import type { Cullable } from "@/frontend/helpers/cullable";
 
 import { Settings } from "@/settings";
 
-import { type ITerrainSystem } from "../system/terrainSystem";
-import { type BuildChunkInput } from "../system/terrainTaskInputs";
-import { getChunkChildIndices, type ChunkIndices } from "./chunkIndices";
-import { type FaceIndex } from "./faceIndex";
-import { type LodUpdateContext } from "./lodUpdateContext";
+import type { ITerrainSystem } from "../system/terrainSystem";
+import type { BuildChunkInput } from "../system/terrainTaskInputs";
+import { getChunkChildIndices } from "./chunkIndices";
+import type { ChunkIndices } from "./chunkIndices";
+import type { FaceIndex } from "./faceIndex";
+import type { LodUpdateContext } from "./lodUpdateContext";
 import type { IScatteringSystem } from "./scatteringSystem";
 import { TerrainChunkMesh } from "./terrainChunkMesh";
-import { TerrainQuadTreeNode, type TerrainQuadTreeChildren } from "./terrainQuadTreeNode";
+import { TerrainQuadTreeNode } from "./terrainQuadTreeNode";
+import type { TerrainQuadTreeChildren } from "./terrainQuadTreeNode";
 
 const splitScreenSpaceErrorThreshold = 32;
 const mergeScreenSpaceErrorThreshold = 16;

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/terrainQuadTreeNode.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/terrainQuadTreeNode.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type TerrainChunkMesh } from "./terrainChunkMesh";
+import type { TerrainChunkMesh } from "./terrainChunkMesh";
 
 export type TerrainQuadTreeChildren = [
     TerrainQuadTreeNode,

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystem.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystem.ts
@@ -18,7 +18,7 @@
 import type { Brand } from "@cosmos-journeyer/typescript";
 
 import type { ScatteredInstanceBuffers } from "../chunks/scatteringSystem";
-import { type BuildChunkInput, type ComputeHeightsInput } from "./terrainTaskInputs";
+import type { BuildChunkInput, ComputeHeightsInput } from "./terrainTaskInputs";
 
 export type TaskId = Brand<string, "TaskId">;
 

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystemCpu.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystemCpu.ts
@@ -81,10 +81,9 @@ export class TerrainSystemCpu implements ITerrainSystem {
     public static async New(nbVerticesPerRow: number): Promise<Result<TerrainSystemCpu, Error>> {
         const nbWorkers = Math.max(1, navigator.hardwareConcurrency - 1); // -1 because the main thread is also used
 
-        const workerResults: Array<Result<Worker, Error>> = [];
-        for (let workerIndex = 0; workerIndex < nbWorkers; workerIndex++) {
-            workerResults.push(await this.CreateBuildWorker());
-        }
+        const workerResults = await Promise.all(
+            Array.from({ length: nbWorkers }, async () => this.CreateBuildWorker()),
+        );
 
         const errors: Array<Error> = [];
         const availableWorkers: Array<Worker> = [];

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystemCpu.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystemCpu.ts
@@ -15,25 +15,26 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 
 import { Settings } from "@/settings";
 
-import {
-    type BuildChunkWorkerPayload,
-    type ComputeHeightsWorkerPayload,
-    type TerrainSystemWorkerOutput,
-    type TerrainSystemWorkerTask,
+import type {
+    BuildChunkWorkerPayload,
+    ComputeHeightsWorkerPayload,
+    TerrainSystemWorkerOutput,
+    TerrainSystemWorkerTask,
 } from "../workers/terrainSystemWorkerProtocol";
-import {
-    type ChunkId,
-    type ITerrainSystem,
-    type TaskId,
-    type TerrainSystemChunkOutput,
-    type TerrainSystemHeightsOutput,
-    makeTaskId,
+import { makeTaskId } from "./terrainSystem";
+import type {
+    ChunkId,
+    ITerrainSystem,
+    TaskId,
+    TerrainSystemChunkOutput,
+    TerrainSystemHeightsOutput,
 } from "./terrainSystem";
-import { type BuildChunkInput, type ComputeHeightsInput } from "./terrainTaskInputs";
+import type { BuildChunkInput, ComputeHeightsInput } from "./terrainTaskInputs";
 import { TerrainTaskRegistry } from "./terrainTaskRegistry";
 import { WorkerPool } from "./workerPool";
 

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainTaskInputs.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainTaskInputs.ts
@@ -15,11 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type TelluricPlanetModel, type TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
+import type { TelluricPlanetModel, TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
 
-import { type FaceIndex } from "../chunks/faceIndex";
+import type { FaceIndex } from "../chunks/faceIndex";
 
 export type BuildChunkInput = {
     planetModel: DeepReadonly<TelluricPlanetModel> | DeepReadonly<TelluricSatelliteModel>;

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainTaskRegistry.spec.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/system/terrainTaskRegistry.spec.ts
@@ -17,7 +17,8 @@
 
 import { describe, expect, it } from "vitest";
 
-import { makeChunkId, makeTaskId, type TerrainBuffers } from "./terrainSystem";
+import { makeChunkId, makeTaskId } from "./terrainSystem";
+import type { TerrainBuffers } from "./terrainSystem";
 import { TerrainTaskRegistry } from "./terrainTaskRegistry";
 
 function makeBuffers(value: number): TerrainBuffers {

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/terrainConstants.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/terrainConstants.ts
@@ -1,0 +1,18 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2026 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+export const BeachElevationSpan = 100;

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/workers/terrainSystemWorker.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/workers/terrainSystemWorker.ts
@@ -18,11 +18,11 @@
 import { createChunkBuffers } from "../chunks/createChunkBuffers";
 import { computeHeights } from "../computeHeights";
 import type { TaskId } from "../system/terrainSystem";
-import {
-    type BuildChunkWorkerPayload,
-    type ComputeHeightsWorkerPayload,
-    type TerrainSystemWorkerTask,
-    type TerrainSystemWorkerOutput,
+import type {
+    BuildChunkWorkerPayload,
+    ComputeHeightsWorkerPayload,
+    TerrainSystemWorkerOutput,
+    TerrainSystemWorkerTask,
 } from "./terrainSystemWorkerProtocol";
 
 type ReturnPayload = {

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/workers/terrainSystemWorkerProtocol.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/workers/terrainSystemWorkerProtocol.ts
@@ -16,10 +16,10 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type TelluricPlanetModel, type TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
+import type { TelluricPlanetModel, TelluricSatelliteModel } from "@cosmos-journeyer/universe-model";
 
-import { type FaceIndex } from "../chunks/faceIndex";
-import { type ScatteredInstanceBuffers } from "../chunks/scatteringSystem";
+import type { FaceIndex } from "../chunks/faceIndex";
+import type { ScatteredInstanceBuffers } from "../chunks/scatteringSystem";
 import type { TaskId } from "../system/terrainSystem";
 
 export type BuildChunkWorkerPayload = {

--- a/packages/game/src/ts/frontend/universe/starFieldBox.ts
+++ b/packages/game/src/ts/frontend/universe/starFieldBox.ts
@@ -17,16 +17,16 @@
 
 import { BackgroundMaterial } from "@babylonjs/core/Materials/Background/backgroundMaterial";
 import type { Material } from "@babylonjs/core/Materials/material";
-import { type CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
+import type { CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { Matrix } from "@babylonjs/core/Maths/math.vector";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { RenderingManager } from "@babylonjs/core/Rendering/renderingManager";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
-import { type Transformable } from "@/frontend/universe/architecture/transformable";
+import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
 export class StarFieldBox implements Transformable {
     readonly mesh: Mesh;

--- a/packages/game/src/ts/frontend/universe/starSystemController.ts
+++ b/packages/game/src/ts/frontend/universe/starSystemController.ts
@@ -15,21 +15,18 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Color3, Matrix, Quaternion } from "@babylonjs/core/Maths/math";
+import { Matrix, Quaternion } from "@babylonjs/core/Maths/math";
+import type { Color3 } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { Scene } from "@babylonjs/core/scene";
 import { lightYearsToMeters } from "@cosmos-journeyer/physics";
 import type { DeepReadonly, NonEmptyArray } from "@cosmos-journeyer/typescript";
-import {
-    type OrbitalObjectId,
-    type StarSystemCoordinates,
-    type StarSystemModel,
-} from "@cosmos-journeyer/universe-model";
+import type { OrbitalObjectId, StarSystemCoordinates, StarSystemModel } from "@cosmos-journeyer/universe-model";
 
-import { type UniverseBackend } from "@/backend/universe/universeBackend";
+import type { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { wrapVector3 } from "@/frontend/helpers/algebra";
 import { SystemTarget } from "@/frontend/universe/systemTarget";
 
@@ -37,22 +34,23 @@ import { Settings } from "@/settings";
 
 import { FloatingOriginSystem } from "../helpers/floatingOriginSystem";
 import { StellarLightSystem } from "../helpers/stellarLightSystem";
-import {
-    type Anomaly,
-    type CelestialBody,
-    type OrbitalFacility,
-    type OrbitalObject,
-    type Planet,
-    type StellarObject,
+import type {
+    Anomaly,
+    CelestialBody,
+    OrbitalFacility,
+    OrbitalObject,
+    Planet,
+    StellarObject,
 } from "./architecture/orbitalObject";
 import { GravitySystem } from "./gravitySystem";
-import { KeplerianOrbitalSimulation, type OrbitalTransform } from "./keplerianOrbitalSimulation";
+import { KeplerianOrbitalSimulation } from "./keplerianOrbitalSimulation";
+import type { OrbitalTransform } from "./keplerianOrbitalSimulation";
 import type { GasPlanet } from "./planets/gasPlanet/gasPlanet";
 import { TelluricPlanet } from "./planets/telluricPlanet/telluricPlanet";
 import { ScatteringSystem } from "./planets/telluricPlanet/terrain/chunks/scatteringSystem";
-import { type ITerrainSystem } from "./planets/telluricPlanet/terrain/system/terrainSystem";
+import type { ITerrainSystem } from "./planets/telluricPlanet/terrain/system/terrainSystem";
 import { StarFieldBox } from "./starFieldBox";
-import { type StarSystemLoader } from "./starSystemLoader";
+import type { StarSystemLoader } from "./starSystemLoader";
 
 /**
  * The controller of the star system manages all resources specific to a single star system.

--- a/packages/game/src/ts/frontend/universe/starSystemLoader.ts
+++ b/packages/game/src/ts/frontend/universe/starSystemLoader.ts
@@ -16,23 +16,19 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type Scene } from "@babylonjs/core/scene";
-import {
-    assertUnreachable,
-    isNonEmptyArray,
-    type DeepReadonly,
-    type NonEmptyArray,
-} from "@cosmos-journeyer/typescript";
-import {
-    type AnomalyModel,
-    type PlanetModel,
-    type StellarObjectModel,
-    type TelluricSatelliteModel,
-    type StarSystemModel,
+import type { Scene } from "@babylonjs/core/scene";
+import { assertUnreachable, isNonEmptyArray } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly, NonEmptyArray } from "@cosmos-journeyer/typescript";
+import type {
+    AnomalyModel,
+    PlanetModel,
+    StellarObjectModel,
+    TelluricSatelliteModel,
+    StarSystemModel,
 } from "@cosmos-journeyer/universe-model";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
-import { type RenderingAssets } from "@/frontend/assets/renderingAssets";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { RenderingAssets } from "@/frontend/assets/renderingAssets";
 import { GasPlanet } from "@/frontend/universe/planets/gasPlanet/gasPlanet";
 import { TelluricPlanet } from "@/frontend/universe/planets/telluricPlanet/telluricPlanet";
 import { BlackHole } from "@/frontend/universe/stellarObjects/blackHole/blackHole";
@@ -41,7 +37,7 @@ import { Star } from "@/frontend/universe/stellarObjects/star/star";
 
 import { wait } from "@/utils/wait";
 
-import { type Anomaly, type OrbitalFacility, type Planet, type StellarObject } from "./architecture/orbitalObject";
+import type { Anomaly, OrbitalFacility, Planet, StellarObject } from "./architecture/orbitalObject";
 import { DarkKnight } from "./darkKnight";
 import { EmptyCelestialBody } from "./emptyCelestialBody";
 import { SpaceElevator } from "./orbitalFacility/spaceElevator";

--- a/packages/game/src/ts/frontend/universe/stellarObjects/blackHole/blackHole.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/blackHole/blackHole.ts
@@ -15,16 +15,17 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
+import type { CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
 import { Quaternion } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import { getSchwarzschildRadius, getShadowRadius } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type BlackHoleModel } from "@cosmos-journeyer/universe-model";
+import type { BlackHoleModel } from "@cosmos-journeyer/universe-model";
 
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
-import { defaultTargetInfoCelestialBody, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import { defaultTargetInfoCelestialBody } from "@/frontend/universe/architecture/targetable";
+import type { TargetInfo } from "@/frontend/universe/architecture/targetable";
 
 import type { CelestialBodyBase } from "../../architecture/celestialBody";
 import { AccretionDisk } from "./accretionDisk";

--- a/packages/game/src/ts/frontend/universe/stellarObjects/blackHole/blackHolePostProcess.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/blackHole/blackHolePostProcess.ts
@@ -15,21 +15,22 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Constants } from "@babylonjs/core/Engines/constants";
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { PostProcess } from "@babylonjs/core/PostProcesses/postProcess";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import type { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { CameraUniformNames, setCameraUniforms } from "@/frontend/postProcesses/uniforms/cameraUniforms";
 import { ObjectUniformNames, setObjectUniforms } from "@/frontend/postProcesses/uniforms/objectUniforms";
 import { SamplerUniformNames, setSamplerUniforms } from "@/frontend/postProcesses/uniforms/samplerUniforms";
-import { type UpdatablePostProcess } from "@/frontend/postProcesses/updatablePostProcess";
+import type { UpdatablePostProcess } from "@/frontend/postProcesses/updatablePostProcess";
 
-import { BlackHoleSamplerNames, BlackHoleUniformNames, type BlackHoleUniforms } from "./blackHoleUniforms";
+import { BlackHoleSamplerNames, BlackHoleUniformNames } from "./blackHoleUniforms";
+import type { BlackHoleUniforms } from "./blackHoleUniforms";
 
 import blackHoleFragment from "@shaders/blackhole.glsl";
 

--- a/packages/game/src/ts/frontend/universe/stellarObjects/blackHole/blackHoleUniforms.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/blackHole/blackHoleUniforms.ts
@@ -15,13 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Effect } from "@babylonjs/core/Materials/effect";
-import { type CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
+import type { Effect } from "@babylonjs/core/Materials/effect";
+import type { CubeTexture } from "@babylonjs/core/Materials/Textures/cubeTexture";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { G, getKerrMetricA, getSchwarzschildRadius } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type BlackHoleModel } from "@cosmos-journeyer/universe-model";
+import type { BlackHoleModel } from "@cosmos-journeyer/universe-model";
 
 import { computeSpinAxisOrientation } from "@/frontend/helpers/orbit";
 

--- a/packages/game/src/ts/frontend/universe/stellarObjects/neutronStar/neutronStar.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/neutronStar/neutronStar.ts
@@ -15,27 +15,28 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Quaternion } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { TransformNode } from "@babylonjs/core/Meshes";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type NeutronStarModel } from "@cosmos-journeyer/universe-model";
+import type { NeutronStarModel } from "@cosmos-journeyer/universe-model";
 
-import { type Textures } from "@/frontend/assets/textures";
-import { type Cullable } from "@/frontend/helpers/cullable";
+import type { Textures } from "@/frontend/assets/textures";
+import type { Cullable } from "@/frontend/helpers/cullable";
 import { isSizeOnScreenEnough } from "@/frontend/helpers/isObjectVisibleOnScreen";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
-import { type RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";
+import type { RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";
 import { RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
 import { VolumetricLightUniforms } from "@/frontend/postProcesses/volumetricLight/volumetricLightUniforms";
-import { defaultTargetInfoCelestialBody, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import { defaultTargetInfoCelestialBody } from "@/frontend/universe/architecture/targetable";
+import type { TargetInfo } from "@/frontend/universe/architecture/targetable";
 import { AsteroidField } from "@/frontend/universe/asteroidFields/asteroidField";
 
-import { type ItemPool } from "@/utils/itemPool";
+import type { ItemPool } from "@/utils/itemPool";
 import { getRgbFromTemperature } from "@/utils/specrend";
 
 import { Settings } from "@/settings";

--- a/packages/game/src/ts/frontend/universe/stellarObjects/star/star.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/star/star.ts
@@ -15,27 +15,28 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Camera } from "@babylonjs/core/Cameras/camera";
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Quaternion } from "@babylonjs/core/Maths/math.vector";
-import { type TransformNode } from "@babylonjs/core/Meshes";
-import { type Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { TransformNode } from "@babylonjs/core/Meshes";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type StarModel } from "@cosmos-journeyer/universe-model";
+import type { StarModel } from "@cosmos-journeyer/universe-model";
 
-import { type Textures } from "@/frontend/assets/textures";
-import { type Cullable } from "@/frontend/helpers/cullable";
+import type { Textures } from "@/frontend/assets/textures";
+import type { Cullable } from "@/frontend/helpers/cullable";
 import { isSizeOnScreenEnough } from "@/frontend/helpers/isObjectVisibleOnScreen";
 import { getOrbitalObjectTypeToI18nString } from "@/frontend/helpers/orbitalObjectTypeToDisplay";
-import { type RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";
+import type { RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";
 import { RingsUniforms } from "@/frontend/postProcesses/rings/ringsUniform";
 import { VolumetricLightUniforms } from "@/frontend/postProcesses/volumetricLight/volumetricLightUniforms";
-import { defaultTargetInfoCelestialBody, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import { defaultTargetInfoCelestialBody } from "@/frontend/universe/architecture/targetable";
+import type { TargetInfo } from "@/frontend/universe/architecture/targetable";
 import { AsteroidField } from "@/frontend/universe/asteroidFields/asteroidField";
 
-import { type ItemPool } from "@/utils/itemPool";
+import type { ItemPool } from "@/utils/itemPool";
 import { getRgbFromTemperature } from "@/utils/specrend";
 
 import { Settings } from "@/settings";

--- a/packages/game/src/ts/frontend/universe/stellarObjects/star/starMaterial.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/star/starMaterial.ts
@@ -17,15 +17,15 @@
 
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import { createEmptyTexture } from "@/frontend/assets/procedural/proceduralTexture";
 
 import type { RGBColor } from "@/utils/colors";
-import { type ItemPool } from "@/utils/itemPool";
+import type { ItemPool } from "@/utils/itemPool";
 import { getRgbFromTemperature } from "@/utils/specrend";
 
-import { type StarMaterialLut } from "./starMaterialLut";
+import type { StarMaterialLut } from "./starMaterialLut";
 
 import starMaterialFragment from "@shaders/starMaterial/fragment.glsl";
 import starMaterialVertex from "@shaders/starMaterial/vertex.glsl";

--- a/packages/game/src/ts/frontend/universe/stellarObjects/star/starMaterialLut.ts
+++ b/packages/game/src/ts/frontend/universe/stellarObjects/star/starMaterialLut.ts
@@ -17,7 +17,7 @@
 
 import { Effect } from "@babylonjs/core/Materials/effect";
 import { ProceduralTexture } from "@babylonjs/core/Materials/Textures/Procedurals/proceduralTexture";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 import lutFragment from "@shaders/starMaterial/utils/lut.glsl";
 

--- a/packages/game/src/ts/frontend/universe/systemTarget.ts
+++ b/packages/game/src/ts/frontend/universe/systemTarget.ts
@@ -1,11 +1,13 @@
-import { Vector3, type Matrix } from "@babylonjs/core/Maths/math.vector";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Matrix } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes";
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 import { lightYearsToMeters } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type StarSystemCoordinates, type StarSystemModel } from "@cosmos-journeyer/universe-model";
+import type { StarSystemCoordinates, StarSystemModel } from "@cosmos-journeyer/universe-model";
 
-import { ObjectTargetCursorType, type Targetable, type TargetInfo } from "@/frontend/universe/architecture/targetable";
+import { ObjectTargetCursorType } from "@/frontend/universe/architecture/targetable";
+import type { Targetable, TargetInfo } from "@/frontend/universe/architecture/targetable";
 
 import i18n from "@/i18n";
 

--- a/packages/game/src/ts/frontend/vehicle/hingedDoor.ts
+++ b/packages/game/src/ts/frontend/vehicle/hingedDoor.ts
@@ -15,10 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import {
-    PhysicsConstraintMotorType,
-    type PhysicsConstraintAxis,
-} from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
+import { PhysicsConstraintMotorType } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
+import type { PhysicsConstraintAxis } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import type { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 import type { PhysicsBody } from "@babylonjs/core/Physics/v2/physicsBody";
 import type { Physics6DoFConstraint } from "@babylonjs/core/Physics/v2/physicsConstraint";

--- a/packages/game/src/ts/frontend/vehicle/vehicle.ts
+++ b/packages/game/src/ts/frontend/vehicle/vehicle.ts
@@ -26,7 +26,8 @@ import { clamp, lerp, lerpSmooth } from "@/utils/math";
 
 import i18n from "@/i18n";
 
-import { ObjectTargetCursorType, type Targetable, type TargetInfo } from "../universe/architecture/targetable";
+import { ObjectTargetCursorType } from "../universe/architecture/targetable";
+import type { Targetable, TargetInfo } from "../universe/architecture/targetable";
 import type { Door } from "./door";
 import type { Wheel } from "./wheel";
 

--- a/packages/game/src/ts/frontend/vehicle/vehicleBuilder.ts
+++ b/packages/game/src/ts/frontend/vehicle/vehicleBuilder.ts
@@ -29,8 +29,10 @@ import type { RenderingAssets } from "../assets/renderingAssets";
 import type { Door } from "./door";
 import { filterVehicleShape } from "./filterVehicleShape";
 import { HingedDoor } from "./hingedDoor";
-import { Vehicle, type FixedVehiclePart } from "./vehicle";
-import { CreateAxle, CreateWheel, Wheel, type WheelModel } from "./wheel";
+import { Vehicle } from "./vehicle";
+import type { FixedVehiclePart } from "./vehicle";
+import { CreateAxle, CreateWheel, Wheel } from "./wheel";
+import type { WheelModel } from "./wheel";
 
 type FixationModel = {
     rotation?: {

--- a/packages/game/src/ts/frontend/vehicle/vehicleControls.ts
+++ b/packages/game/src/ts/frontend/vehicle/vehicleControls.ts
@@ -29,12 +29,9 @@ import type { Controls } from "../controls";
 import { CustomAnimation } from "../helpers/animations/customAnimation";
 import { easeInOutCubic } from "../helpers/animations/interpolations";
 import { toggleDoor } from "./door";
-import {
-    type ThirdPersonCameraPreset,
-    type ThirdPersonCameraPresetNames,
-    thirdPersonCameraPresets,
-} from "./thirdPersonCameraPresets";
-import { type Vehicle } from "./vehicle";
+import { thirdPersonCameraPresets } from "./thirdPersonCameraPresets";
+import type { ThirdPersonCameraPreset, ThirdPersonCameraPresetNames } from "./thirdPersonCameraPresets";
+import type { Vehicle } from "./vehicle";
 import { VehicleInputs } from "./vehicleControlsInputs";
 
 type CameraPresetInput = (typeof VehicleInputs.map)["resetCamera"];

--- a/packages/game/src/ts/frontend/vehicle/wireframeTopology.ts
+++ b/packages/game/src/ts/frontend/vehicle/wireframeTopology.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 
 type VertexHandle = number;
 

--- a/packages/game/src/ts/frontend/vehicle/wolfMk2.ts
+++ b/packages/game/src/ts/frontend/vehicle/wolfMk2.ts
@@ -17,11 +17,13 @@
 
 import { PBRMaterial } from "@babylonjs/core/Materials/PBR/pbrMaterial";
 import { Axis } from "@babylonjs/core/Maths/math.axis";
-import { Vector3, type Quaternion } from "@babylonjs/core/Maths/math.vector";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Quaternion } from "@babylonjs/core/Maths/math.vector";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import { PhysicsConstraintAxis } from "@babylonjs/core/Physics/v2/IPhysicsEnginePlugin";
 import type { Scene } from "@babylonjs/core/scene";
-import { err, ok, type Result } from "@cosmos-journeyer/typescript";
+import { err, ok } from "@cosmos-journeyer/typescript";
+import type { Result } from "@cosmos-journeyer/typescript";
 import earcut from "earcut";
 
 import type { RenderingAssets } from "../assets/renderingAssets";

--- a/packages/game/src/ts/frontend/view.ts
+++ b/packages/game/src/ts/frontend/view.ts
@@ -1,4 +1,4 @@
-import { type Scene } from "@babylonjs/core/scene";
+import type { Scene } from "@babylonjs/core/scene";
 
 /**
  * A view is a super set of a scene. In order to prevent interactions between post-processes and the GUI, we actually

--- a/packages/game/src/ts/i18n.ts
+++ b/packages/game/src/ts/i18n.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import i18next, { init, t, type Resource, type ResourceKey, type ResourceLanguage } from "i18next";
+import i18next, { init, t } from "i18next";
+import type { Resource, ResourceKey, ResourceLanguage } from "i18next";
 import { z } from "zod";
 
 import { renderMarkdownInline } from "./utils/markdown";

--- a/packages/game/src/ts/playground.ts
+++ b/packages/game/src/ts/playground.ts
@@ -19,7 +19,8 @@ import "@styles/index.css";
 
 import "@babylonjs/node-editor";
 
-import { Engine, PhysicsViewer, Tools, type Scene } from "@babylonjs/core";
+import { Engine, PhysicsViewer, Tools } from "@babylonjs/core";
+import type { Scene } from "@babylonjs/core";
 import { Inspector } from "@babylonjs/inspector";
 
 import { LoadingScreen } from "@/frontend/helpers/loadingScreen";

--- a/packages/game/src/ts/playgrounds/anomalies/juliaSet.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/juliaSet.ts
@@ -15,10 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ArcRotateCamera, DirectionalLight, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { ArcRotateCamera, DirectionalLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { generateJuliaSetModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { CelestialBodyUberShaderPass } from "@/frontend/postProcesses/celestialBodyUberShader/celestialBodyUberShaderPass";
 import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";

--- a/packages/game/src/ts/playgrounds/anomalies/mandelbox.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/mandelbox.ts
@@ -15,10 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ArcRotateCamera, DirectionalLight, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { ArcRotateCamera, DirectionalLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { generateMandelboxModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { CelestialBodyUberShaderPass } from "@/frontend/postProcesses/celestialBodyUberShader/celestialBodyUberShaderPass";
 import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";

--- a/packages/game/src/ts/playgrounds/anomalies/mandelbulb.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/mandelbulb.ts
@@ -15,10 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ArcRotateCamera, DirectionalLight, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { ArcRotateCamera, DirectionalLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { generateMandelbulbModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { CelestialBodyUberShaderPass } from "@/frontend/postProcesses/celestialBodyUberShader/celestialBodyUberShaderPass";
 import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";

--- a/packages/game/src/ts/playgrounds/anomalies/mengerSponge.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/mengerSponge.ts
@@ -15,10 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ArcRotateCamera, DirectionalLight, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { ArcRotateCamera, DirectionalLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { generateMengerSpongeModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { CelestialBodyUberShaderPass } from "@/frontend/postProcesses/celestialBodyUberShader/celestialBodyUberShaderPass";
 import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";

--- a/packages/game/src/ts/playgrounds/anomalies/sierpinski.ts
+++ b/packages/game/src/ts/playgrounds/anomalies/sierpinski.ts
@@ -15,10 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ArcRotateCamera, DirectionalLight, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { ArcRotateCamera, DirectionalLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { generateSierpinskiPyramidModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { CelestialBodyUberShaderPass } from "@/frontend/postProcesses/celestialBodyUberShader/celestialBodyUberShaderPass";
 import { EmptyCelestialBody } from "@/frontend/universe/emptyCelestialBody";

--- a/packages/game/src/ts/playgrounds/asteroidField.ts
+++ b/packages/game/src/ts/playgrounds/asteroidField.ts
@@ -23,10 +23,10 @@ import {
     PhysicsShapeType,
     Scene,
     Vector3,
-    type AbstractEngine,
 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadAsteroids } from "@/frontend/assets/objects/asteroids";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { lookAt } from "@/frontend/helpers/transform";

--- a/packages/game/src/ts/playgrounds/atmosphericScattering.ts
+++ b/packages/game/src/ts/playgrounds/atmosphericScattering.ts
@@ -16,10 +16,10 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { DirectionalLight, MeshBuilder, Vector3 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { lookAt } from "@/frontend/helpers/transform";

--- a/packages/game/src/ts/playgrounds/automaticLanding.ts
+++ b/packages/game/src/ts/playgrounds/automaticLanding.ts
@@ -23,13 +23,13 @@ import {
     PhysicsShapeType,
     Quaternion,
 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 import { randRange } from "extended-random";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { LandingPad } from "@/frontend/assets/procedural/spaceStation/landingPad/landingPad";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";

--- a/packages/game/src/ts/playgrounds/butterfly.ts
+++ b/packages/game/src/ts/playgrounds/butterfly.ts
@@ -16,11 +16,11 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ArcRotateCamera, DirectionalLight, HemisphericLight, Vector3 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 import { seededSquirrelNoise } from "squirrel-noise";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { createButterfly } from "@/frontend/assets/procedural/butterfly/butterfly";
 import { ButterflyMaterial } from "@/frontend/assets/procedural/butterfly/butterflyMaterial";
 import { loadParticleTextures } from "@/frontend/assets/textures/particles";

--- a/packages/game/src/ts/playgrounds/character.ts
+++ b/packages/game/src/ts/playgrounds/character.ts
@@ -26,11 +26,11 @@ import {
     PhysicsShapeType,
     Space,
 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadHumanoidPrefabs } from "@/frontend/assets/objects/humanoids";
 import { CharacterControls } from "@/frontend/controls/characterControls/characterControls";
 import { CharacterInputs } from "@/frontend/controls/characterControls/characterControlsInputs";

--- a/packages/game/src/ts/playgrounds/cryptographicSecret.ts
+++ b/packages/game/src/ts/playgrounds/cryptographicSecret.ts
@@ -15,10 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { FreeCamera, HemisphericLight, MeshBuilder, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { FreeCamera, HemisphericLight, MeshBuilder, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import * as BABYLON from "@babylonjs/core";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { decryptFunction } from "@/frontend/helpers/cipher";
 import { alertModal, promptModalString } from "@/frontend/ui/dialogModal";

--- a/packages/game/src/ts/playgrounds/customSystem.ts
+++ b/packages/game/src/ts/playgrounds/customSystem.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 import type { StarSystemModel } from "@cosmos-journeyer/universe-model";
 
@@ -26,14 +26,15 @@ import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { getVestaSystemModel } from "@/backend/universe/customSystems/vesta";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";
 import { positionNearObjectBrightSide } from "@/frontend/helpers/positionNearObject";
 import { Player } from "@/frontend/player/player";
 import { StarSystemView } from "@/frontend/starSystemView";
-import { NotificationManagerMock, type INotificationManager } from "@/frontend/ui/notificationManager";
+import { NotificationManagerMock } from "@/frontend/ui/notificationManager";
+import type { INotificationManager } from "@/frontend/ui/notificationManager";
 import { TerrainSystemCpu } from "@/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystemCpu";
 
 import { initI18n } from "@/i18n";

--- a/packages/game/src/ts/playgrounds/darkKnight.ts
+++ b/packages/game/src/ts/playgrounds/darkKnight.ts
@@ -15,10 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { generateDarkKnightModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadEnvironmentTextures } from "@/frontend/assets/textures/environment";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { lookAt } from "@/frontend/helpers/transform";

--- a/packages/game/src/ts/playgrounds/debugAssets.ts
+++ b/packages/game/src/ts/playgrounds/debugAssets.ts
@@ -15,13 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { FreeCamera, MeshBuilder, PointLight, StandardMaterial, type BaseTexture } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { FreeCamera, MeshBuilder, PointLight, StandardMaterial } from "@babylonjs/core";
+import type { BaseTexture } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 
 import { enablePhysics } from "./utils";

--- a/packages/game/src/ts/playgrounds/default.ts
+++ b/packages/game/src/ts/playgrounds/default.ts
@@ -16,10 +16,10 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { FreeCamera, HemisphericLight, MeshBuilder, Vector3 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 
 export async function createDefaultScene(
     engine: AbstractEngine,

--- a/packages/game/src/ts/playgrounds/flightDemo.ts
+++ b/packages/game/src/ts/playgrounds/flightDemo.ts
@@ -16,12 +16,12 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Color3, DirectionalLight, Matrix, MeshBuilder, PBRMaterial } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";

--- a/packages/game/src/ts/playgrounds/forest.ts
+++ b/packages/game/src/ts/playgrounds/forest.ts
@@ -26,10 +26,10 @@ import {
     Quaternion,
     Vector3,
 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 
 import { enablePhysics } from "./utils";

--- a/packages/game/src/ts/playgrounds/gasPlanet.ts
+++ b/packages/game/src/ts/playgrounds/gasPlanet.ts
@@ -15,11 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { DirectionalLight, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { DirectionalLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { SolarTemperature } from "@cosmos-journeyer/physics";
 import { generateGasPlanetModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadTextures } from "@/frontend/assets/textures";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/grass.ts
+++ b/packages/game/src/ts/playgrounds/grass.ts
@@ -24,11 +24,11 @@ import {
     PBRMaterial,
     Vector3,
 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 import { seededSquirrelNoise } from "squirrel-noise";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { createGrassBlade } from "@/frontend/assets/procedural/grass/grassBlade";
 import { GrassMaterial } from "@/frontend/assets/procedural/grass/grassMaterial";
 import { loadNoiseTextures } from "@/frontend/assets/textures/noises";

--- a/packages/game/src/ts/playgrounds/gravitySystem.ts
+++ b/packages/game/src/ts/playgrounds/gravitySystem.ts
@@ -26,8 +26,8 @@ import {
     PhysicsShapeType,
     Scene,
     Vector3,
-    type AbstractEngine,
 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
 import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/hyperspaceTunnel.ts
+++ b/packages/game/src/ts/playgrounds/hyperspaceTunnel.ts
@@ -15,13 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Axis } from "@babylonjs/core/Maths/math.axis";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { HyperSpaceTunnel } from "@/frontend/assets/procedural/hyperSpaceTunnel";
 import { loadNoiseTextures } from "@/frontend/assets/textures/noises";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";

--- a/packages/game/src/ts/playgrounds/interaction.ts
+++ b/packages/game/src/ts/playgrounds/interaction.ts
@@ -26,11 +26,11 @@ import {
     PhysicsShapeType,
     Scene,
     Vector3,
-    type AbstractEngine,
 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
 import { loadSounds } from "@/frontend/assets/audio/sounds";
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadHumanoidPrefabs } from "@/frontend/assets/objects/humanoids";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { CharacterControls } from "@/frontend/controls/characterControls/characterControls";

--- a/packages/game/src/ts/playgrounds/landingPad.ts
+++ b/packages/game/src/ts/playgrounds/landingPad.ts
@@ -15,23 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import {
-    ClusteredLightContainer,
-    Color3,
-    GlowLayer,
-    HemisphericLight,
-    Scene,
-    Vector3,
-    type AbstractEngine,
-} from "@babylonjs/core";
+import { ClusteredLightContainer, Color3, GlowLayer, HemisphericLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { LandingPad } from "@/frontend/assets/procedural/spaceStation/landingPad/landingPad";
 import { LandingPadMaterial } from "@/frontend/assets/procedural/spaceStation/landingPad/landingPadMaterial";
-import {
-    ProceduralSpotLightInstances,
-    type ProceduralSpotLightInstanceData,
-} from "@/frontend/assets/procedural/spotLight";
+import { ProceduralSpotLightInstances } from "@/frontend/assets/procedural/spotLight";
+import type { ProceduralSpotLightInstanceData } from "@/frontend/assets/procedural/spotLight";
 import { loadConcreteTextures } from "@/frontend/assets/textures/materials/concrete";
 import { createSquareTextDecalTexture } from "@/frontend/assets/textures/squareTextDecalTexture";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";

--- a/packages/game/src/ts/playgrounds/lensFlareOcclusion.ts
+++ b/packages/game/src/ts/playgrounds/lensFlareOcclusion.ts
@@ -15,18 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import {
-    Color3,
-    FreeCamera,
-    MeshBuilder,
-    Scene,
-    StandardMaterial,
-    TransformNode,
-    Vector3,
-    type AbstractEngine,
-} from "@babylonjs/core";
+import { Color3, FreeCamera, MeshBuilder, Scene, StandardMaterial, TransformNode, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { LensFlarePostProcess } from "@/frontend/postProcesses/lensFlarePostProcess";
 

--- a/packages/game/src/ts/playgrounds/onFoot.ts
+++ b/packages/game/src/ts/playgrounds/onFoot.ts
@@ -26,11 +26,11 @@ import {
     Quaternion,
     Vector3,
 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 import { seededSquirrelNoise } from "squirrel-noise";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadHumanoidPrefabs } from "@/frontend/assets/objects/humanoids";
 import { createButterfly } from "@/frontend/assets/procedural/butterfly/butterfly";
 import { ButterflyMaterial } from "@/frontend/assets/procedural/butterfly/butterflyMaterial";

--- a/packages/game/src/ts/playgrounds/orbitalDemo.ts
+++ b/packages/game/src/ts/playgrounds/orbitalDemo.ts
@@ -15,14 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import { Tools } from "@babylonjs/core/Misc/tools";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { lookAt } from "@/frontend/helpers/transform";
 import { AxisRenderer } from "@/frontend/universe/axisRenderer";

--- a/packages/game/src/ts/playgrounds/playgroundRegistry.ts
+++ b/packages/game/src/ts/playgrounds/playgroundRegistry.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine, type Scene } from "@babylonjs/core";
+import type { AbstractEngine, Scene } from "@babylonjs/core";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 
 import { createJuliaSetScene } from "./anomalies/juliaSet";
 import { createMandelboxScene } from "./anomalies/mandelbox";

--- a/packages/game/src/ts/playgrounds/rings.ts
+++ b/packages/game/src/ts/playgrounds/rings.ts
@@ -15,12 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { DirectionalLight, MeshBuilder, type TransformNode, Vector3 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { DirectionalLight, MeshBuilder, Vector3 } from "@babylonjs/core";
+import type { TransformNode } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
-import { type RingsModel } from "@cosmos-journeyer/universe-model";
+import type { RingsModel } from "@cosmos-journeyer/universe-model";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { lookAt } from "@/frontend/helpers/transform";

--- a/packages/game/src/ts/playgrounds/rover.ts
+++ b/packages/game/src/ts/playgrounds/rover.ts
@@ -27,8 +27,8 @@ import {
     Quaternion,
     Scene,
     Vector3,
-    type AbstractEngine,
 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
 import { loadSounds } from "@/frontend/assets/audio/sounds";
 import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";

--- a/packages/game/src/ts/playgrounds/saveLoadingPanelContent.ts
+++ b/packages/game/src/ts/playgrounds/saveLoadingPanelContent.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { FreeCamera, Vector3 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
 import { SaveBackendSingleFile } from "@/backend/save/saveBackendSingleFile";
@@ -24,7 +24,7 @@ import { SaveLocalStorage } from "@/backend/save/saveLocalStorage";
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { alertModal } from "@/frontend/ui/dialogModal";
 import { NotificationManagerMock } from "@/frontend/ui/notificationManager";

--- a/packages/game/src/ts/playgrounds/sol/jupiter.ts
+++ b/packages/game/src/ts/playgrounds/sol/jupiter.ts
@@ -15,11 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Axis, DirectionalLight, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { Axis, DirectionalLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
 import { getJupiterModel } from "@/backend/universe/customSystems/sol/jupiter";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadTextures } from "@/frontend/assets/textures";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/sol/saturn.ts
+++ b/packages/game/src/ts/playgrounds/sol/saturn.ts
@@ -15,11 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { DirectionalLight, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { DirectionalLight, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
 import { getSaturnModel } from "@/backend/universe/customSystems/sol/saturn";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/sol/sol.ts
+++ b/packages/game/src/ts/playgrounds/sol/sol.ts
@@ -15,11 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
 import { getSolSystemModel } from "@/backend/universe/customSystems/sol/sol";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/sol/sun.ts
+++ b/packages/game/src/ts/playgrounds/sol/sun.ts
@@ -15,11 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { FreeCamera, Scene, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { FreeCamera, Scene, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 
 import { getSunModel } from "@/backend/universe/customSystems/sol/sun";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadTextures } from "@/frontend/assets/textures";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/spaceDots.ts
+++ b/packages/game/src/ts/playgrounds/spaceDots.ts
@@ -16,10 +16,10 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Color4, FreeCamera, GlowLayer, Quaternion, TransformNode, Vector3 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { SpaceDots } from "@/frontend/assets/procedural/spaceDots";
 
 const DEFAULT_THROTTLE = 0.6;

--- a/packages/game/src/ts/playgrounds/spaceElevator.ts
+++ b/packages/game/src/ts/playgrounds/spaceElevator.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { CreateSphere, DirectionalLight, GlowLayer, PBRMaterial } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 import { astronomicalUnitToMeters } from "@cosmos-journeyer/physics";
@@ -25,7 +25,7 @@ import type { StarSystemModel } from "@cosmos-journeyer/universe-model";
 
 import { getSunModel } from "@/backend/universe/customSystems/sol/sun";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { lookAt } from "@/frontend/helpers/transform";

--- a/packages/game/src/ts/playgrounds/spaceStation.ts
+++ b/packages/game/src/ts/playgrounds/spaceStation.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { DirectionalLight, GlowLayer } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 import { astronomicalUnitToMeters } from "@cosmos-journeyer/physics";
@@ -25,7 +25,7 @@ import type { StarSystemModel } from "@cosmos-journeyer/universe-model";
 
 import { getSunModel } from "@/backend/universe/customSystems/sol/sun";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { lookAt } from "@/frontend/helpers/transform";

--- a/packages/game/src/ts/playgrounds/spaceStationUI.ts
+++ b/packages/game/src/ts/playgrounds/spaceStationUI.ts
@@ -15,14 +15,14 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
 import { EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/encyclopaediaGalacticaManager";
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";

--- a/packages/game/src/ts/playgrounds/sphericalHeightFieldTerrain.ts
+++ b/packages/game/src/ts/playgrounds/sphericalHeightFieldTerrain.ts
@@ -22,13 +22,13 @@ import {
     Quaternion,
     Scene,
     Vector3,
-    type AbstractEngine,
 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { generateTelluricPlanetModel } from "@cosmos-journeyer/universe-generation";
 
 import { getSunModel } from "@/backend/universe/customSystems/sol/sun";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { lookAt } from "@/frontend/helpers/transform";
 import { ScatteringSystemMock } from "@/frontend/universe/planets/telluricPlanet/terrain/chunks/scatteringSystem";

--- a/packages/game/src/ts/playgrounds/spotLights.ts
+++ b/packages/game/src/ts/playgrounds/spotLights.ts
@@ -16,14 +16,12 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ClusteredLightContainer, Color3, FreeCamera, GlowLayer, MeshBuilder, Vector3 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
-import {
-    ProceduralSpotLightInstances,
-    type ProceduralSpotLightInstanceData,
-} from "@/frontend/assets/procedural/spotLight";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import { ProceduralSpotLightInstances } from "@/frontend/assets/procedural/spotLight";
+import type { ProceduralSpotLightInstanceData } from "@/frontend/assets/procedural/spotLight";
 
 export async function createSpotLightsScene(
     engine: AbstractEngine,

--- a/packages/game/src/ts/playgrounds/starMap.ts
+++ b/packages/game/src/ts/playgrounds/starMap.ts
@@ -15,13 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadStarMapTextures } from "@/frontend/assets/textures/starMap";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { StarMap } from "@/frontend/starmap/starMap";

--- a/packages/game/src/ts/playgrounds/starMapView.ts
+++ b/packages/game/src/ts/playgrounds/starMapView.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 import { StarSystemCoordinatesSchema } from "@cosmos-journeyer/universe-model";
 
@@ -23,7 +23,7 @@ import { EncyclopaediaGalacticaLocal } from "@/backend/encyclopaedia/encyclopaed
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadStarMapTextures } from "@/frontend/assets/textures/starMap";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { Player } from "@/frontend/player/player";

--- a/packages/game/src/ts/playgrounds/starSystemView.ts
+++ b/packages/game/src/ts/playgrounds/starSystemView.ts
@@ -15,21 +15,22 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
 import { EncyclopaediaGalacticaManager } from "@/backend/encyclopaedia/encyclopaediaGalacticaManager";
 import { getAlphaTestisSystemModel } from "@/backend/universe/customSystems/alphaTestis";
 import { UniverseBackend } from "@/backend/universe/universeBackend";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";
 import { positionNearObjectBrightSide } from "@/frontend/helpers/positionNearObject";
 import { Player } from "@/frontend/player/player";
 import { StarSystemView } from "@/frontend/starSystemView";
-import { NotificationManagerMock, type INotificationManager } from "@/frontend/ui/notificationManager";
+import { NotificationManagerMock } from "@/frontend/ui/notificationManager";
+import type { INotificationManager } from "@/frontend/ui/notificationManager";
 import { TerrainSystemCpu } from "@/frontend/universe/planets/telluricPlanet/terrain/system/terrainSystemCpu";
 
 import { initI18n } from "@/i18n";

--- a/packages/game/src/ts/playgrounds/stationLanding.ts
+++ b/packages/game/src/ts/playgrounds/stationLanding.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { DirectionalLight, GlowLayer } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 import { astronomicalUnitToMeters } from "@cosmos-journeyer/physics";
@@ -25,7 +25,7 @@ import type { StarSystemModel } from "@cosmos-journeyer/universe-model";
 
 import { getSunModel } from "@/backend/universe/customSystems/sol/sun";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";

--- a/packages/game/src/ts/playgrounds/stellarObjects/blackHole.ts
+++ b/packages/game/src/ts/playgrounds/stellarObjects/blackHole.ts
@@ -15,12 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 import { generateBlackHoleModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadEnvironmentTextures } from "@/frontend/assets/textures/environment";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/stellarObjects/neutronStar.ts
+++ b/packages/game/src/ts/playgrounds/stellarObjects/neutronStar.ts
@@ -16,12 +16,12 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Axis } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 import { generateNeutronStarModel } from "@cosmos-journeyer/universe-generation";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadTextures } from "@/frontend/assets/textures";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/swimming.ts
+++ b/packages/game/src/ts/playgrounds/swimming.ts
@@ -25,11 +25,11 @@ import {
     PhysicsAggregate,
     PhysicsShapeType,
 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadHumanoidPrefabs } from "@/frontend/assets/objects/humanoids";
 import { CharacterControls } from "@/frontend/controls/characterControls/characterControls";
 import { CharacterInputs } from "@/frontend/controls/characterControls/characterControlsInputs";

--- a/packages/game/src/ts/playgrounds/telluricPlanet.ts
+++ b/packages/game/src/ts/playgrounds/telluricPlanet.ts
@@ -15,12 +15,13 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Color3, Scene, TransformNode, Vector3, type AbstractEngine } from "@babylonjs/core";
+import { Color3, Scene, TransformNode, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { generateTelluricPlanetModel } from "@cosmos-journeyer/universe-generation";
 
 import { getSunModel } from "@/backend/universe/customSystems/sol/sun";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";

--- a/packages/game/src/ts/playgrounds/thrusterExhaust.ts
+++ b/packages/game/src/ts/playgrounds/thrusterExhaust.ts
@@ -24,11 +24,11 @@ import {
     MeshBuilder,
     PBRMetallicRoughnessMaterial,
     Vector3,
-    type AbstractEngine,
 } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { ThrusterExhaust } from "@/frontend/spaceship/thrusterExhaust";
 
 function createSlider(

--- a/packages/game/src/ts/playgrounds/triPlanarNormal.ts
+++ b/packages/game/src/ts/playgrounds/triPlanarNormal.ts
@@ -23,7 +23,7 @@ import {
     NodeMaterial,
     Vector3,
 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 import { AdvancedDynamicTexture, Control, Rectangle, Slider, StackPanel, TextBlock } from "@babylonjs/gui";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
@@ -44,7 +44,7 @@ import {
     vertexAttribute,
 } from "babylonjs-shading-language";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadTextureAsync } from "@/frontend/assets/textures/utils";
 
 import { getTriPlanarBlending, getTriPlanarUVs, unpackNormal, whiteoutBlend } from "@/utils/bslExtensions";

--- a/packages/game/src/ts/playgrounds/tutorial.ts
+++ b/packages/game/src/ts/playgrounds/tutorial.ts
@@ -16,10 +16,10 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { FreeCamera, Vector3 } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Scene } from "@babylonjs/core/scene";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TutorialLayer } from "@/frontend/ui/tutorial/tutorialLayer";
 import { FlightTutorial } from "@/frontend/ui/tutorial/tutorials/flightTutorial";

--- a/packages/game/src/ts/playgrounds/utils.ts
+++ b/packages/game/src/ts/playgrounds/utils.ts
@@ -17,20 +17,10 @@
 
 import "@babylonjs/core/Physics/physicsEngineComponent";
 
-import {
-    CascadedShadowGenerator,
-    HavokPlugin,
-    MeshBuilder,
-    ReflectionProbe,
-    Vector3,
-    type AbstractEngine,
-    type AbstractMesh,
-    type Camera,
-    type DirectionalLight,
-    type PhysicsEngineV2,
-    type Scene,
-} from "@babylonjs/core";
-import HavokPhysics, { type HavokPhysicsWithBindings } from "@babylonjs/havok";
+import { CascadedShadowGenerator, HavokPlugin, MeshBuilder, ReflectionProbe, Vector3 } from "@babylonjs/core";
+import type { AbstractEngine, AbstractMesh, Camera, DirectionalLight, PhysicsEngineV2, Scene } from "@babylonjs/core";
+import HavokPhysics from "@babylonjs/havok";
+import type { HavokPhysicsWithBindings } from "@babylonjs/havok";
 import { SkyMaterial } from "@babylonjs/materials";
 import * as QRCode from "qrcode";
 

--- a/packages/game/src/ts/playgrounds/xr.ts
+++ b/packages/game/src/ts/playgrounds/xr.ts
@@ -15,8 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ArcRotateCamera, DirectionalLight, type TransformNode } from "@babylonjs/core";
-import { type AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { ArcRotateCamera, DirectionalLight } from "@babylonjs/core";
+import type { TransformNode } from "@babylonjs/core";
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Scene } from "@babylonjs/core/scene";
 import {
@@ -26,9 +27,9 @@ import {
     generateMengerSpongeModel,
     generateSierpinskiPyramidModel,
 } from "@cosmos-journeyer/universe-generation";
-import { type ProceduralRingsModel } from "@cosmos-journeyer/universe-model";
+import type { ProceduralRingsModel } from "@cosmos-journeyer/universe-model";
 
-import { type ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
+import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { CelestialBodyUberShaderPass } from "@/frontend/postProcesses/celestialBodyUberShader/celestialBodyUberShaderPass";
 import { RingsProceduralPatternLut } from "@/frontend/postProcesses/rings/ringsProceduralLut";

--- a/packages/game/src/ts/settings.ts
+++ b/packages/game/src/ts/settings.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Tools } from "@babylonjs/core/Misc/tools";
+import { degreesToRadians } from "@cosmos-journeyer/physics";
 
 export const Settings = {
     UNIVERSE_SEED: Math.PI,
@@ -59,7 +59,7 @@ export const Settings = {
      */
     HYDROPONIC_TO_CONVENTIONAL_RATIO: 3.5,
 
-    FOV: Tools.ToRadians(60),
+    FOV: degreesToRadians(60),
 
     CHARACTER_FIRST_PERSON_INTERACTION_RANGE: 5,
     CHARACTER_THIRD_PERSON_INTERACTION_RANGE: 8,

--- a/packages/game/src/ts/utils/bslExtensions/utils.ts
+++ b/packages/game/src/ts/utils/bslExtensions/utils.ts
@@ -17,20 +17,8 @@
 
 import type { NodeMaterialConnectionPoint } from "@babylonjs/core/Materials/Node/nodeMaterialBlockConnectionPoint";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import {
-    abs,
-    add,
-    f,
-    mod,
-    mul,
-    normalize,
-    remap,
-    splitVec,
-    sub,
-    vec,
-    vec3,
-    type TargetOptions,
-} from "babylonjs-shading-language";
+import { abs, add, f, mod, mul, normalize, remap, splitVec, sub, vec, vec3 } from "babylonjs-shading-language";
+import type { TargetOptions } from "babylonjs-shading-language";
 
 export function triangleWave3d(
     input: NodeMaterialConnectionPoint,

--- a/packages/game/src/ts/utils/colors.spec.ts
+++ b/packages/game/src/ts/utils/colors.spec.ts
@@ -17,7 +17,8 @@
 
 import { describe, expect, it } from "vitest";
 
-import { hsvToRgb, type HSVColor } from "./colors";
+import { hsvToRgb } from "./colors";
+import type { HSVColor } from "./colors";
 
 describe("color utilities", () => {
     describe("hsvToRgb", () => {

--- a/packages/game/src/ts/utils/downloadCommanderArchive.ts
+++ b/packages/game/src/ts/utils/downloadCommanderArchive.ts
@@ -1,7 +1,7 @@
-import { type DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 
 import { createCommanderArchive, createCommanderArchiveFileName } from "@/backend/save/commanderArchive";
-import { type CmdrSaves } from "@/backend/save/saveFileData";
+import type { CmdrSaves } from "@/backend/save/saveFileData";
 
 import { downloadBlob } from "./downloadBlob";
 

--- a/packages/game/src/ts/utils/ringVolume.spec.ts
+++ b/packages/game/src/ts/utils/ringVolume.spec.ts
@@ -1,12 +1,8 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { describe, expect, it } from "vitest";
 
-import {
-    distanceToRingVolume,
-    getNearestPointOnRingVolume,
-    isPositionInsideRingVolume,
-    type RingVolume,
-} from "./ringVolume";
+import { distanceToRingVolume, getNearestPointOnRingVolume, isPositionInsideRingVolume } from "./ringVolume";
+import type { RingVolume } from "./ringVolume";
 
 const ring: RingVolume = {
     center: Vector3.Zero(),

--- a/packages/game/tests/e2e/utils/renderSnap.ts
+++ b/packages/game/tests/e2e/utils/renderSnap.ts
@@ -1,4 +1,5 @@
-import { expect, type Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 export async function renderAndSnap(
     page: Page,

--- a/packages/game/vite.config.ts
+++ b/packages/game/vite.config.ts
@@ -3,7 +3,8 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 import basicSsl from "@vitejs/plugin-basic-ssl";
-import { defineConfig, type PluginOption } from "vite";
+import { defineConfig } from "vite";
+import type { PluginOption } from "vite";
 import glsl from "vite-plugin-glsl";
 import wasm from "vite-plugin-wasm";
 

--- a/packages/universe-generation/src/proceduralGenerators/anomalies/darkKnightModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/anomalies/darkKnightModelGenerator.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { astronomicalUnitToMeters, EarthMass } from "@cosmos-journeyer/physics";
-import { type DarkKnightModel, type OrbitalObjectId } from "@cosmos-journeyer/universe-model";
+import type { DarkKnightModel, OrbitalObjectId } from "@cosmos-journeyer/universe-model";
 
 export function generateDarkKnightModel(parentIds: ReadonlyArray<OrbitalObjectId>): DarkKnightModel {
     return {

--- a/packages/universe-generation/src/proceduralGenerators/anomalies/juliaSetModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/anomalies/juliaSetModelGenerator.ts
@@ -20,13 +20,8 @@ import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { clamp } from "#/utils/math";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
-import { type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type JuliaSetModel,
-    type OrbitalObjectModel,
-    type Orbit,
-    type Rotation,
-} from "@cosmos-journeyer/universe-model";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { JuliaSetModel, OrbitalObjectModel, Orbit, Rotation } from "@cosmos-journeyer/universe-model";
 import { normalRandom, randRange } from "extended-random";
 
 export function generateJuliaSetModel(

--- a/packages/universe-generation/src/proceduralGenerators/anomalies/mandelboxModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/anomalies/mandelboxModelGenerator.ts
@@ -20,13 +20,8 @@ import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { clamp } from "#/utils/math";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
-import { type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type MandelboxModel,
-    type OrbitalObjectModel,
-    type Orbit,
-    type Rotation,
-} from "@cosmos-journeyer/universe-model";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { MandelboxModel, OrbitalObjectModel, Orbit, Rotation } from "@cosmos-journeyer/universe-model";
 import { normalRandom, randRange } from "extended-random";
 
 export function generateMandelboxModel(

--- a/packages/universe-generation/src/proceduralGenerators/anomalies/mandelbulbModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/anomalies/mandelbulbModelGenerator.ts
@@ -20,13 +20,8 @@ import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { clamp } from "#/utils/math";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
-import { type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type MandelbulbModel,
-    type OrbitalObjectModel,
-    type Orbit,
-    type Rotation,
-} from "@cosmos-journeyer/universe-model";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { MandelbulbModel, OrbitalObjectModel, Orbit, Rotation } from "@cosmos-journeyer/universe-model";
 import { normalRandom, randRange } from "extended-random";
 
 export function generateMandelbulbModel(

--- a/packages/universe-generation/src/proceduralGenerators/anomalies/mengerSpongeModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/anomalies/mengerSpongeModelGenerator.ts
@@ -20,13 +20,8 @@ import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { clamp } from "#/utils/math";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
-import { type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type MengerSpongeModel,
-    type OrbitalObjectModel,
-    type Orbit,
-    type Rotation,
-} from "@cosmos-journeyer/universe-model";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { MengerSpongeModel, OrbitalObjectModel, Orbit, Rotation } from "@cosmos-journeyer/universe-model";
 import { normalRandom, randRange } from "extended-random";
 
 export function generateMengerSpongeModel(

--- a/packages/universe-generation/src/proceduralGenerators/anomalies/sierpinskiPyramidModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/anomalies/sierpinskiPyramidModelGenerator.ts
@@ -20,13 +20,8 @@ import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { clamp } from "#/utils/math";
 import { degreesToRadians } from "@cosmos-journeyer/physics";
-import { type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type SierpinskiPyramidModel,
-    type OrbitalObjectModel,
-    type Orbit,
-    type Rotation,
-} from "@cosmos-journeyer/universe-model";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { SierpinskiPyramidModel, OrbitalObjectModel, Orbit, Rotation } from "@cosmos-journeyer/universe-model";
 import { normalRandom, randRange } from "extended-random";
 
 export function generateSierpinskiPyramidModel(

--- a/packages/universe-generation/src/proceduralGenerators/cloudsModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/cloudsModelGenerator.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getWaterSaturationPressure } from "@cosmos-journeyer/physics";
-import { type CloudsModel } from "@cosmos-journeyer/universe-model";
+import type { CloudsModel } from "@cosmos-journeyer/universe-model";
 
 export function generateCloudsModel(
     planetRadius: number,

--- a/packages/universe-generation/src/proceduralGenerators/gasPlanet/gasPlanetModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/gasPlanet/gasPlanetModelGenerator.ts
@@ -21,13 +21,8 @@ import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { degreesToRadians, EarthSeaLevelPressure, getCoolGasGiantRadiusFromMass } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    getCelestialBodyRadius,
-    type GasPlanetModel,
-    type Orbit,
-    type Rotation,
-    type StellarObjectModel,
-} from "@cosmos-journeyer/universe-model";
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type { GasPlanetModel, Orbit, Rotation, StellarObjectModel } from "@cosmos-journeyer/universe-model";
 import { normalRandom, randRange, randRangeInt, uniformRandBool } from "extended-random";
 
 import { getGasPlanetOrbitRadius, sampleGasPlanetMass } from "./gasPlanetModelHelpers";

--- a/packages/universe-generation/src/proceduralGenerators/orbitalFacilities/spaceElevatorModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/orbitalFacilities/spaceElevatorModelGenerator.ts
@@ -17,7 +17,8 @@
 
 import { HydroponicToConventionalRatio, IndividualAverageDailyIntake, SeedHalfRange } from "#/constants";
 import { getFactionFromCoordinates } from "#/society/factions";
-import { CropTypes, getEdibleEnergyPerAreaPerDay, type CropType } from "#/utils/agriculture";
+import { CropTypes, getEdibleEnergyPerAreaPerDay } from "#/utils/agriculture";
+import type { CropType } from "#/utils/agriculture";
 import { getDistancesToStellarObjects } from "#/utils/distanceToStellarObject";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { randomPieChart, wheelOfFortune } from "#/utils/random";
@@ -29,15 +30,16 @@ import {
     km2ToM2,
     kwhPerYearToWatts,
 } from "@cosmos-journeyer/physics";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    getCelestialBodyRadius,
-    type PlanetModel,
-    type Orbit,
-    type SpaceElevatorModel,
-    type ElevatorSectionModel,
-    type StarSystemModel,
-    type Rotation,
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type {
+    PlanetModel,
+    Orbit,
+    SpaceElevatorModel,
+    ElevatorSectionModel,
+    StarSystemModel,
+    Rotation,
 } from "@cosmos-journeyer/universe-model";
 
 import { generateFusionSectionModel } from "./sections/fusion";

--- a/packages/universe-generation/src/proceduralGenerators/orbitalFacilities/spaceStationModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/orbitalFacilities/spaceStationModelGenerator.ts
@@ -17,7 +17,8 @@
 
 import { HydroponicToConventionalRatio, IndividualAverageDailyIntake, SeedHalfRange } from "#/constants";
 import { getFactionFromCoordinates } from "#/society/factions";
-import { CropTypes, getEdibleEnergyPerAreaPerDay, type CropType } from "#/utils/agriculture";
+import { CropTypes, getEdibleEnergyPerAreaPerDay } from "#/utils/agriculture";
+import type { CropType } from "#/utils/agriculture";
 import { getDistancesToStellarObjects } from "#/utils/distanceToStellarObject";
 import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
@@ -31,15 +32,16 @@ import {
     km2ToM2,
     kwhPerYearToWatts,
 } from "@cosmos-journeyer/physics";
-import { assertUnreachable, type DeepPartial, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    getCelestialBodyRadius,
-    type CelestialBodyModel,
-    type Orbit,
-    type SpaceStationModel,
-    type StationSectionModel,
-    type StarSystemModel,
-    type Rotation,
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepPartial, DeepReadonly } from "@cosmos-journeyer/typescript";
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type {
+    CelestialBodyModel,
+    Orbit,
+    SpaceStationModel,
+    StationSectionModel,
+    StarSystemModel,
+    Rotation,
 } from "@cosmos-journeyer/universe-model";
 import { normalRandom } from "extended-random";
 

--- a/packages/universe-generation/src/proceduralGenerators/ringsModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/ringsModelGenerator.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type RingsModel } from "@cosmos-journeyer/universe-model";
+import type { RingsModel } from "@cosmos-journeyer/universe-model";
 import { normalRandom, randRange } from "extended-random";
 
 export function generateSeededRingsModel(celestialBodyRadius: number, rng: (step: number) => number): RingsModel {

--- a/packages/universe-generation/src/proceduralGenerators/starSystemModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/starSystemModelGenerator.ts
@@ -21,17 +21,18 @@ import { wheelOfFortune } from "#/utils/random";
 import { Alphabet, ReversedGreekAlphabet } from "#/utils/strings/alphabets";
 import { romanNumeral } from "#/utils/strings/romanNumerals";
 import { generateStarName } from "#/utils/strings/starNameGenerator";
-import { assertUnreachable, isNonEmptyArray, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type StarSystemCoordinates,
-    type AnomalyModel,
-    type AnomalyType,
-    type OrbitalFacilityModel,
-    type PlanetModel,
-    type StellarObjectModel,
-    type TelluricSatelliteModel,
-    type StarSystemModel,
-    createOrbitalObjectId,
+import { assertUnreachable, isNonEmptyArray } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import { createOrbitalObjectId } from "@cosmos-journeyer/universe-model";
+import type {
+    StarSystemCoordinates,
+    AnomalyModel,
+    AnomalyType,
+    OrbitalFacilityModel,
+    PlanetModel,
+    StellarObjectModel,
+    TelluricSatelliteModel,
+    StarSystemModel,
 } from "@cosmos-journeyer/universe-model";
 import { centeredRand, randRangeInt, uniformRandBool } from "extended-random";
 

--- a/packages/universe-generation/src/proceduralGenerators/stellarObjects/blackHoleModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/stellarObjects/blackHoleModelGenerator.ts
@@ -19,13 +19,8 @@ import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { getMassFromSchwarzschildRadius } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    getCelestialBodyRadius,
-    type CelestialBodyModel,
-    type Orbit,
-    type BlackHoleModel,
-    type Rotation,
-} from "@cosmos-journeyer/universe-model";
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type { CelestialBodyModel, Orbit, BlackHoleModel, Rotation } from "@cosmos-journeyer/universe-model";
 import { normalRandom } from "extended-random";
 
 export function generateBlackHoleModel(

--- a/packages/universe-generation/src/proceduralGenerators/stellarObjects/neutronStarModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/stellarObjects/neutronStarModelGenerator.ts
@@ -19,13 +19,8 @@ import { generateSeededRingsModel } from "#/proceduralGenerators/ringsModelGener
 import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { clamp } from "#/utils/math";
-import { type DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type OrbitalObjectModel,
-    type Orbit,
-    type NeutronStarModel,
-    type Rotation,
-} from "@cosmos-journeyer/universe-model";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { OrbitalObjectModel, Orbit, NeutronStarModel, Rotation } from "@cosmos-journeyer/universe-model";
 import { normalRandom, randRange, randRangeInt, uniformRandBool } from "extended-random";
 
 /**

--- a/packages/universe-generation/src/proceduralGenerators/stellarObjects/starModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/stellarObjects/starModelGenerator.ts
@@ -19,9 +19,11 @@ import { generateSeededRingsModel } from "#/proceduralGenerators/ringsModelGener
 import { GenerationSteps } from "#/utils/generationSteps";
 import { getRngFromSeed } from "#/utils/getRngFromSeed";
 import { wheelOfFortune } from "#/utils/random";
-import { SolarRadius, type StellarType } from "@cosmos-journeyer/physics";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
-import { type OrbitalObjectModel, type Orbit, type StarModel, type Rotation } from "@cosmos-journeyer/universe-model";
+import { SolarRadius } from "@cosmos-journeyer/physics";
+import type { StellarType } from "@cosmos-journeyer/physics";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
+import type { OrbitalObjectModel, Orbit, StarModel, Rotation } from "@cosmos-journeyer/universe-model";
 import { randRange, randRangeInt, uniformRandBool } from "extended-random";
 
 export function generateStarModel(

--- a/packages/universe-generation/src/proceduralGenerators/telluricPlanetModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/telluricPlanetModelGenerator.ts
@@ -28,16 +28,16 @@ import {
     hasLiquidWater,
 } from "@cosmos-journeyer/physics";
 import type { DeepPartial, DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    getCelestialBodyRadius,
-    type AtmosphereModel,
-    type CloudsModel,
-    type OceanModel,
-    type Orbit,
-    type RingsModel,
-    type Rotation,
-    type StellarObjectModel,
-    type TelluricPlanetModel,
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type {
+    AtmosphereModel,
+    CloudsModel,
+    OceanModel,
+    Orbit,
+    RingsModel,
+    Rotation,
+    StellarObjectModel,
+    TelluricPlanetModel,
 } from "@cosmos-journeyer/universe-model";
 import { normalRandom, uniformRandBool } from "extended-random";
 

--- a/packages/universe-generation/src/proceduralGenerators/telluricSatelliteModelGenerator.ts
+++ b/packages/universe-generation/src/proceduralGenerators/telluricSatelliteModelGenerator.ts
@@ -30,16 +30,16 @@ import {
     MoonMass,
 } from "@cosmos-journeyer/physics";
 import type { DeepReadonly, NonEmptyArray } from "@cosmos-journeyer/typescript";
-import {
-    getCelestialBodyRadius,
-    type AtmosphereModel,
-    type CloudsModel,
-    type PlanetModel,
-    type StellarObjectModel,
-    type OceanModel,
-    type Orbit,
-    type TelluricSatelliteModel,
-    type Rotation,
+import { getCelestialBodyRadius } from "@cosmos-journeyer/universe-model";
+import type {
+    AtmosphereModel,
+    CloudsModel,
+    PlanetModel,
+    StellarObjectModel,
+    OceanModel,
+    Orbit,
+    TelluricSatelliteModel,
+    Rotation,
 } from "@cosmos-journeyer/universe-model";
 import { normalRandom } from "extended-random";
 

--- a/packages/universe-generation/src/society/factions.ts
+++ b/packages/universe-generation/src/society/factions.ts
@@ -1,4 +1,5 @@
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import type { Faction, StarSystemCoordinates } from "@cosmos-journeyer/universe-model";
 import { uniformRandBool } from "extended-random";
 

--- a/packages/universe-generation/src/utils/agriculture.ts
+++ b/packages/universe-generation/src/utils/agriculture.ts
@@ -1,6 +1,6 @@
 import { perHaToPerM2 } from "@cosmos-journeyer/physics";
 import { assertUnreachable } from "@cosmos-journeyer/typescript";
-import { type CropType } from "@cosmos-journeyer/universe-model";
+import type { CropType } from "@cosmos-journeyer/universe-model";
 
 export type { CropType };
 

--- a/packages/universe-generation/src/utils/distanceToStellarObject.spec.ts
+++ b/packages/universe-generation/src/utils/distanceToStellarObject.spec.ts
@@ -18,7 +18,8 @@
 import { ScaledEarthRadius } from "#/constants";
 import { astronomicalUnitToMeters, EarthMass, SolarMass, SolarRadius } from "@cosmos-journeyer/physics";
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import { getObjectModelById, type StarSystemModel } from "@cosmos-journeyer/universe-model";
+import { getObjectModelById } from "@cosmos-journeyer/universe-model";
+import type { StarSystemModel } from "@cosmos-journeyer/universe-model";
 import { describe, expect, it } from "vitest";
 
 import { getDistancesToStellarObjects } from "./distanceToStellarObject";

--- a/packages/universe-generation/src/utils/distanceToStellarObject.ts
+++ b/packages/universe-generation/src/utils/distanceToStellarObject.ts
@@ -16,12 +16,8 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
-import {
-    type OrbitalObjectModel,
-    type StellarObjectModel,
-    getObjectModelById,
-    type StarSystemModel,
-} from "@cosmos-journeyer/universe-model";
+import { getObjectModelById } from "@cosmos-journeyer/universe-model";
+import type { OrbitalObjectModel, StellarObjectModel, StarSystemModel } from "@cosmos-journeyer/universe-model";
 
 export function getDistancesToStellarObjects(
     object: DeepReadonly<OrbitalObjectModel>,

--- a/packages/universe-model/src/orbitalObjects/anomalies/darkKnightModel.ts
+++ b/packages/universe-model/src/orbitalObjects/anomalies/darkKnightModel.ts
@@ -15,6 +15,6 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
 
 export type DarkKnightModel = OrbitalObjectModelBase<"darkKnight">;

--- a/packages/universe-model/src/orbitalObjects/anomalies/juliaSetModel.ts
+++ b/packages/universe-model/src/orbitalObjects/anomalies/juliaSetModel.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { RGBColor } from "../../common";
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
 
 export type JuliaSetModel = OrbitalObjectModelBase<"juliaSet"> & {
     radius: number;

--- a/packages/universe-model/src/orbitalObjects/anomalies/mandelboxModel.ts
+++ b/packages/universe-model/src/orbitalObjects/anomalies/mandelboxModel.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { RGBColor } from "../../common";
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
 
 export type MandelboxModel = OrbitalObjectModelBase<"mandelbox"> & {
     radius: number;

--- a/packages/universe-model/src/orbitalObjects/anomalies/mandelbulbModel.ts
+++ b/packages/universe-model/src/orbitalObjects/anomalies/mandelbulbModel.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { RGBColor } from "../../common";
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
 
 export type MandelbulbModel = OrbitalObjectModelBase<"mandelbulb"> & {
     radius: number;

--- a/packages/universe-model/src/orbitalObjects/anomalies/mengerSpongeModel.ts
+++ b/packages/universe-model/src/orbitalObjects/anomalies/mengerSpongeModel.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { RGBColor } from "../../common";
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
 
 export type MengerSpongeModel = OrbitalObjectModelBase<"mengerSponge"> & {
     radius: number;

--- a/packages/universe-model/src/orbitalObjects/anomalies/sierpinskiPyramidModel.ts
+++ b/packages/universe-model/src/orbitalObjects/anomalies/sierpinskiPyramidModel.ts
@@ -16,7 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { RGBColor } from "../../common";
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
 
 export type SierpinskiPyramidModel = OrbitalObjectModelBase<"sierpinskiPyramid"> & {
     radius: number;

--- a/packages/universe-model/src/orbitalObjects/gasPlanetModel.ts
+++ b/packages/universe-model/src/orbitalObjects/gasPlanetModel.ts
@@ -15,11 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type RGBColor } from "../common";
-import { type AtmosphereModel } from "./atmosphereModel";
-import { type HasSeed } from "./hasSeed";
-import { type OrbitalObjectModelBase } from "./orbitalObjectModelBase";
-import { type RingsModel } from "./ringsModel";
+import type { RGBColor } from "../common";
+import type { AtmosphereModel } from "./atmosphereModel";
+import type { HasSeed } from "./hasSeed";
+import type { OrbitalObjectModelBase } from "./orbitalObjectModelBase";
+import type { RingsModel } from "./ringsModel";
 
 export type GasPlanetProceduralColorPalette = {
     type: "procedural";

--- a/packages/universe-model/src/orbitalObjects/getCelestialBodyRadius.ts
+++ b/packages/universe-model/src/orbitalObjects/getCelestialBodyRadius.ts
@@ -16,9 +16,10 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getSchwarzschildRadius } from "@cosmos-journeyer/physics";
-import { assertUnreachable, type DeepReadonly } from "@cosmos-journeyer/typescript";
+import { assertUnreachable } from "@cosmos-journeyer/typescript";
+import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 
-import { type CelestialBodyModel } from "./index";
+import type { CelestialBodyModel } from "./index";
 
 export function getCelestialBodyRadius(body: DeepReadonly<CelestialBodyModel>): number {
     switch (body.type) {

--- a/packages/universe-model/src/orbitalObjects/index.ts
+++ b/packages/universe-model/src/orbitalObjects/index.ts
@@ -15,21 +15,21 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type DarkKnightModel } from "./anomalies/darkKnightModel";
-import { type JuliaSetModel } from "./anomalies/juliaSetModel";
-import { type MandelboxModel } from "./anomalies/mandelboxModel";
-import { type MandelbulbModel } from "./anomalies/mandelbulbModel";
-import { type MengerSpongeModel } from "./anomalies/mengerSpongeModel";
-import { type SierpinskiPyramidModel } from "./anomalies/sierpinskiPyramidModel";
-import { type GasPlanetModel } from "./gasPlanetModel";
-import { type SpaceElevatorModel } from "./orbitalFacilities/spaceElevatorModel";
-import { type SpaceStationModel } from "./orbitalFacilities/spacestationModel";
-import { type OrbitalObjectModelBase } from "./orbitalObjectModelBase";
-import { type BlackHoleModel } from "./stellarObjects/blackHoleModel";
-import { type NeutronStarModel } from "./stellarObjects/neutronStarModel";
-import { type StarModel } from "./stellarObjects/starModel";
-import { type TelluricPlanetModel } from "./telluricPlanetModel";
-import { type TelluricSatelliteModel } from "./telluricSatelliteModel";
+import type { DarkKnightModel } from "./anomalies/darkKnightModel";
+import type { JuliaSetModel } from "./anomalies/juliaSetModel";
+import type { MandelboxModel } from "./anomalies/mandelboxModel";
+import type { MandelbulbModel } from "./anomalies/mandelbulbModel";
+import type { MengerSpongeModel } from "./anomalies/mengerSpongeModel";
+import type { SierpinskiPyramidModel } from "./anomalies/sierpinskiPyramidModel";
+import type { GasPlanetModel } from "./gasPlanetModel";
+import type { SpaceElevatorModel } from "./orbitalFacilities/spaceElevatorModel";
+import type { SpaceStationModel } from "./orbitalFacilities/spacestationModel";
+import type { OrbitalObjectModelBase } from "./orbitalObjectModelBase";
+import type { BlackHoleModel } from "./stellarObjects/blackHoleModel";
+import type { NeutronStarModel } from "./stellarObjects/neutronStarModel";
+import type { StarModel } from "./stellarObjects/starModel";
+import type { TelluricPlanetModel } from "./telluricPlanetModel";
+import type { TelluricSatelliteModel } from "./telluricSatelliteModel";
 
 export type StellarObjectModel = StarModel | NeutronStarModel | BlackHoleModel;
 

--- a/packages/universe-model/src/orbitalObjects/orbitalFacilities/orbitalFacilityModelBase.ts
+++ b/packages/universe-model/src/orbitalObjects/orbitalFacilities/orbitalFacilityModelBase.ts
@@ -15,10 +15,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type OrbitalObjectType } from "..";
-import { type CropType, type Faction } from "../../common";
-import { type StarSystemCoordinates } from "../../starSystemCoordinates";
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { OrbitalObjectType } from "..";
+import type { CropType, Faction } from "../../common";
+import type { StarSystemCoordinates } from "../../starSystemCoordinates";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
 
 export type OrbitalFacilityModelBase<T extends OrbitalObjectType> = OrbitalObjectModelBase<T> & {
     starSystemCoordinates: StarSystemCoordinates;

--- a/packages/universe-model/src/orbitalObjects/orbitalFacilities/spaceElevatorModel.ts
+++ b/packages/universe-model/src/orbitalObjects/orbitalFacilities/spaceElevatorModel.ts
@@ -15,8 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type HasSeed } from "../hasSeed";
-import { type OrbitalFacilityModelBase } from "./orbitalFacilityModelBase";
+import type { HasSeed } from "../hasSeed";
+import type { OrbitalFacilityModelBase } from "./orbitalFacilityModelBase";
 import type { ElevatorSectionModel } from "./sections";
 
 export type SpaceElevatorModel = OrbitalFacilityModelBase<"spaceElevator"> &

--- a/packages/universe-model/src/orbitalObjects/orbitalFacilities/spacestationModel.ts
+++ b/packages/universe-model/src/orbitalObjects/orbitalFacilities/spacestationModel.ts
@@ -15,8 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type HasSeed } from "../hasSeed";
-import { type OrbitalFacilityModelBase } from "./orbitalFacilityModelBase";
+import type { HasSeed } from "../hasSeed";
+import type { OrbitalFacilityModelBase } from "./orbitalFacilityModelBase";
 import type { StationSectionModel } from "./sections";
 
 export type SpaceStationModel = OrbitalFacilityModelBase<"spaceStation"> &

--- a/packages/universe-model/src/orbitalObjects/orbitalObjectId.ts
+++ b/packages/universe-model/src/orbitalObjects/orbitalObjectId.ts
@@ -17,7 +17,7 @@
 
 import { z } from "zod";
 
-import { type OrbitalObjectType } from "./index";
+import type { OrbitalObjectType } from "./index";
 
 export const OrbitalObjectIdSchema = z.string();
 

--- a/packages/universe-model/src/orbitalObjects/orbitalObjectModelBase.ts
+++ b/packages/universe-model/src/orbitalObjects/orbitalObjectModelBase.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type OrbitalObjectType } from "./index";
-import { type Orbit } from "./orbit";
-import { type OrbitalObjectId } from "./orbitalObjectId";
+import type { OrbitalObjectType } from "./index";
+import type { Orbit } from "./orbit";
+import type { OrbitalObjectId } from "./orbitalObjectId";
 import type { Rotation } from "./rotation";
 
 /**

--- a/packages/universe-model/src/orbitalObjects/ringsModel.ts
+++ b/packages/universe-model/src/orbitalObjects/ringsModel.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type RGBColor } from "../common";
+import type { RGBColor } from "../common";
 
 type RingsModelBase = {
     /**

--- a/packages/universe-model/src/orbitalObjects/stellarObjects/blackHoleModel.ts
+++ b/packages/universe-model/src/orbitalObjects/stellarObjects/blackHoleModel.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
 
 export type BlackHoleModel = OrbitalObjectModelBase<"blackHole"> & {
     /**

--- a/packages/universe-model/src/orbitalObjects/stellarObjects/neutronStarModel.ts
+++ b/packages/universe-model/src/orbitalObjects/stellarObjects/neutronStarModel.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type HasSeed } from "../hasSeed";
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
-import { type RingsModel } from "../ringsModel";
+import type { HasSeed } from "../hasSeed";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { RingsModel } from "../ringsModel";
 
 export type NeutronStarModel = OrbitalObjectModelBase<"neutronStar"> &
     HasSeed & {

--- a/packages/universe-model/src/orbitalObjects/stellarObjects/starModel.ts
+++ b/packages/universe-model/src/orbitalObjects/stellarObjects/starModel.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type HasSeed } from "../hasSeed";
-import { type OrbitalObjectModelBase } from "../orbitalObjectModelBase";
-import { type RingsModel } from "../ringsModel";
+import type { HasSeed } from "../hasSeed";
+import type { OrbitalObjectModelBase } from "../orbitalObjectModelBase";
+import type { RingsModel } from "../ringsModel";
 
 export type StarModel = OrbitalObjectModelBase<"star"> &
     HasSeed & {

--- a/packages/universe-model/src/orbitalObjects/telluricPlanetModel.ts
+++ b/packages/universe-model/src/orbitalObjects/telluricPlanetModel.ts
@@ -15,9 +15,9 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type HasSeed } from "./hasSeed";
-import { type RingsModel } from "./ringsModel";
-import { type TelluricPlanetaryMassObjectModelBase } from "./telluricPlanetaryMassObjectModel";
+import type { HasSeed } from "./hasSeed";
+import type { RingsModel } from "./ringsModel";
+import type { TelluricPlanetaryMassObjectModelBase } from "./telluricPlanetaryMassObjectModel";
 
 export type TelluricPlanetModel = TelluricPlanetaryMassObjectModelBase<"telluricPlanet"> &
     HasSeed & {

--- a/packages/universe-model/src/orbitalObjects/telluricPlanetaryMassObjectModel.ts
+++ b/packages/universe-model/src/orbitalObjects/telluricPlanetaryMassObjectModel.ts
@@ -15,12 +15,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type AtmosphereModel } from "./atmosphereModel";
-import { type CloudsModel } from "./cloudsModel";
-import { type OrbitalObjectType } from "./index";
-import { type OceanModel } from "./oceanModel";
+import type { AtmosphereModel } from "./atmosphereModel";
+import type { CloudsModel } from "./cloudsModel";
+import type { OrbitalObjectType } from "./index";
+import type { OceanModel } from "./oceanModel";
 import type { OrbitalObjectModelBase } from "./orbitalObjectModelBase";
-import { type TerrainSettings } from "./terrainSettings";
+import type { TerrainSettings } from "./terrainSettings";
 
 type Elements = "rock" | "h2o";
 

--- a/packages/universe-model/src/orbitalObjects/telluricSatelliteModel.ts
+++ b/packages/universe-model/src/orbitalObjects/telluricSatelliteModel.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type HasSeed } from "./hasSeed";
-import { type TelluricPlanetaryMassObjectModelBase } from "./telluricPlanetaryMassObjectModel";
+import type { HasSeed } from "./hasSeed";
+import type { TelluricPlanetaryMassObjectModelBase } from "./telluricPlanetaryMassObjectModel";
 
 export type TelluricSatelliteModel = TelluricPlanetaryMassObjectModelBase<"telluricSatellite"> & HasSeed;

--- a/packages/universe-model/src/starSystemModel.ts
+++ b/packages/universe-model/src/starSystemModel.ts
@@ -17,16 +17,16 @@
 
 import type { DeepReadonly, NonEmptyArray } from "@cosmos-journeyer/typescript";
 
-import {
-    type AnomalyModel,
-    type OrbitalFacilityModel,
-    type OrbitalObjectModel,
-    type PlanetModel,
-    type StellarObjectModel,
+import type {
+    AnomalyModel,
+    OrbitalFacilityModel,
+    OrbitalObjectModel,
+    PlanetModel,
+    StellarObjectModel,
 } from "./orbitalObjects/index";
-import { type OrbitalObjectId } from "./orbitalObjects/orbitalObjectId";
-import { type TelluricSatelliteModel } from "./orbitalObjects/telluricSatelliteModel";
-import { type StarSystemCoordinates } from "./starSystemCoordinates";
+import type { OrbitalObjectId } from "./orbitalObjects/orbitalObjectId";
+import type { TelluricSatelliteModel } from "./orbitalObjects/telluricSatelliteModel";
+import type { StarSystemCoordinates } from "./starSystemCoordinates";
 
 /**
  * Data model for a star system. It holds all the information necessary to generate and render a star system.

--- a/packages/universe-model/src/universeObjectId.ts
+++ b/packages/universe-model/src/universeObjectId.ts
@@ -18,14 +18,14 @@
 import type { DeepReadonly } from "@cosmos-journeyer/typescript";
 import { z } from "zod";
 
-import { type OrbitalObjectModel } from "./orbitalObjects/index";
+import type { OrbitalObjectModel } from "./orbitalObjects/index";
 import { orbitalObjectIdEquals, OrbitalObjectIdSchema } from "./orbitalObjects/orbitalObjectId";
 import {
     serializeStarSystemCoordinates,
     starSystemCoordinatesEquals,
     StarSystemCoordinatesSchema,
 } from "./starSystemCoordinates";
-import { type StarSystemModel } from "./starSystemModel";
+import type { StarSystemModel } from "./starSystemModel";
 
 export const UniverseObjectIdSchema = z.object({
     idInSystem: OrbitalObjectIdSchema,

--- a/packages/website/src/app/ViewCommunity.tsx
+++ b/packages/website/src/app/ViewCommunity.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 
-import { FAQ, type FAQItem } from "@/components/FAQ";
+import { FAQ } from "@/components/FAQ";
+import type { FAQItem } from "@/components/FAQ";
 import { siteConfig } from "@/siteConfig";
 
 const featuredCommunityLinks = [


### PR DESCRIPTION
## What does this do?

Reduces terrain worker startup cost by removing accidental runtime dependencies from the worker bundle and restoring concurrent worker creation.

- Moves shared terrain constants out of the rendering module.
- Removes the Babylon dependency from settings.
- Enforces top-level type-only imports across the TypeScript workspace and migrates existing imports in one dedicated commit.
- Initializes terrain workers concurrently with Promise.all.

The production terrain worker is reduced from 583,729 bytes to 84,866 bytes, an 85.5 percent reduction.

## How to test?

- Run pnpm build.
- Run pnpm typecheck.
- Run pnpm test:unit.
- Run pnpm lint.
- Start the game and verify terrain workers initialize normally.

Verification completed:

- Full workspace production build passed.
- Full workspace typecheck passed.
- Full workspace unit tests passed.
- Full workspace lint passed with zero errors and pre-existing warnings.
- A focused production build after removing the BSL metadata change still emitted an 84,866-byte terrain worker.

## Interesting findings / surprises / setbacks

With verbatimModuleSyntax enabled, inline-only imports such as import { type Value } can be emitted as an empty runtime import. The terrain worker protocol imported a type from scatteringSystem, which caused Vite to retain and evaluate its Babylon rendering dependency graph.

Babylon NodeMaterial block modules perform runtime class registration. This PR deliberately does not mark babylonjs-shading-language as side-effect-free because its current imports preserve that Babylon behavior.

## AI Usage

### Tooling and model

Codex using GPT-5.

### Usage

Root-cause investigation, bundle dependency tracing, implementation, workspace-wide type-import migration, history restructuring, and verification.

## What's next?

Monitor terrain initialization timing in representative browsers and hardware configurations.