### PR TITLE
refactor(game): centralize clustered lighting

### DIFF
--- a/packages/game/src/ts/frontend/helpers/clusteredLightingSystem.spec.ts
+++ b/packages/game/src/ts/frontend/helpers/clusteredLightingSystem.spec.ts
@@ -1,0 +1,146 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { NullEngine } from "@babylonjs/core/Engines/nullEngine";
+import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
+import type { Light } from "@babylonjs/core/Lights/light";
+import { PointLight } from "@babylonjs/core/Lights/pointLight";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import { Scene } from "@babylonjs/core/scene";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ClusteredLightingRegion } from "@/frontend/universe/architecture/clusteredLightingRegion";
+
+import { ClusteredLightingSystem } from "./clusteredLightingSystem";
+
+describe("ClusteredLightingSystem", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let system: ClusteredLightingSystem | null;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        engine._webGLVersion = 2;
+        const caps = engine.getCaps();
+        caps.texelFetch = true;
+        caps.colorBufferFloat = true;
+        caps.blendFloat = true;
+
+        scene = new Scene(engine);
+        system = new ClusteredLightingSystem(scene);
+    });
+
+    afterEach(() => {
+        system?.dispose();
+        scene.dispose();
+        engine.dispose();
+    });
+
+    const getContainer = (): ClusteredLightContainer => {
+        const container = scene.lights.find((light) => light instanceof ClusteredLightContainer);
+        if (container === undefined) {
+            throw new Error("Global clustered light container not found");
+        }
+        return container;
+    };
+
+    const createRegion = (name: string, lights: ReadonlyArray<Light>): ClusteredLightingRegion => {
+        const transform = new TransformNode(`${name}Transform`, scene);
+        return {
+            getTransform: () => transform,
+            getBoundingRadius: () => 1,
+            getLights: () => lights,
+        };
+    };
+
+    const createLight = (name: string): PointLight => {
+        const light = new PointLight(name, Vector3.Zero(), scene, true);
+        light.setEnabled(false);
+        return light;
+    };
+
+    it("registers every light and enables it", () => {
+        const lights = [createLight("first"), createLight("second")];
+        const region = createRegion("station", lights);
+
+        system?.registerRegion(region);
+
+        expect(getContainer().lights).toEqual(lights);
+        expect(lights.every((light) => light.isEnabled())).toBe(true);
+    });
+
+    it("does not register a region twice", () => {
+        const light = createLight("light");
+        const region = createRegion("station", [light]);
+
+        system?.registerRegion(region);
+        system?.registerRegion(region);
+
+        expect(getContainer().lights).toEqual([light]);
+    });
+
+    it("unregisters every light, disables it, and ignores repeated unregisters", () => {
+        const lights = [createLight("first"), createLight("second")];
+        const region = createRegion("station", lights);
+        system?.registerRegion(region);
+
+        system?.unregisterRegion(region);
+        system?.unregisterRegion(region);
+
+        expect(getContainer().lights).toEqual([]);
+        expect(lights.every((light) => !light.isEnabled())).toBe(true);
+    });
+
+    it("can register a region again after unregistering it", () => {
+        const light = createLight("light");
+        const region = createRegion("station", [light]);
+
+        system?.registerRegion(region);
+        system?.unregisterRegion(region);
+        system?.registerRegion(region);
+
+        expect(getContainer().lights).toEqual([light]);
+        expect(light.isEnabled()).toBe(true);
+    });
+
+    it("keeps producer-owned lights alive when disposed", () => {
+        const light = createLight("light");
+        const region = createRegion("station", [light]);
+        system?.registerRegion(region);
+
+        system?.dispose();
+        system = null;
+
+        expect(light.isDisposed()).toBe(false);
+        expect(light.isEnabled()).toBe(false);
+        expect(scene.lights).toContain(light);
+        expect(scene.lights.some((sceneLight) => sceneLight instanceof ClusteredLightContainer)).toBe(false);
+    });
+
+    it("shares one container between station and spaceship regions", () => {
+        const stationLight = createLight("stationLight");
+        const spaceshipLight = createLight("spaceshipLight");
+
+        system?.registerRegion(createRegion("station", [stationLight]));
+        system?.registerRegion(createRegion("spaceship", [spaceshipLight]));
+
+        const containers = scene.lights.filter((light) => light instanceof ClusteredLightContainer);
+        expect(containers).toHaveLength(1);
+        expect(containers[0]?.lights).toEqual([stationLight, spaceshipLight]);
+    });
+});

--- a/packages/game/src/ts/frontend/helpers/clusteredLightingSystem.ts
+++ b/packages/game/src/ts/frontend/helpers/clusteredLightingSystem.ts
@@ -1,0 +1,71 @@
+//  This file is part of Cosmos Journeyer
+//
+//  Copyright (C) 2024 Barthélemy Paléologue <barth.paleologue@cosmosjourneyer.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
+import type { Light } from "@babylonjs/core/Lights/light";
+import type { Scene } from "@babylonjs/core/scene";
+
+import type { ClusteredLightingRegion } from "@/frontend/universe/architecture/clusteredLightingRegion";
+
+export class ClusteredLightingSystem {
+    private readonly container: ClusteredLightContainer;
+
+    private readonly regions = new Set<ClusteredLightingRegion>();
+
+    public constructor(scene: Scene) {
+        this.container = new ClusteredLightContainer("globalClusteredLights", [], scene);
+    }
+
+    public registerRegion(region: ClusteredLightingRegion): void {
+        if (this.regions.has(region)) {
+            return;
+        }
+
+        this.regions.add(region);
+        for (const light of region.getLights()) {
+            this.activateLight(light);
+        }
+    }
+
+    public unregisterRegion(region: ClusteredLightingRegion): void {
+        if (!this.regions.delete(region)) {
+            return;
+        }
+
+        for (const light of region.getLights()) {
+            this.deactivateLight(light);
+        }
+    }
+
+    public dispose(): void {
+        for (const region of [...this.regions]) {
+            this.unregisterRegion(region);
+        }
+
+        this.container.dispose();
+    }
+
+    private activateLight(light: Light): void {
+        this.container.addLight(light);
+        light.setEnabled(true);
+    }
+
+    private deactivateLight(light: Light): void {
+        light.setEnabled(false);
+        this.container.removeLight(light);
+    }
+}

--- a/packages/game/src/ts/frontend/spaceship/spaceship.ts
+++ b/packages/game/src/ts/frontend/spaceship/spaceship.ts
@@ -15,7 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
+import type { Light } from "@babylonjs/core/Lights/light";
 import { Quaternion } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { AbstractMesh, TransformNode } from "@babylonjs/core/Meshes";
@@ -39,6 +39,7 @@ import { AudioMasks } from "@/frontend/audio/audioMasks";
 import type { ISoundInstance } from "@/frontend/audio/soundInstance";
 import type { ISoundPlayer } from "@/frontend/audio/soundPlayer";
 import { translate } from "@/frontend/helpers/transform";
+import type { ClusteredLightingRegion } from "@/frontend/universe/architecture/clusteredLightingRegion";
 import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
 import type { CelestialBody, OrbitalObject } from "@/frontend/universe/architecture/orbitalObject";
 import type { Transformable } from "@/frontend/universe/architecture/transformable";
@@ -68,7 +69,7 @@ type SoundInstances = {
     thruster: ISoundInstance;
 };
 
-export class Spaceship implements Transformable, Targetable {
+export class Spaceship implements Transformable, Targetable, ClusteredLightingRegion {
     readonly shipType: ShipType;
 
     readonly id: string;
@@ -139,8 +140,6 @@ export class Spaceship implements Transformable, Targetable {
     readonly onAutoPilotEngaged = new Observable<void>();
 
     readonly boundingExtent: Vector3;
-
-    readonly lightContainer: ClusteredLightContainer;
 
     public static async New(
         serializedSpaceShip: DeepReadonly<SerializedSpaceship>,
@@ -238,12 +237,9 @@ export class Spaceship implements Transformable, Targetable {
         this.aggregate.body.setCollisionCallbackEnabled(true);
         this.collisionObservable = this.aggregate.body.getCollisionObservable();
 
-        this.lightContainer = new ClusteredLightContainer("spaceshipLightContainer", [], scene);
-
         for (const child of this.frame.getChildMeshes()) {
             if (child.name.includes("mainThruster")) {
                 const mainThruster = new Thruster(child, this.frame.forward.negate(), this.aggregate);
-                this.lightContainer.addLight(mainThruster.light);
                 this.mainThrusters.push(mainThruster);
                 continue;
             }
@@ -301,6 +297,10 @@ export class Spaceship implements Transformable, Targetable {
 
     public getBoundingRadius(): number {
         return this.boundingExtent.length() / 2;
+    }
+
+    public getLights(): ReadonlyArray<Light> {
+        return this.mainThrusters.map((thruster) => thruster.light);
     }
 
     public getTypeName(): string {
@@ -947,8 +947,6 @@ export class Spaceship implements Transformable, Targetable {
             thruster.dispose();
         });
         this.mainThrusters.length = 0;
-        this.lightContainer.dispose();
-
         this.spaceDots.dispose();
         this.hyperSpaceTunnel.dispose();
         this.aggregate.dispose();

--- a/packages/game/src/ts/frontend/starSystemView.spec.ts
+++ b/packages/game/src/ts/frontend/starSystemView.spec.ts
@@ -22,6 +22,7 @@ import { UniverseBackend } from "@/backend/universe/universeBackend";
 
 import { Player } from "@/frontend/player/player";
 import { Spaceship } from "@/frontend/spaceship/spaceship";
+import { StarSystemController } from "@/frontend/universe/starSystemController";
 
 import { StarSystemView } from "./starSystemView";
 
@@ -56,9 +57,14 @@ describe("StarSystemView", () => {
             reset: vi.fn(),
             setSpaceship: vi.fn(),
         };
+        const clusteredLightingSystem = {
+            registerRegion: vi.fn(),
+            unregisterRegion: vi.fn(),
+        };
         const context = {
             assets: {},
             characterControls: {},
+            clusteredLightingSystem,
             defaultControls: { getCameras: () => [] },
             interactionSystem: { register: vi.fn() },
             physicsEngine: {},
@@ -87,6 +93,8 @@ describe("StarSystemView", () => {
         expect(player.instancedSpaceships).toEqual([spaceship]);
         expect(nextPlayer.serializedSpaceships).toEqual([nextSpaceshipSerialized]);
         expect(spaceshipControls.setSpaceship).toHaveBeenCalledWith(spaceship);
+        expect(clusteredLightingSystem.unregisterRegion).toHaveBeenCalledWith(oldSpaceship);
+        expect(clusteredLightingSystem.registerRegion).toHaveBeenCalledWith(spaceship);
         expect(oldSpaceship.dispose).toHaveBeenCalled();
     });
 
@@ -128,5 +136,48 @@ describe("StarSystemView", () => {
         expect(player.serializedSpaceships).toEqual([currentSpaceshipSerialized]);
         expect(player.instancedSpaceships).toEqual([]);
         expect(nextPlayer.serializedSpaceships).toEqual([nextSpaceshipSerialized]);
+    });
+
+    it("rewires facility lights before disposing the previous star system", async () => {
+        const oldFacility = {};
+        const newFacility = {};
+        const oldStarSystem = {
+            dispose: vi.fn(),
+            getOrbitalFacilities: (): ReadonlyArray<object> => [oldFacility],
+        };
+        const newStarSystem = {
+            getOrbitalFacilities: () => [newFacility],
+            stellarLightSystem: { addShadowCaster: vi.fn() },
+        } as unknown as StarSystemController;
+        vi.spyOn(StarSystemController, "CreateAsync").mockResolvedValue(newStarSystem);
+
+        const clusteredLightingSystem = {
+            registerRegion: vi.fn(),
+            unregisterRegion: vi.fn(),
+        };
+        const context = {
+            _isLoadingSystem: false,
+            assets: {},
+            characterControls: null,
+            clusteredLightingSystem,
+            loader: {},
+            postProcessManager: { reset: vi.fn() },
+            progressMonitor: {},
+            scene: {},
+            spaceStationLayer: { reset: vi.fn() },
+            spaceshipControls: null,
+            starSystem: oldStarSystem,
+            targetCursorLayer: { reset: vi.fn() },
+            terrainSystem: { reset: vi.fn() },
+        } as unknown as StarSystemView;
+
+        await StarSystemView.prototype.loadStarSystem.call(context, {} as never);
+
+        expect(clusteredLightingSystem.unregisterRegion).toHaveBeenCalledWith(oldFacility);
+        expect(oldStarSystem.dispose).toHaveBeenCalledOnce();
+        expect(clusteredLightingSystem.registerRegion).toHaveBeenCalledWith(newFacility);
+        expect(clusteredLightingSystem.unregisterRegion.mock.invocationCallOrder[0]).toBeLessThan(
+            oldStarSystem.dispose.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+        );
     });
 });

--- a/packages/game/src/ts/frontend/starSystemView.ts
+++ b/packages/game/src/ts/frontend/starSystemView.ts
@@ -46,6 +46,7 @@ import { CharacterInputs } from "@/frontend/controls/characterControls/character
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
 import { DefaultControlsInputs } from "@/frontend/controls/defaultControls/defaultControlsInputs";
 import { wrapVector3 } from "@/frontend/helpers/algebra";
+import { ClusteredLightingSystem } from "@/frontend/helpers/clusteredLightingSystem";
 import { getNeighborStarSystemCoordinates } from "@/frontend/helpers/getNeighborStarSystems";
 import { axisCompositeToString, dPadCompositeToString } from "@/frontend/helpers/inputControlsString";
 import { positionNearObjectBrightSide } from "@/frontend/helpers/positionNearObject";
@@ -236,6 +237,8 @@ export class StarSystemView implements View {
 
     private readonly depthRendererManager: DepthRendererManager;
 
+    private readonly clusteredLightingSystem: ClusteredLightingSystem;
+
     /**
      * Creates an empty star system view with a scene, a gui and a physics engine
      * To fill it with a star system, use `loadStarSystem` and then `initStarSystem`
@@ -276,6 +279,7 @@ export class StarSystemView implements View {
         this.scene = scene;
         this.scene.skipPointerMovePicking = true;
         this.scene.autoClear = false;
+        this.clusteredLightingSystem = new ClusteredLightingSystem(this.scene);
 
         this.physicsEngine = physicsEngine;
 
@@ -505,6 +509,9 @@ export class StarSystemView implements View {
             this.spaceshipControls?.setClosestLandableFacility(null);
             this.terrainSystem.reset();
             this.postProcessManager.reset();
+            for (const facility of this.starSystem.getOrbitalFacilities()) {
+                this.clusteredLightingSystem.unregisterRegion(facility);
+            }
             this.starSystem.dispose();
             this.targetCursorLayer.reset();
             this.spaceStationLayer.reset();
@@ -517,6 +524,10 @@ export class StarSystemView implements View {
             this.scene,
             this.progressMonitor,
         );
+
+        for (const facility of this.starSystem.getOrbitalFacilities()) {
+            this.clusteredLightingSystem.registerRegion(facility);
+        }
 
         const shipMesh = this.spaceshipControls?.getSpaceship();
         if (shipMesh !== undefined) {
@@ -756,11 +767,14 @@ export class StarSystemView implements View {
                 this.notificationManager,
             );
             this.spaceshipControls.getCameras().forEach((camera) => (camera.maxZ = maxZ));
+            this.clusteredLightingSystem.registerRegion(spaceship);
         } else {
             const oldSpaceship = this.spaceshipControls.getSpaceship();
+            this.clusteredLightingSystem.unregisterRegion(oldSpaceship);
             this.spaceshipControls.reset();
             this.spaceshipControls.setSpaceship(spaceship);
             oldSpaceship.dispose(this.soundPlayer);
+            this.clusteredLightingSystem.registerRegion(spaceship);
         }
 
         if (this.characterControls === null) {

--- a/packages/game/src/ts/frontend/universe/architecture/clusteredLightingRegion.ts
+++ b/packages/game/src/ts/frontend/universe/architecture/clusteredLightingRegion.ts
@@ -15,15 +15,11 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { OrbitalObjectType } from "@cosmos-journeyer/universe-model";
+import type { Light } from "@babylonjs/core/Lights/light";
 
-import type { Cullable } from "@/frontend/helpers/cullable";
-import type { ClusteredLightingRegion } from "@/frontend/universe/architecture/clusteredLightingRegion";
-import type { OrbitalObjectBase } from "@/frontend/universe/architecture/orbitalObjectBase";
-import type { Targetable } from "@/frontend/universe/architecture/targetable";
-import type { ManagesLandingPads } from "@/frontend/universe/orbitalFacility/managesLandingPads";
+import type { HasBoundingSphere } from "./hasBoundingSphere";
+import type { Transformable } from "./transformable";
 
-export interface OrbitalFacilityBase<T extends OrbitalObjectType>
-    extends OrbitalObjectBase<T>, ManagesLandingPads, Cullable, Targetable, ClusteredLightingRegion {
-    getSubTargets(): ReadonlyArray<Targetable>;
+export interface ClusteredLightingRegion extends Transformable, HasBoundingSphere {
+    getLights(): ReadonlyArray<Light>;
 }

--- a/packages/game/src/ts/frontend/universe/orbitalFacility/spaceElevator.ts
+++ b/packages/game/src/ts/frontend/universe/orbitalFacility/spaceElevator.ts
@@ -16,7 +16,6 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Camera } from "@babylonjs/core/Cameras/camera";
-import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
 import type { Light } from "@babylonjs/core/Lights/light";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
@@ -78,8 +77,6 @@ export class SpaceElevator implements OrbitalFacilityBase<"spaceElevator"> {
     readonly targetInfo: TargetInfo;
 
     private readonly landingPadManager: LandingPadManager;
-
-    private readonly lightContainer: ClusteredLightContainer;
 
     constructor(model: DeepReadonly<SpaceElevatorModel>, assets: RenderingAssets, scene: Scene) {
         this.model = model;
@@ -165,11 +162,9 @@ export class SpaceElevator implements OrbitalFacilityBase<"spaceElevator"> {
             minDistance: this.getBoundingRadius() * 6.0,
             maxDistance: 0.0,
         };
-
-        this.lightContainer = new ClusteredLightContainer("SpaceElevatorLightContainer", this.getLights(), scene);
     }
 
-    getLights(): Array<Light> {
+    getLights(): ReadonlyArray<Light> {
         return this.sections.flatMap((section) => section.getLights());
     }
 
@@ -291,7 +286,5 @@ export class SpaceElevator implements OrbitalFacilityBase<"spaceElevator"> {
         this.climber.dispose();
 
         this.root.dispose();
-
-        this.lightContainer.dispose();
     }
 }

--- a/packages/game/src/ts/frontend/universe/orbitalFacility/spaceStation.ts
+++ b/packages/game/src/ts/frontend/universe/orbitalFacility/spaceStation.ts
@@ -16,7 +16,6 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Camera } from "@babylonjs/core/Cameras/camera";
-import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
 import type { Light } from "@babylonjs/core/Lights/light";
 import { Axis, Space } from "@babylonjs/core/Maths/math.axis";
 import { Quaternion } from "@babylonjs/core/Maths/math.vector";
@@ -66,8 +65,6 @@ export class SpaceStation implements OrbitalFacilityBase<"spaceStation"> {
     readonly targetInfo: TargetInfo;
 
     private readonly landingPadManager: LandingPadManager;
-
-    private readonly lightContainer: ClusteredLightContainer;
 
     constructor(model: DeepReadonly<SpaceStationModel>, assets: RenderingAssets, scene: Scene) {
         this.model = model;
@@ -119,11 +116,9 @@ export class SpaceStation implements OrbitalFacilityBase<"spaceStation"> {
             minDistance: this.getBoundingRadius() * 6.0,
             maxDistance: 0.0,
         };
-
-        this.lightContainer = new ClusteredLightContainer(`${this.name}_lightContainer`, this.getLights(), scene);
     }
 
-    getLights(): Array<Light> {
+    getLights(): ReadonlyArray<Light> {
         return this.sections.flatMap((section) => section.getLights());
     }
 
@@ -210,7 +205,6 @@ export class SpaceStation implements OrbitalFacilityBase<"spaceStation"> {
     }
 
     dispose(): void {
-        this.lightContainer.dispose();
         for (const section of this.sections) {
             section.dispose();
         }

--- a/packages/game/src/ts/playgrounds/automaticLanding.ts
+++ b/packages/game/src/ts/playgrounds/automaticLanding.ts
@@ -34,6 +34,7 @@ import { LandingPad } from "@/frontend/assets/procedural/spaceStation/landingPad
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
+import { ClusteredLightingSystem } from "@/frontend/helpers/clusteredLightingSystem";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { Spaceship } from "@/frontend/spaceship/spaceship";
 import { LandingPadSize } from "@/frontend/universe/orbitalFacility/landingPadManager";
@@ -60,6 +61,8 @@ export async function createAutomaticLandingScene(
     const soundPlayer = new SoundPlayerMock();
 
     const ship = await Spaceship.CreateDefault(scene, assets, soundPlayer, getPhysicsEngineV2(scene));
+    const clusteredLightingSystem = new ClusteredLightingSystem(scene);
+    clusteredLightingSystem.registerRegion(ship);
 
     const initShipTransform = (): void => {
         ship.getTransform().position.copyFromFloats(

--- a/packages/game/src/ts/playgrounds/flightDemo.ts
+++ b/packages/game/src/ts/playgrounds/flightDemo.ts
@@ -25,6 +25,7 @@ import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressM
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";
+import { ClusteredLightingSystem } from "@/frontend/helpers/clusteredLightingSystem";
 import { DepthRendererManager } from "@/frontend/helpers/depthRendererManager";
 import { ShipControls } from "@/frontend/spaceship/shipControls";
 import { SpaceShipControlsInputs } from "@/frontend/spaceship/spaceShipControlsInputs";
@@ -49,6 +50,8 @@ export async function createFlightDemoScene(
     const notificationManager = new NotificationManagerMock();
 
     const ship = await ShipControls.CreateDefault(scene, assets, tts, soundPlayer, notificationManager);
+    const clusteredLightingSystem = new ClusteredLightingSystem(scene);
+    clusteredLightingSystem.registerRegion(ship.getSpaceship());
 
     const camera = ship.getActiveCamera();
     camera.minZ = 0.1;

--- a/packages/game/src/ts/playgrounds/onFoot.ts
+++ b/packages/game/src/ts/playgrounds/onFoot.ts
@@ -43,6 +43,7 @@ import type { Controls } from "@/frontend/controls";
 import { CharacterControls } from "@/frontend/controls/characterControls/characterControls";
 import { CharacterInputs } from "@/frontend/controls/characterControls/characterControlsInputs";
 import { HumanoidAvatar } from "@/frontend/controls/characterControls/humanoidAvatar";
+import { ClusteredLightingSystem } from "@/frontend/helpers/clusteredLightingSystem";
 import { createInstancePatch, createSquareMatrixBuffer } from "@/frontend/helpers/instancing";
 import { InteractionSystem } from "@/frontend/inputs/interaction/interactionSystem";
 import { ShipControls } from "@/frontend/spaceship/shipControls";
@@ -153,6 +154,8 @@ export async function createOnFootScene(
 
     const soundPlayer = new SoundPlayerMock();
     const spaceship = await Spaceship.CreateDefault(scene, assets, soundPlayer, getPhysicsEngineV2(scene));
+    const clusteredLightingSystem = new ClusteredLightingSystem(scene);
+    clusteredLightingSystem.registerRegion(spaceship);
     spaceship.getTransform().position.copyFromFloats(16, 5, 16);
 
     const tts = new TtsMock();

--- a/packages/game/src/ts/playgrounds/spaceElevator.ts
+++ b/packages/game/src/ts/playgrounds/spaceElevator.ts
@@ -28,6 +28,7 @@ import { getSunModel } from "@/backend/universe/customSystems/sol/sun";
 import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
+import { ClusteredLightingSystem } from "@/frontend/helpers/clusteredLightingSystem";
 import { lookAt } from "@/frontend/helpers/transform";
 import { CustomOrbitalObject } from "@/frontend/universe/customOrbitalObject";
 import { KeplerianOrbitalSimulation } from "@/frontend/universe/keplerianOrbitalSimulation";
@@ -93,6 +94,8 @@ export async function createSpaceElevatorScene(
     );
 
     const spaceElevator = new SpaceElevator(spaceElevatorModel, assets, scene);
+    const clusteredLightingSystem = new ClusteredLightingSystem(scene);
+    clusteredLightingSystem.registerRegion(spaceElevator);
 
     const landingBay = spaceElevator.landingBays[0];
     if (landingBay === undefined) {

--- a/packages/game/src/ts/playgrounds/spaceStation.ts
+++ b/packages/game/src/ts/playgrounds/spaceStation.ts
@@ -28,6 +28,7 @@ import { getSunModel } from "@/backend/universe/customSystems/sol/sun";
 import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressMonitor";
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { DefaultControls } from "@/frontend/controls/defaultControls/defaultControls";
+import { ClusteredLightingSystem } from "@/frontend/helpers/clusteredLightingSystem";
 import { lookAt } from "@/frontend/helpers/transform";
 import { SpaceStation } from "@/frontend/universe/orbitalFacility/spaceStation";
 
@@ -91,6 +92,8 @@ export async function createSpaceStationScene(
     );
 
     const spaceStation = new SpaceStation(spaceStationModel, assets, scene);
+    const clusteredLightingSystem = new ClusteredLightingSystem(scene);
+    clusteredLightingSystem.registerRegion(spaceStation);
 
     const landingBay = spaceStation.landingBays[0];
     if (landingBay === undefined) {

--- a/packages/game/src/ts/playgrounds/spaceStationUI.ts
+++ b/packages/game/src/ts/playgrounds/spaceStationUI.ts
@@ -26,6 +26,7 @@ import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressM
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";
+import { ClusteredLightingSystem } from "@/frontend/helpers/clusteredLightingSystem";
 import { Player } from "@/frontend/player/player";
 import { ShipControls } from "@/frontend/spaceship/shipControls";
 import { Spaceship } from "@/frontend/spaceship/spaceship";
@@ -72,6 +73,8 @@ export async function createSpaceStationUIScene(
         soundPlayer,
         getPhysicsEngineV2(scene),
     );
+    const clusteredLightingSystem = new ClusteredLightingSystem(scene);
+    clusteredLightingSystem.registerRegion(spaceship);
     player.instancedSpaceships.push(spaceship);
 
     const shipControls = new ShipControls(spaceship, scene, soundPlayer, tts, notificationManager);

--- a/packages/game/src/ts/playgrounds/stationLanding.ts
+++ b/packages/game/src/ts/playgrounds/stationLanding.ts
@@ -29,6 +29,7 @@ import type { ILoadingProgressMonitor } from "@/frontend/assets/loadingProgressM
 import { loadRenderingAssets } from "@/frontend/assets/renderingAssets";
 import { SoundPlayerMock } from "@/frontend/audio/soundPlayer";
 import { TtsMock } from "@/frontend/audio/tts";
+import { ClusteredLightingSystem } from "@/frontend/helpers/clusteredLightingSystem";
 import { lookAt } from "@/frontend/helpers/transform";
 import { ShipControls } from "@/frontend/spaceship/shipControls";
 import { SpaceShipControlsInputs } from "@/frontend/spaceship/spaceShipControlsInputs";
@@ -98,6 +99,9 @@ export async function createStationLandingScene(
     );
 
     const spaceStation = new SpaceStation(spaceStationModel, assets, scene);
+    const clusteredLightingSystem = new ClusteredLightingSystem(scene);
+    clusteredLightingSystem.registerRegion(spaceStation);
+    clusteredLightingSystem.registerRegion(shipControls.getSpaceship());
 
     const landingBay = spaceStation.landingBays[0];
     if (landingBay === undefined) {


### PR DESCRIPTION
## What does this do?

This PR replaces the per-object clustered light containers owned by SpaceStation, SpaceElevator, and Spaceship with one ClusteredLightingSystem owned by StarSystemView.

- introduces the ClusteredLightingRegion contract
- centralizes Babylon addLight/removeLight ordering and ownership
- keeps producer-owned lights alive across unregister and system disposal
- wires facilities across star-system replacement and spaceships across player reset
- keeps all registered regions permanently active; no spatial culling is introduced
- wires the standalone station, elevator, and landing playgrounds through the same system

## How to test?

Automated validation performed:

- pnpm build:game
- pnpm --filter @cosmos-journeyer/game typecheck
- pnpm --filter @cosmos-journeyer/game test:unit — 243 tests passed
- pnpm --filter @cosmos-journeyer/game lint — no errors; 80 pre-existing warnings
- targeted clustered-lighting E2E — 6 tests passed with unchanged snapshots
- complete E2E run — 40/41 passed; the station physics playground hit its 60-second readiness timeout under four-worker contention
- isolated retry of spaceStation.spec.ts with one worker — 2/2 passed, including the timed-out case

Manual review should focus on station/elevator lights, spaceship thrusters, jumping twice between systems, and reset/replacement of the player spaceship.

## Interesting findings / surprises / setbacks

Babylon adds a removed clustered child light back to scene.lights, so unregister must disable before removeLight. Conversely, activation must add before enabling. ClusteredLightContainer.dispose also disposes remaining child lights, so ClusteredLightingSystem first unregisters every region.

The direct station/elevator playgrounds bypass StarSystemView. They therefore need their own scene-lifetime ClusteredLightingSystem wiring to preserve their previous rendering while keeping business objects unaware of the container.

## AI Usage

### Tooling and model

Codex, GPT-5.

### Usage

Repository investigation, Babylon lifecycle verification, architecture refactor implementation, unit and integration test authoring, E2E diagnosis, and validation.

## What is next?

A follow-up PR can add distance-based activation, deactivation, hysteresis, and update scheduling without changing light ownership or region registration.