### PR TITLE
feat(game): spatially activate clustered lights

### DIFF
--- a/packages/game/src/ts/frontend/helpers/clusteredLightingSystem.spec.ts
+++ b/packages/game/src/ts/frontend/helpers/clusteredLightingSystem.spec.ts
@@ -15,6 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { FreeCamera } from "@babylonjs/core/Cameras/freeCamera";
 import { NullEngine } from "@babylonjs/core/Engines/nullEngine";
 import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
 import type { Light } from "@babylonjs/core/Lights/light";
@@ -31,6 +32,7 @@ import { ClusteredLightingSystem } from "./clusteredLightingSystem";
 describe("ClusteredLightingSystem", () => {
     let engine: NullEngine;
     let scene: Scene;
+    let camera: FreeCamera;
     let system: ClusteredLightingSystem | null;
 
     beforeEach(() => {
@@ -42,6 +44,8 @@ describe("ClusteredLightingSystem", () => {
         caps.blendFloat = true;
 
         scene = new Scene(engine);
+        camera = new FreeCamera("camera", Vector3.Zero(), scene);
+        camera.fov = 1;
         system = new ClusteredLightingSystem(scene);
     });
 
@@ -59,8 +63,10 @@ describe("ClusteredLightingSystem", () => {
         return container;
     };
 
-    const createRegion = (name: string, lights: ReadonlyArray<Light>): ClusteredLightingRegion => {
+    const createRegion = (name: string, lights: ReadonlyArray<Light>, distance = 0): ClusteredLightingRegion => {
         const transform = new TransformNode(`${name}Transform`, scene);
+        transform.position.x = distance;
+        transform.computeWorldMatrix(true);
         return {
             getTransform: () => transform,
             getBoundingRadius: () => 1,
@@ -69,35 +75,111 @@ describe("ClusteredLightingSystem", () => {
     };
 
     const createLight = (name: string): PointLight => {
-        const light = new PointLight(name, Vector3.Zero(), scene, true);
-        light.setEnabled(false);
-        return light;
+        return new PointLight(name, Vector3.Zero(), scene, true);
     };
 
-    it("registers every light and enables it", () => {
+    const setRegionDistance = (region: ClusteredLightingRegion, distance: number): void => {
+        region.getTransform().position.x = distance;
+        region.getTransform().computeWorldMatrix(true);
+    };
+
+    it("registers a region inactive", () => {
         const lights = [createLight("first"), createLight("second")];
         const region = createRegion("station", lights);
 
         system?.registerRegion(region);
 
-        expect(getContainer().lights).toEqual(lights);
-        expect(lights.every((light) => light.isEnabled())).toBe(true);
+        expect(getContainer().lights).toEqual([]);
+        expect(lights.every((light) => !light.isEnabled())).toBe(true);
     });
 
-    it("does not register a region twice", () => {
+    it("activates a nearby region without duplicating its lights", () => {
         const light = createLight("light");
         const region = createRegion("station", [light]);
 
         system?.registerRegion(region);
         system?.registerRegion(region);
+        system?.update(camera);
+        system?.update(camera);
 
         expect(getContainer().lights).toEqual([light]);
+        expect(light.isEnabled()).toBe(true);
     });
 
-    it("unregisters every light, disables it, and ignores repeated unregisters", () => {
+    it("deactivates a region that becomes too small on screen", () => {
         const lights = [createLight("first"), createLight("second")];
         const region = createRegion("station", lights);
         system?.registerRegion(region);
+        system?.update(camera);
+
+        setRegionDistance(region, 1_000);
+        system?.update(camera);
+
+        expect(getContainer().lights).toEqual([]);
+        expect(lights.every((light) => !light.isEnabled())).toBe(true);
+    });
+
+    it("applies hysteresis around the activation threshold", () => {
+        const light = createLight("light");
+        const region = createRegion("station", [light], 1_000);
+        system?.registerRegion(region);
+        system?.update(camera);
+        expect(light.isEnabled()).toBe(false);
+
+        setRegionDistance(region, 100);
+        system?.update(camera);
+        expect(light.isEnabled()).toBe(true);
+
+        setRegionDistance(region, 450);
+        system?.update(camera);
+        expect(light.isEnabled()).toBe(true);
+
+        setRegionDistance(region, 1_000);
+        system?.update(camera);
+        expect(light.isEnabled()).toBe(false);
+
+        setRegionDistance(region, 450);
+        system?.update(camera);
+        expect(light.isEnabled()).toBe(false);
+
+        setRegionDistance(region, 100);
+        system?.update(camera);
+        expect(light.isEnabled()).toBe(true);
+    });
+
+    it("activates only regions that are large enough on screen", () => {
+        const nearLight = createLight("nearLight");
+        const farLight = createLight("farLight");
+        const nearRegion = createRegion("near", [nearLight], 100);
+        const farRegion = createRegion("far", [farLight], 1_000);
+        system?.registerRegion(nearRegion);
+        system?.registerRegion(farRegion);
+
+        system?.update(camera);
+        expect(getContainer().lights).toEqual([nearLight]);
+
+        setRegionDistance(nearRegion, 1_000);
+        setRegionDistance(farRegion, 100);
+        system?.update(camera);
+        expect(getContainer().lights).toEqual([farLight]);
+    });
+
+    it("activates a region when the camera is inside its bounding sphere", () => {
+        const light = createLight("light");
+        const region = createRegion("station", [light]);
+        system?.registerRegion(region);
+
+        system?.update(camera);
+
+        expect(getContainer().lights).toEqual([light]);
+        expect(light.isEnabled()).toBe(true);
+    });
+
+    it("unregisters an active region and ignores repeated unregisters", () => {
+        const lights = [createLight("first"), createLight("second")];
+        const region = createRegion("station", lights);
+        system?.registerRegion(region);
+        system?.update(camera);
 
         system?.unregisterRegion(region);
         system?.unregisterRegion(region);
@@ -106,13 +188,30 @@ describe("ClusteredLightingSystem", () => {
         expect(lights.every((light) => !light.isEnabled())).toBe(true);
     });
 
-    it("can register a region again after unregistering it", () => {
+    it("unregisters an inactive region without touching the container", () => {
+        const light = createLight("light");
+        const region = createRegion("station", [light], 1_000);
+
+        system?.registerRegion(region);
+        system?.unregisterRegion(region);
+
+        expect(getContainer().lights).toEqual([]);
+        expect(light.isEnabled()).toBe(false);
+    });
+
+    it("can reactivate a region after unregistering and registering it again", () => {
         const light = createLight("light");
         const region = createRegion("station", [light]);
 
         system?.registerRegion(region);
+        system?.update(camera);
         system?.unregisterRegion(region);
         system?.registerRegion(region);
+
+        expect(getContainer().lights).toEqual([]);
+        expect(light.isEnabled()).toBe(false);
+
+        system?.update(camera);
 
         expect(getContainer().lights).toEqual([light]);
         expect(light.isEnabled()).toBe(true);
@@ -122,6 +221,7 @@ describe("ClusteredLightingSystem", () => {
         const light = createLight("light");
         const region = createRegion("station", [light]);
         system?.registerRegion(region);
+        system?.update(camera);
 
         system?.dispose();
         system = null;
@@ -138,6 +238,7 @@ describe("ClusteredLightingSystem", () => {
 
         system?.registerRegion(createRegion("station", [stationLight]));
         system?.registerRegion(createRegion("spaceship", [spaceshipLight]));
+        system?.update(camera);
 
         const containers = scene.lights.filter((light) => light instanceof ClusteredLightContainer);
         expect(containers).toHaveLength(1);

--- a/packages/game/src/ts/frontend/helpers/clusteredLightingSystem.ts
+++ b/packages/game/src/ts/frontend/helpers/clusteredLightingSystem.ts
@@ -15,16 +15,27 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { Camera } from "@babylonjs/core/Cameras/camera";
 import { ClusteredLightContainer } from "@babylonjs/core/Lights/Clustered/clusteredLightContainer";
 import type { Light } from "@babylonjs/core/Lights/light";
 import type { Scene } from "@babylonjs/core/scene";
 
 import type { ClusteredLightingRegion } from "@/frontend/universe/architecture/clusteredLightingRegion";
 
+import { DefaultMinProjectedDiameter, getProjectedDiameter01 } from "./isObjectVisibleOnScreen";
+
+type ClusteredLightingRegionState = {
+    isActive: boolean;
+};
+
+const ACTIVATION_THRESHOLD = DefaultMinProjectedDiameter;
+// Keep lights active slightly beyond the visual culling threshold to prevent flicker around the boundary.
+const DEACTIVATION_THRESHOLD = DefaultMinProjectedDiameter * 0.8;
+
 export class ClusteredLightingSystem {
     private readonly container: ClusteredLightContainer;
 
-    private readonly regions = new Set<ClusteredLightingRegion>();
+    private readonly regions = new Map<ClusteredLightingRegion, ClusteredLightingRegionState>();
 
     public constructor(scene: Scene) {
         this.container = new ClusteredLightContainer("globalClusteredLights", [], scene);
@@ -35,28 +46,74 @@ export class ClusteredLightingSystem {
             return;
         }
 
-        this.regions.add(region);
+        this.regions.set(region, { isActive: false });
         for (const light of region.getLights()) {
-            this.activateLight(light);
+            light.setEnabled(false);
         }
     }
 
     public unregisterRegion(region: ClusteredLightingRegion): void {
-        if (!this.regions.delete(region)) {
+        const state = this.regions.get(region);
+        if (state === undefined) {
+            return;
+        }
+
+        if (state.isActive) {
+            this.deactivateRegion(region, state);
+        }
+        this.regions.delete(region);
+    }
+
+    public update(camera: Camera): void {
+        for (const [region, state] of this.regions) {
+            const projectedDiameter = getProjectedDiameter01(
+                region.getTransform().getAbsolutePosition(),
+                region.getBoundingRadius(),
+                camera.globalPosition,
+                camera.fov,
+            );
+
+            if (!state.isActive) {
+                if (projectedDiameter >= ACTIVATION_THRESHOLD) {
+                    this.activateRegion(region, state);
+                }
+                continue;
+            }
+
+            if (projectedDiameter < DEACTIVATION_THRESHOLD) {
+                this.deactivateRegion(region, state);
+            }
+        }
+    }
+
+    public dispose(): void {
+        for (const region of [...this.regions.keys()]) {
+            this.unregisterRegion(region);
+        }
+
+        this.container.dispose();
+    }
+
+    private activateRegion(region: ClusteredLightingRegion, state: ClusteredLightingRegionState): void {
+        if (state.isActive) {
+            return;
+        }
+
+        for (const light of region.getLights()) {
+            this.activateLight(light);
+        }
+        state.isActive = true;
+    }
+
+    private deactivateRegion(region: ClusteredLightingRegion, state: ClusteredLightingRegionState): void {
+        if (!state.isActive) {
             return;
         }
 
         for (const light of region.getLights()) {
             this.deactivateLight(light);
         }
-    }
-
-    public dispose(): void {
-        for (const region of [...this.regions]) {
-            this.unregisterRegion(region);
-        }
-
-        this.container.dispose();
+        state.isActive = false;
     }
 
     private activateLight(light: Light): void {

--- a/packages/game/src/ts/frontend/helpers/isObjectVisibleOnScreen.ts
+++ b/packages/game/src/ts/frontend/helpers/isObjectVisibleOnScreen.ts
@@ -21,6 +21,8 @@ import { Vector3 } from "@babylonjs/core/Maths/math";
 import type { HasBoundingSphere } from "@/frontend/universe/architecture/hasBoundingSphere";
 import type { Transformable } from "@/frontend/universe/architecture/transformable";
 
+export const DefaultMinProjectedDiameter = 0.005;
+
 export function getProjectedDiameter01(
     position: Vector3,
     radius: number,
@@ -46,7 +48,7 @@ export function getProjectedDiameter01(
 export function isSizeOnScreenEnough(
     object: HasBoundingSphere & Transformable,
     camera: Camera,
-    threshold = 0.005,
+    threshold = DefaultMinProjectedDiameter,
 ): boolean {
     const angularSize = getProjectedDiameter01(
         object.getTransform().getAbsolutePosition(),

--- a/packages/game/src/ts/frontend/starSystemView.spec.ts
+++ b/packages/game/src/ts/frontend/starSystemView.spec.ts
@@ -15,6 +15,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getLoneStarSystem } from "@/backend/universe/customSystems/loneStar";
@@ -178,6 +179,51 @@ describe("StarSystemView", () => {
         expect(clusteredLightingSystem.registerRegion).toHaveBeenCalledWith(newFacility);
         expect(clusteredLightingSystem.unregisterRegion.mock.invocationCallOrder[0]).toBeLessThan(
             oldStarSystem.dispose.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+        );
+    });
+
+    it("updates clustered lighting after star system positions", () => {
+        const camera = {};
+        const expectedError = new Error("Stop after clustered lighting update");
+        const starSystem = {
+            gravitySystem: { getLastComputedForce: (): Vector3 => Vector3.Down() },
+            update: vi.fn(),
+        };
+        const clusteredLightingSystem = {
+            update: vi.fn((): never => {
+                throw expectedError;
+            }),
+        };
+        const activeControls = {
+            getActiveCamera: (): object => camera,
+            update: vi.fn(),
+        };
+        const context = {
+            _isLoadingSystem: false,
+            activeControls,
+            characterControls: {
+                avatar: {
+                    aggregate: { body: {} },
+                    getTransform: () => ({ up: Vector3.Up() }),
+                },
+            },
+            clusteredLightingSystem,
+            getStarSystem: () => starSystem,
+            scene: { activeCamera: camera },
+            spaceshipControls: {},
+            starSystem,
+            terrainSystem: { update: vi.fn() },
+        } as unknown as StarSystemView;
+        const starSystemViewPrototype = StarSystemView.prototype as unknown as {
+            updateBeforeRender(this: StarSystemView, deltaSeconds: number): void;
+        };
+
+        expect(() => {
+            starSystemViewPrototype.updateBeforeRender.call(context, 1);
+        }).toThrow(expectedError);
+        expect(clusteredLightingSystem.update).toHaveBeenCalledWith(camera);
+        expect(starSystem.update.mock.invocationCallOrder[0]).toBeLessThan(
+            clusteredLightingSystem.update.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
         );
     });
 });

--- a/packages/game/src/ts/frontend/starSystemView.ts
+++ b/packages/game/src/ts/frontend/starSystemView.ts
@@ -976,6 +976,7 @@ export class StarSystemView implements View {
         activeControls.update(deltaSeconds);
 
         starSystem.update(deltaSeconds, this.terrainSystem);
+        this.clusteredLightingSystem.update(activeControls.getActiveCamera());
 
         const nearestOrbitalObject = starSystem.getNearestOrbitalObject(
             activeControls.getTransform().getAbsolutePosition(),

--- a/packages/game/src/ts/playgrounds/automaticLanding.ts
+++ b/packages/game/src/ts/playgrounds/automaticLanding.ts
@@ -118,12 +118,14 @@ export async function createAutomaticLandingScene(
 
     engageLanding();
 
+    clusteredLightingSystem.update(camera);
     scene.onBeforeRenderObservable.add(() => {
         const deltaSeconds = engine.getDeltaTime() / 1000;
 
         ship.update(deltaSeconds);
 
         defaultControls.update(deltaSeconds);
+        clusteredLightingSystem.update(camera);
     });
 
     document.addEventListener("keydown", (event) => {

--- a/packages/game/src/ts/playgrounds/flightDemo.ts
+++ b/packages/game/src/ts/playgrounds/flightDemo.ts
@@ -90,9 +90,11 @@ export async function createFlightDemoScene(
 
     enableShadows(sun, new DepthRendererManager(scene), { maxZ: 3e3 });
 
+    clusteredLightingSystem.update(camera);
     scene.onBeforeRenderObservable.add(() => {
         const deltaSeconds = engine.getDeltaTime() / 1000;
         ship.update(deltaSeconds);
+        clusteredLightingSystem.update(camera);
     });
 
     return scene;

--- a/packages/game/src/ts/playgrounds/onFoot.ts
+++ b/packages/game/src/ts/playgrounds/onFoot.ts
@@ -260,6 +260,7 @@ export async function createOnFootScene(
         }
     });
 
+    clusteredLightingSystem.update(activeControls.getActiveCamera());
     scene.onBeforeRenderObservable.add(() => {
         if (activeControls.getActiveCamera() !== scene.activeCamera) {
             scene.activeCamera?.detachControl();
@@ -275,6 +276,7 @@ export async function createOnFootScene(
         shipControls.update(deltaSeconds);
         interactionSystem.update(deltaSeconds);
         interactionLayer.update(deltaSeconds);
+        clusteredLightingSystem.update(activeControls.getActiveCamera());
     });
 
     return scene;

--- a/packages/game/src/ts/playgrounds/spaceElevator.ts
+++ b/packages/game/src/ts/playgrounds/spaceElevator.ts
@@ -146,8 +146,9 @@ export async function createSpaceElevatorScene(
     lookAt(defaultControls.getTransform(), spaceElevator.getTransform().position, scene.useRightHandedSystem);
 
     defaultControls.getTransform().setParent(spaceElevator.getTransform());
+    clusteredLightingSystem.update(camera);
 
-    scene.onBeforePhysicsObservable.add(() => {
+    scene.onBeforeRenderObservable.add(() => {
         const deltaSeconds = engine.getDeltaTime() / 1000;
         elapsedSeconds += deltaSeconds;
 
@@ -167,6 +168,7 @@ export async function createSpaceElevatorScene(
             transform.computeWorldMatrix(true);
         }
         spaceElevator.update([planetImpostor], cameraWorldPosition, deltaSeconds);
+        clusteredLightingSystem.update(camera);
     });
 
     return scene;

--- a/packages/game/src/ts/playgrounds/spaceStation.ts
+++ b/packages/game/src/ts/playgrounds/spaceStation.ts
@@ -108,7 +108,8 @@ export async function createSpaceStationScene(
 
     new GlowLayer("glow", scene);
 
-    scene.onBeforePhysicsObservable.add(() => {
+    clusteredLightingSystem.update(camera);
+    scene.onBeforeRenderObservable.add(() => {
         const deltaSeconds = engine.getDeltaTime() / 1000;
 
         defaultControls.update(deltaSeconds);
@@ -116,6 +117,7 @@ export async function createSpaceStationScene(
         const cameraWorldPosition = camera.globalPosition;
 
         spaceStation.update([], cameraWorldPosition, deltaSeconds);
+        clusteredLightingSystem.update(camera);
     });
 
     return scene;

--- a/packages/game/src/ts/playgrounds/spaceStationUI.ts
+++ b/packages/game/src/ts/playgrounds/spaceStationUI.ts
@@ -103,6 +103,11 @@ export async function createSpaceStationUIScene(
     spaceStationUI.setStation(stationModel, [], player);
     spaceStationUI.setVisibility(true);
 
+    clusteredLightingSystem.update(camera);
+    scene.onBeforeRenderObservable.add(() => {
+        clusteredLightingSystem.update(camera);
+    });
+
     (window as Window & typeof globalThis & { player: Player }).player = player;
 
     return scene;

--- a/packages/game/src/ts/playgrounds/stationLanding.ts
+++ b/packages/game/src/ts/playgrounds/stationLanding.ts
@@ -127,10 +127,12 @@ export async function createStationLandingScene(
     new DirectionalLight("sun", new Vector3(-1, -1, 1).normalize(), scene);
     new GlowLayer("glow", scene);
 
-    scene.onBeforePhysicsObservable.add(() => {
+    clusteredLightingSystem.update(camera);
+    scene.onBeforeRenderObservable.add(() => {
         const deltaSeconds = engine.getDeltaTime() / 1000;
         shipControls.update(deltaSeconds);
         spaceStation.update([], camera.globalPosition, deltaSeconds);
+        clusteredLightingSystem.update(camera);
     });
 
     return scene;


### PR DESCRIPTION
## What does this do?

This PR adds screen-space activation to the global clustered lighting system introduced in #833.

- Registered regions now start inactive and carry only an `isActive` state.
- `update(camera)` activates regions at the shared visual relevance threshold and deactivates them at 80% of that threshold for hysteresis.
- Activation uses each region's projected bounding-sphere diameter through `getProjectedDiameter01`; it does not use light range or business-type special cases.
- `StarSystemView` updates clustered lighting after the star system spatial update.
- Standalone playgrounds perform one initial clustered-lighting update after their camera setup, then update their local system during `onBeforeRenderObservable`.
- The remaining playground-only `onBeforePhysicsObservable` callbacks were migrated to the render lifecycle used by the game.
- Unit tests cover activation, deactivation, hysteresis, multiple regions, idempotence, inside-sphere behavior, unregister, disposal, and StarSystemView update ordering.

## How to test?

- `pnpm --filter @cosmos-journeyer/game typecheck`
- `pnpm --filter @cosmos-journeyer/game build`
- `pnpm --filter @cosmos-journeyer/game test:unit` (46 files, 249 tests)
- `pnpm --filter @cosmos-journeyer/game lint`
- `pnpm --filter @cosmos-journeyer/game exec playwright test tests/e2e/spaceElevator.spec.ts tests/e2e/spaceStation.spec.ts tests/e2e/stationLanding.spec.ts --workers=1`

Manually, approach and leave a station and verify that its local lights activate without flickering while the spaceship thruster lights remain active near the camera.

## Interesting findings / surprises / setbacks

The playground runner calls `scene.executeWhenReady()` before starting the render loop. Because clustered activation normally happens in `onBeforeRenderObservable`, waiting at that point would only prepare the initially empty container and the first rendered frame could be invalid while Babylon resized the clustered batches. Each affected playground therefore evaluates clustered lighting once after its final camera setup and immediately before registering its per-frame callback. `executeWhenReady()` then observes the actual initial clustered state, preserving the invariant that the first rendered frame is valid without changing the playground contract or adding a warm-up render.

## AI Usage

### Tooling and model

OpenAI Codex, GPT-5.

### Usage

Codex was used to inspect the existing architecture and Babylon.js clustered-lighting implementation, implement the spatial state machine and wiring, extend unit coverage, diagnose the initial-frame Playwright regression, and run the validation suite. The contributor reviewed the plan, architecture, and resulting changes.

## What's next?

Profile the number of registered regions and clustered-light transitions in representative systems before considering throttling, spatial indexing, per-region thresholds, or global light budgets.
