### PR TITLE
chore(deps): group weekly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,84 +1,40 @@
 version: 2
+
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Paris"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "weekly-dependencies"
     cooldown:
       semver-major-days: 14
-    groups:
-      babylonjs:
-        applies-to: "version-updates"
-        patterns:
-          - "@babylonjs/*"
-        exclude-patterns:
-          - "@babylonjs/havok"
-
-      production-minor-patch:
-        applies-to: "version-updates"
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-
-      development-minor-patch:
-        applies-to: "version-updates"
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "uv"
     directory: "/packages/gaia-explorer"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Paris"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "weekly-dependencies"
     cooldown:
       semver-major-days: 14
-    groups:
-      minor-patch:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "cargo"
     directory: "/packages/terrain-generation"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Paris"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "weekly-dependencies"
     cooldown:
       semver-major-days: 14
-    groups:
-      minor-patch:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Paris"
-    groups:
-      minor-patch:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "weekly-dependencies"


### PR DESCRIPTION
## Summary

Simplify Dependabot by grouping version updates from npm, uv, Cargo, and GitHub Actions into a single weekly multi-ecosystem pull request.

## Changes

- add a `weekly-dependencies` multi-ecosystem group scheduled for Monday at 06:00 Europe/Paris
- include all dependencies from npm, uv, Cargo, and GitHub Actions in that group
- remove the separate per-ecosystem minor/patch groups and the special BabylonJS grouping
- keep the existing 14-day major-version cooldown for npm, uv, and Cargo

This makes routine dependency maintenance a single repository-wide update snapshot validated by CI.