### PR TITLE
fix(dependabot): limit version updates to minor and patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "weekly-dependencies"
+    allow:
+      - dependency-type: "all"
+        update-types:
+          - "minor"
+          - "patch"
     cooldown:
       semver-major-days: 14
 
@@ -22,6 +27,11 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "weekly-dependencies"
+    allow:
+      - dependency-type: "all"
+        update-types:
+          - "minor"
+          - "patch"
     cooldown:
       semver-major-days: 14
 
@@ -30,6 +40,11 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "weekly-dependencies"
+    allow:
+      - dependency-type: "all"
+        update-types:
+          - "minor"
+          - "patch"
     cooldown:
       semver-major-days: 14
 
@@ -38,3 +53,8 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "weekly-dependencies"
+    allow:
+      - dependency-type: "all"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,8 @@ updates:
       - "*"
     multi-ecosystem-group: "weekly-dependencies"
     allow:
-      - dependency-type: "all"
-        update-types:
-          - "minor"
-          - "patch"
-    cooldown:
-      semver-major-days: 14
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "uv"
     directory: "/packages/gaia-explorer"
@@ -28,12 +24,8 @@ updates:
       - "*"
     multi-ecosystem-group: "weekly-dependencies"
     allow:
-      - dependency-type: "all"
-        update-types:
-          - "minor"
-          - "patch"
-    cooldown:
-      semver-major-days: 14
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "cargo"
     directory: "/packages/terrain-generation"
@@ -41,12 +33,8 @@ updates:
       - "*"
     multi-ecosystem-group: "weekly-dependencies"
     allow:
-      - dependency-type: "all"
-        update-types:
-          - "minor"
-          - "patch"
-    cooldown:
-      semver-major-days: 14
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -54,7 +42,5 @@ updates:
       - "*"
     multi-ecosystem-group: "weekly-dependencies"
     allow:
-      - dependency-type: "all"
-        update-types:
-          - "minor"
-          - "patch"
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
## What does this do?

Restricts Dependabot version updates to minor and patch releases across npm, uv, Cargo, and GitHub Actions while keeping the existing weekly multi-ecosystem group.

This restores the behavior that existed before #839, where major upgrades were not included in the regular grouped dependency updates.

## Why?

PR #840 demonstrated that the new multi-ecosystem configuration could include major upgrades such as TypeScript 6 → 7. That is too risky for the weekly dependency batch because a single incompatible major can block the whole grouped PR.

The configuration now uses `allow.update-types` with `minor` and `patch` for each ecosystem. This limits regular version updates while preserving Dependabot security updates when GitHub needs to move outside those ranges to remediate a vulnerability.

## Validation

- Keeps the existing `weekly-dependencies` multi-ecosystem group and schedule.
- Applies the same minor/patch policy to npm, uv, Cargo, and GitHub Actions.
- No application code changes.

## Related

- Follow-up to #839
- Motivated by #840
