### PR TITLE
Improved depth unprojection

### DIFF
--- a/packages/game/src/shaders/blackhole.glsl
+++ b/packages/game/src/shaders/blackhole.glsl
@@ -227,13 +227,12 @@ float customLength(vec3 v) {
 void main() {
     vec4 screenColor = texture2D(textureSampler, vUV);// the current screen color
 
-    vec3 pixelWorldPosition = worldFromUV(vUV, camera_inverseProjection, camera_inverseView);// the pixel position in world space (near plane)
-    vec3 rayDirWorld = normalize(pixelWorldPosition - camera_position);// normalized direction of the ray
-
     float depth = texture2D(depthSampler, vUV).r;// the depth corresponding to the pixel in the depth map
+    vec3 pixelWorldPosition = worldFromUV(vUV, depth, camera_inverseProjectionView);
+    vec3 rayDirWorld = normalize(worldFromUV(vUV, 1.0, camera_inverseProjectionView) - camera_position);
 
     // actual depth of the scene
-    float maximumDistance = length(pixelWorldPosition - camera_position) * remap(depth, 0.0, 1.0, camera_near, camera_far);
+    float maximumDistance = length(pixelWorldPosition - camera_position);
 
     float maxBendDistance = max(accretionDiskRadius * 3.0, schwarzschildRadius * 15.0);
 
@@ -330,16 +329,13 @@ void main() {
     // getting the screen coordinate of the end of the bended ray
     vec3 rayEndWorldPosition = blackHoleSpaceToWorld(rayPositionBlackHoleSpace);
     vec2 uv = uvFromWorld(rayEndWorldPosition, camera_projection, camera_view);
-    // check if there is an object occlusion
-    vec3 pixelWorldPositionEndRay = worldFromUV(uv, camera_inverseProjection, camera_inverseView);// the pixel position in world space (near plane)
-
     float depthEndRay = texture2D(depthSampler, uv).r;// the depth corresponding to the pixel in the depth map
     for(int i = 0; i < 10; i++) {
         vec2 offset = (vec2(hash(float(i)), hash(float(i + 1))) - 0.5) * 0.01;
         depthEndRay = min(depthEndRay, texture2D(depthSampler, uv + offset).r);
     }
     // closest physical point from the camera in the direction of the pixel (occlusion)
-    vec3 closestPointEndRay = camera_position + normalize(pixelWorldPositionEndRay - camera_position) * remap(depthEndRay, 0.0, 1.0, camera_near, camera_far);
+    vec3 closestPointEndRay = worldFromUV(uv, depthEndRay, camera_inverseProjectionView);
 
     bool behindBH = dot(closestPointEndRay - camera_position, closestPointEndRay - worldPosition) >= 0.0;
     // checking for alignment: camera, object, blackhole in this order

--- a/packages/game/src/shaders/celestialBodyUberShaderFragment.glsl
+++ b/packages/game/src/shaders/celestialBodyUberShaderFragment.glsl
@@ -282,10 +282,10 @@ void main() {
     vec4 screenColor = texelFetch(textureSampler, texelCoord, 0);
     float depth = texelFetch(depthSampler, texelCoord, 0).r;
 
-    vec3 pixelWorldPosition = worldFromUV(vUV, camera_inverseProjection, camera_inverseView);
-    vec3 viewDir = normalize(pixelWorldPosition - camera_position);
+    vec3 pixelWorldPosition = worldFromUV(vUV, depth, camera_inverseProjectionView);
+    vec3 viewDir = normalize(worldFromUV(vUV, 1.0, camera_inverseProjectionView) - camera_position);
 
-    float sceneDistance = length(pixelWorldPosition - camera_position) * remap(depth, 0.0, 1.0, camera_near, camera_far);
+    float sceneDistance = length(pixelWorldPosition - camera_position);
     float centralBodyDistance = computeCentralBodyDistance(viewDir, sceneDistance);
 
     vec4 baseColor = screenColor;

--- a/packages/game/src/shaders/lensflare.glsl
+++ b/packages/game/src/shaders/lensflare.glsl
@@ -33,7 +33,7 @@ float projectDepth(vec3 worldPosition) {
 }
 
 float sampleVisibilityAtUV(vec2 sampleUV, float depthEpsilon) {
-    vec3 sampleWorldPosition = worldFromUV(sampleUV, camera_inverseProjection, camera_inverseView);
+    vec3 sampleWorldPosition = worldFromUV(sampleUV, 1.0, camera_inverseProjectionView);
     vec3 sampleRay = normalize(sampleWorldPosition - camera_position);
     float sphereEnterDistance;
     float sphereExitDistance;
@@ -186,7 +186,7 @@ void main() {
         return;
     }
 
-    vec3 pixelWorldPosition = worldFromUV(vUV, camera_inverseProjection, camera_inverseView);// the pixel position in world space (near plane)
+    vec3 pixelWorldPosition = worldFromUV(vUV, 1.0, camera_inverseProjectionView);
     vec3 rayDir = normalize(pixelWorldPosition - camera_position);
 
     vec3 objectDirection = normalize(object_position - camera_position);

--- a/packages/game/src/shaders/sphereShadows.glsl
+++ b/packages/game/src/shaders/sphereShadows.glsl
@@ -53,12 +53,12 @@ void main() {
 
     float depth = texture2D(depthSampler, vUV).r;// the depth corresponding to the pixel in the depth map
 
-    vec3 pixelWorldPosition = worldFromUV(vUV, camera_inverseProjection, camera_inverseView);// the pixel position in world space (near plane)
+    vec3 pixelWorldPosition = worldFromUV(vUV, depth, camera_inverseProjectionView);
 
     // closest physical point from the camera in the direction of the pixel (occlusion)
-    float maximumDistance = length(pixelWorldPosition - camera_position) * remap(depth, 0.0, 1.0, camera_near, camera_far);
+    float maximumDistance = length(pixelWorldPosition - camera_position);
 
-    vec3 rayDir = normalize(pixelWorldPosition - camera_position);// normalized direction of the ray
+    vec3 rayDir = normalize(worldFromUV(vUV, 1.0, camera_inverseProjectionView) - camera_position);
 
     vec4 finalColor = screenColor;
 

--- a/packages/game/src/shaders/starmapNebulaFog.glsl
+++ b/packages/game/src/shaders/starmapNebulaFog.glsl
@@ -172,7 +172,7 @@ vec4 raymarchNebula(vec3 rayOrigin, vec3 rayDirection, float maximumDistance) {
 }
 
 void main() {
-    vec3 pixelWorldPosition = worldFromUV(vUV, camera_inverseProjection, camera_inverseView);
+    vec3 pixelWorldPosition = worldFromUV(vUV, 1.0, camera_inverseProjectionView);
     vec3 rayDirection = normalize(pixelWorldPosition - camera_position);
     vec4 fogData = raymarchNebula(camera_position, rayDirection, maxFogDistance);
     gl_FragColor = fogData;

--- a/packages/game/src/shaders/utils/camera.glsl
+++ b/packages/game/src/shaders/utils/camera.glsl
@@ -18,8 +18,7 @@
 uniform vec3  camera_position;
 uniform mat4  camera_projection;
 uniform mat4  camera_view;
-uniform mat4  camera_inverseProjection;
-uniform mat4  camera_inverseView;
+uniform mat4  camera_inverseProjectionView;
 uniform float camera_near;
 uniform float camera_far;
 uniform float camera_fov;

--- a/packages/game/src/shaders/utils/worldFromUV.glsl
+++ b/packages/game/src/shaders/utils/worldFromUV.glsl
@@ -15,14 +15,20 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// compute the world position of a pixel from its uv coordinates
+// compute the world position of a pixel from its uv coordinates and its depth buffer value
 // This is an evolution from the code found here
 // https://forum.babylonjs.com/t/pixel-position-in-world-space-from-fragment-postprocess-shader-issue/30232
 // also see https://www.babylonjs-playground.com/#1PHYB0#318 for smaller scale testing
-// This is a revised version that works with the reverse depth buffer
-vec3 worldFromUV(vec2 pos, mat4 inverseProjection, mat4 inverseView) {
-    vec4 ndc = vec4(pos.xy * 2.0 - 1.0, 1.0, 1.0); // get ndc position (z = 1 because the depth buffer is reversed)
-    vec4 posVS = inverseProjection * ndc; // unproject the ndc coordinates : we are now in view space if i understand correctly
-    vec4 posWS = inverseView * posVS; // then we use inverse view to get to world space, division by w to get actual coordinates
-    return  posWS.xyz / posWS.w;
+// also see https://forum.babylonjs.com/t/clip-space-to-world-space-with-non-linear-reverse-depth-buffer-with-webgpu/48892/5
+// On WebGL, the depth renderer stores a linear view-space metric: depth 0 is the near plane and depth 1 is
+// the far plane, and the value is linear in the view-space z of the pixel. The world position is therefore
+// reconstructed as camera_position + ray * viewZ, where the ray is obtained by unprojecting the uv at the
+// near plane (which carries the 1/cos(theta) factor between the view-space z and the distance along the ray)
+// and viewZ = mix(camera_near, camera_far, depth).
+vec3 worldFromUV(vec2 pos, float depth, mat4 inverseProjectionView) {
+    vec4 ndc = vec4(pos.xy * 2.0 - 1.0, 1.0, 1.0); // near plane (reverse depth buffer)
+    vec4 positionWorldSpace = inverseProjectionView * ndc;
+    vec3 nearPlaneOffset = positionWorldSpace.xyz / positionWorldSpace.w - camera_position;
+    float viewZ = mix(camera_near, camera_far, depth);
+    return camera_position + nearPlaneOffset * (viewZ / camera_near);
 }

--- a/packages/game/src/ts/frontend/postProcesses/uniforms/cameraUniforms.ts
+++ b/packages/game/src/ts/frontend/postProcesses/uniforms/cameraUniforms.ts
@@ -24,9 +24,8 @@ import { OffsetViewToRef } from "@/frontend/helpers/floatingOrigin";
 export const CameraUniformNames = {
     CAMERA_POSITION: "camera_position",
     CAMERA_PROJECTION: "camera_projection",
-    CAMERA_INVERSE_PROJECTION: "camera_inverseProjection",
     CAMERA_VIEW: "camera_view",
-    CAMERA_INVERSE_VIEW: "camera_inverseView",
+    CAMERA_INVERSE_PROJECTION_VIEW: "camera_inverseProjectionView",
     CAMERA_NEAR: "camera_near",
     CAMERA_FAR: "camera_far",
     CAMERA_FOV: "camera_fov",
@@ -45,12 +44,11 @@ export function setCameraUniforms(effect: Effect, camera: Camera, floatingOrigin
         : camera.getWorldMatrix().getTranslationToRef(tempVector1);
     effect.setVector3(CameraUniformNames.CAMERA_POSITION, cameraPosition);
     effect.setMatrix(CameraUniformNames.CAMERA_PROJECTION, camera.getProjectionMatrix());
-    effect.setMatrix(
-        CameraUniformNames.CAMERA_INVERSE_PROJECTION,
-        camera.getProjectionMatrix().invertToRef(tempMatrix2),
-    );
     effect.setMatrix(CameraUniformNames.CAMERA_VIEW, view);
-    effect.setMatrix(CameraUniformNames.CAMERA_INVERSE_VIEW, view.invertToRef(tempMatrix3));
+    effect.setMatrix(
+        CameraUniformNames.CAMERA_INVERSE_PROJECTION_VIEW,
+        view.multiplyToRef(camera.getProjectionMatrix(), tempMatrix2).invertToRef(tempMatrix3),
+    );
     effect.setFloat(CameraUniformNames.CAMERA_NEAR, camera.minZ);
     effect.setFloat(CameraUniformNames.CAMERA_FAR, camera.maxZ);
     effect.setFloat(CameraUniformNames.CAMERA_FOV, camera.fov);

--- a/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/createChunkBuffers.ts
+++ b/packages/game/src/ts/frontend/universe/planets/telluricPlanet/terrain/chunks/createChunkBuffers.ts
@@ -15,7 +15,8 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Axis, Quaternion, Vector3 } from "@babylonjs/core/pure";
+import { Axis } from "@babylonjs/core/Maths/math.axis";
+import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { build_chunk_vertex_data, BuildData } from "terrain-generation";
 
 import { AvailableRockSizes } from "@/frontend/assets/objects/rockSizes";


### PR DESCRIPTION
## What does this do?

This PR backports part of the depth unprojection refactor from the webgpu branch.

Depth must still be linear because of WebGL 2 so this is not a full backport

Bonus: also fixes terrain worker init in dev bundles (there is no tree shaking there!)

<!--
Briefly explain what this PR does.
Example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## How to test?

CI only

<!--
Make sure you test your work before opening a PR.
Include the precise steps to reproduce in order to peer review your work.
Also include screenshots if you can so that reviewers can compare with a baseline.

Here is a small list of things you can do to check everything is working:
 Install Dependencies:- `pnpm install`
 Build Project:- `pnpm build`
 Serving To Web:- `pnpm serve`
 Run Tests:- `npm run test:unit` or `pnpm test:unit`
 Check Formatting:- `npm run format` or `pnpm run format`
 Eslint Check:- `npm run lint` or `pnpm run lint`

Did you document your code?
-->

## Interesting findings / surprises / setbacks

Vite does not perform tree shaking in dev mode. 

<!--
Did you encounter unexpected difficulties while making this PR?
Was there something that surprised you?
Tell us about it, and what you did to overcome them!
-->

## AI Usage

### Tooling and model

Opencode GLM 5.3 Flash & Deepseek V4 flash 

<!--
What AI tooling did you use? Example: Codex, Claude Code, GitHub Copilot, OpenCode...
What model did you use the tool with? Example: GPT5.5 high, Claude Opus 4.8 xhigh...
-->

### Usage

Initial backport by GLM 5.3 Flash. Very disapointing and slow. Deepseek V4 flash finished the job correctly.

<!--
Describe your usage of said tool. Example: code review, investigation, refactoring, line completion...
-->

## Related Tickets

Spontaneous

<!--
Use this format to link issue numbers: Fixes #123 / Closes #123
Reference: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
-->
