### PR TITLE
fix(dependabot): remove stale uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,15 +18,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
-  - package-ecosystem: "uv"
-    directory: "/packages/gaia-explorer"
-    patterns:
-      - "*"
-    multi-ecosystem-group: "weekly-dependencies"
-    allow:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-
   - package-ecosystem: "cargo"
     directory: "/packages/terrain-generation"
     patterns:


### PR DESCRIPTION
## Summary
- remove the obsolete `uv` Dependabot entry for `packages/gaia-explorer`
- keep the existing npm workspace coverage for Gaia Explorer now that it is TypeScript

## Why
`packages/gaia-explorer` no longer contains `pyproject.toml` or `uv.lock`; it is now a TypeScript package in the pnpm workspace. The stale `uv` ecosystem entry can cause Dependabot's grouped update job to fail before processing eligible npm updates.