### PR TITLE
fix: allow oxfmt to skip unmatched staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "typescript-eslint": "catalog:"
     },
     "lint-staged": {
-        "*.{js,jsx,ts,tsx,mjs,cjs,json,md,css,html,yml,yaml}": "oxfmt --write"
+        "*": "oxfmt --write --no-error-on-unmatched-pattern"
     },
     "engines": {
         "node": ">=24.0.0"


### PR DESCRIPTION
## Summary

- let `oxfmt` receive all staged files from `lint-staged`
- use `--no-error-on-unmatched-pattern` so commits do not fail when all staged files are ignored by oxfmt
- keep real oxfmt failures blocking the commit

This avoids false-negative pre-commit failures such as when only ignored files (for example `pnpm-workspace.yaml`) are staged.